### PR TITLE
docs: Fix attribute naming in JSON documentation files

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_AbstractPlatform.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AbstractPlatform.classes.json
@@ -39,21 +39,21 @@
         }
       ],
       "attributes": {
-        "attribute": {
+        "attributes": {
           "type": "Field",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the set of attributes defined in the context"
         },
-        "command": {
+        "commands": {
           "type": "ClientServerOperation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the collection of commands or function optional data arguments) defined in the context ApplicationInterface. atpVariation"
         },
-        "indication": {
+        "indications": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_AdaptiveModule.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_AdaptiveModule.classes.json
@@ -35,7 +35,7 @@
       ],
       "attributes": {
         "communication": {
-          "type": "EthernetCommunication",
+          "type": "any (EthernetCommunication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_CryptoDeployment.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_CryptoDeployment.classes.json
@@ -45,21 +45,21 @@
           "note": "This attribute defines a crypto algorithm restriction (kAlgId"
         },
         "cryptoObjectTypeEnum": {
-          "type": "CryptoObjectTypeEnum",
+          "type": "any (CryptoObjectTypeEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Object type that can be stored in the slot. If this field \"Undefined\" then mSlotCapacity must be larger then 0."
         },
         "keySlotAllowed": {
-          "type": "CryptoKeySlotAllowed",
+          "type": "any (CryptoKeySlotAllowed)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Restricts how this keySlot may be used Tags: atp.Status=candidate"
         },
-        "keySlotContent": {
-          "type": "CryptoKeySlotContent",
+        "keySlotContents": {
+          "type": "any (CryptoKeySlotContent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -73,7 +73,7 @@
           "note": "Capacity of the slot in bytes to be reserved by the stack use case is to define this value in case that is undefined and the slot size can deduced from cryptoObjectType and cryptoAlgId. slot size can be deduced from cryptoObject cryptoAlgId."
         },
         "slotType": {
-          "type": "CryptoKeySlotType",
+          "type": "any (CryptoKeySlotType)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_Firewall.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_Firewall.classes.json
@@ -36,20 +36,20 @@
       ],
       "attributes": {
         "defaultAction": {
-          "type": "FirewallActionEnum",
+          "type": "any (FirewallActionEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute defines a defaultAction in case that the not yet set."
         },
-        "firewallRuleProps": {
+        "firewallRulePropses": {
           "type": "FirewallRuleProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of firewall rules that apply in the vehicle mode Tags: atp.Status=candidate"
         },
-        "firewallState": {
+        "firewallStates": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "reference",
@@ -85,20 +85,20 @@
       ],
       "attributes": {
         "action": {
-          "type": "FirewallActionEnum",
+          "type": "any (FirewallActionEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Action that is performed by the firewall if the matching fulfilled."
         },
-        "matchingEgress": {
+        "matchingEgresses": {
           "type": "FirewallRule",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This element defines an egress rule expression against"
         },
-        "matching": {
+        "matchings": {
           "type": "FirewallRule",
           "multiplicity": "*",
           "kind": "reference",
@@ -149,35 +149,35 @@
           "note": "This attribute defines the capacity of the queue for rate Algorithm). 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
         "dataLinkLayerRule": {
-          "type": "DataLinkLayerRule",
+          "type": "any (DataLinkLayerRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of rules on the Data Link Layer atp.Status=candidate"
         },
         "ddsRule": {
-          "type": "DdsRule",
+          "type": "any (DdsRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of firewall rules for DDS."
         },
         "doIpRule": {
-          "type": "DoIpRule",
+          "type": "any (DoIpRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of firewall rules for DoIP messages"
         },
         "networkLayerRule": {
-          "type": "NetworkLayerRule",
+          "type": "any (NetworkLayerRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of rules on the Network Layer atp.Status=candidate"
         },
-        "payloadBytePattern": {
-          "type": "PayloadBytePattern",
+        "payloadBytePatterns": {
+          "type": "any (PayloadBytePattern)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -191,21 +191,21 @@
           "note": "This attribute defines the output rate that describes how leave the queue per second (leaky-bucket"
         },
         "someipRule": {
-          "type": "SomeipProtocolRule",
+          "type": "any (SomeipProtocolRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of firewall rules for SOME/IP messages"
         },
         "someipSdRule": {
-          "type": "SomeipSdRule",
+          "type": "any (SomeipSdRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of firewall rules for SOME/IP Service"
         },
         "transportLayerRule": {
-          "type": "TransportLayerRule",
+          "type": "any (TransportLayerRule)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_IntrusionDetectionSystem.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AdaptivePlatform_PlatformModuleDeployment_IntrusionDetectionSystem.classes.json
@@ -41,15 +41,15 @@
         }
       ],
       "attributes": {
-        "network": {
-          "type": "PlatformModule",
+        "networks": {
+          "type": "PlatformModuleEthernetEndpointConfiguration",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This association contains the network configuration that shall be applied to an instance of an IDS entity. atp.Status=candidate"
         },
         "timeBaseResource": {
-          "type": "TimeBaseResource",
+          "type": "any (TimeBaseResource)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_AutosarTopLevelStructure.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_AutosarTopLevelStructure.classes.json
@@ -110,7 +110,7 @@
           "is_ref": false,
           "note": "This represents the administrative data of an Autosar file."
         },
-        "arPackage": {
+        "arPackages": {
           "type": "ARPackage",
           "multiplicity": "*",
           "kind": "attribute",
@@ -159,7 +159,7 @@
         }
       ],
       "attributes": {
-        "sdg": {
+        "sdgs": {
           "type": "Sdg",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswBehavior.classes.json
@@ -60,147 +60,147 @@
         }
       ],
       "attributes": {
-        "arTypedPer": {
+        "arTypedPers": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Defines an AUTOSAR typed memory-block that needs to available for each instance of the Basic Software The aggregation of arTypedPerInstanceMemory to variability with the purpose to support the Basic Software Module’s different algorithms in the requiring different number of memory atpVariation"
         },
-        "bswPerInstance": {
-          "type": "BswPerInstance",
+        "bswPerInstances": {
+          "type": "any (BswPerInstance)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Policy for a arTypedPerInstanceMemory The policy selects the options of the Schedule Manager API atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "clientPolicy": {
-          "type": "BswClientPolicy",
+        "clientPolicies": {
+          "type": "any (BswClientPolicy)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Policy for a requiredClientServerEntry. The policy selects of the Schedule Manager API generation. atpVariation"
         },
-        "distinguished": {
-          "type": "BswDistinguished",
+        "distinguisheds": {
+          "type": "BswDistinguishedPartition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates an abstract partition context in which the enclosing BswModuleEntity can be executed. atpVariation"
         },
-        "entity": {
+        "entities": {
           "type": "BswModuleEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A code entity for which the behavior is described atpVariation"
         },
-        "event": {
+        "events": {
           "type": "BswEvent",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An event required by this module behavior. atpVariation"
         },
-        "exclusiveArea": {
-          "type": "BswExclusiveArea",
+        "exclusiveAreas": {
+          "type": "BswExclusiveAreaPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Policy for an ExclusiveArea in this BswInternalBehavior. The policy selects the options of the Schedule Manager atpVariation"
         },
-        "includedDataTypeSet": {
+        "includedDataTypeSets": {
           "type": "IncludedDataTypeSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The includedDataTypeSet is used by a basic software for its implementation."
         },
-        "includedMode": {
-          "type": "IncludedMode",
+        "includedModes": {
+          "type": "IncludedModeDeclarationGroupSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the included Mode DeclarationGroups atpSplitable"
         },
-        "internal": {
-          "type": "BswInternalTriggering",
+        "internals": {
+          "type": "BswInternalTriggeringPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Policy for an internalTriggeringPoint in this BswInternal Behavior.. The policy selects the options of the Schedule API generation. atpVariation"
         },
-        "modeReceiver": {
-          "type": "BswModeReceiver",
+        "modeReceivers": {
+          "type": "BswModeReceiverPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Implementation policy for the reception of mode switches. Stereotypes: atpSplitable; atpVariation"
         },
-        "modeSender": {
+        "modeSenders": {
           "type": "BswModeSenderPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Implementation policy for providing a mode group. atpSplitable; atpVariation"
         },
-        "parameterPolicy": {
-          "type": "BswParameterPolicy",
+        "parameterPolicies": {
+          "type": "any (BswParameterPolicy)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Policy for a perInstanceParameter in this BswInternal policy selects the options of the Schedule generation. atpVariation"
         },
-        "perInstance": {
-          "type": "ParameterData",
+        "perInstances": {
+          "type": "ParameterDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Describes a read only memory object containing characteristic value(s) needed by this BswInternal role name perInstanceParameter is chosen to the similar role in the context of SwcInternal to constantMemory, this object is not allocated the module’s code, but by the BSW Scheduler is accessed from the BSW module via the BSW The main use case is the support of of calibration data. is subject to variability with the purpose implementation variants. atpVariation"
         },
-        "receptionPolicy": {
-          "type": "BswDataReception",
+        "receptionPolicies": {
+          "type": "BswDataReceptionPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Data reception policy for inter-partition and/or inter-core atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "releasedTrigger": {
-          "type": "BswReleasedTrigger",
+        "releasedTriggers": {
+          "type": "any (BswReleasedTrigger)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Policy for a releasedTrigger. The policy selects the options of the Schedule Manager API generation. atpVariation"
         },
-        "schedulerName": {
-          "type": "BswSchedulerName",
+        "schedulerNames": {
+          "type": "BswSchedulerNamePrefix",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Optional definition of one or more prefixes to be used for the BswScheduler. atpVariation"
         },
-        "sendPolicy": {
-          "type": "BswDataSendPolicy",
+        "sendPolicies": {
+          "type": "any (BswDataSendPolicy)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Policy for a providedData. The policy selects the options Schedule Manager API generation. atpVariation"
         },
-        "service": {
-          "type": "BswService",
+        "services": {
+          "type": "any (BswService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the requirements on AUTOSAR Services for a particular item. is subject to variability with the purpose the conditional existence of ServiceNeeds. is splitable in order to support that be provided in later development atpVariation"
         },
-        "triggerDirect": {
-          "type": "BswTriggerDirect",
+        "triggerDirects": {
+          "type": "BswTriggerDirectImplementation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies a trigger to be directly implemented via OS calls. atpVariation"
         },
-        "variationPointProxy": {
+        "variationPointProxies": {
           "type": "VariationPointProxy",
           "multiplicity": "*",
           "kind": "attribute",
@@ -259,35 +259,35 @@
         }
       ],
       "attributes": {
-        "accessedMode": {
+        "accessedModes": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "A mode group which is accessed via API call by this entity. It shall be a ModeDeclarationGroupPrototype this module or cluster. atpVariation"
         },
-        "activationPoint": {
-          "type": "BswInternalTriggering",
+        "activationPoints": {
+          "type": "BswInternalTriggeringPoint",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Activation point used by the module entity to activate one more internal triggers. atpVariation"
         },
-        "callPoint": {
+        "callPoints": {
           "type": "BswModuleCallPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A call point used in the code of this entity. of this association is especially targeted at It is possible to have one variant calling AUTOSAR debug module and another one which atpVariation"
         },
-        "dataReceive": {
+        "dataReceives": {
           "type": "BswVariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The data is received via the BSW Scheduler. atpSplitable; atpVariation"
         },
-        "dataSendPoint": {
+        "dataSendPoints": {
           "type": "BswVariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
@@ -301,14 +301,14 @@
           "is_ref": false,
           "note": "The entry which is implemented by this module entity."
         },
-        "issuedTrigger": {
+        "issuedTriggers": {
           "type": "Trigger",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "A trigger issued by this entity via BSW Scheduler API call."
         },
-        "managedMode": {
+        "managedModes": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -316,7 +316,7 @@
           "note": "A mode group which is managed by this entity. It shall be a ModeDeclarationGroupPrototype provided by this cluster. atpVariation"
         },
         "schedulerName": {
-          "type": "BswSchedulerName",
+          "type": "BswSchedulerNamePrefix",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -490,8 +490,8 @@
         }
       ],
       "attributes": {
-        "context": {
-          "type": "BswDistinguished",
+        "contexts": {
+          "type": "BswDistinguishedPartition",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -535,7 +535,7 @@
           "note": "The BswModuleEntry called at this point."
         },
         "calledFrom": {
-          "type": "ExclusiveAreaNesting",
+          "type": "ExclusiveAreaNestingOrder",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -572,14 +572,14 @@
       ],
       "attributes": {
         "calledEntryEntry": {
-          "type": "BswModuleClientServer",
+          "type": "BswModuleClientServerEntry",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "The entry to be called."
         },
         "calledFrom": {
-          "type": "ExclusiveAreaNesting",
+          "type": "ExclusiveAreaNestingOrder",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -616,7 +616,7 @@
       ],
       "attributes": {
         "calledEntryEntry": {
-          "type": "BswModuleClientServer",
+          "type": "BswModuleClientServerEntry",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -653,7 +653,7 @@
       ],
       "attributes": {
         "asynchronous": {
-          "type": "BswAsynchronous",
+          "type": "any (BswAsynchronous)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -696,8 +696,8 @@
           "is_ref": true,
           "note": "The data accessed via the BSW Scheduler."
         },
-        "context": {
-          "type": "BswDistinguished",
+        "contexts": {
+          "type": "BswDistinguishedPartition",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -821,14 +821,14 @@
         }
       ],
       "attributes": {
-        "context": {
-          "type": "BswDistinguished",
+        "contexts": {
+          "type": "BswDistinguishedPartition",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The existence of this reference indicates that the usage of the event is limited to the context of the referred Bsw"
         },
-        "disabledInModeDescriptionInstanceRef": {
+        "disabledInModeDescriptionInstanceRefs": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1114,7 +1114,7 @@
       ],
       "attributes": {
         "eventSourcePoint": {
-          "type": "BswInternalTriggering",
+          "type": "BswInternalTriggeringPoint",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": true,
@@ -1318,7 +1318,7 @@
       ],
       "attributes": {
         "entry": {
-          "type": "BswModuleClientServer",
+          "type": "BswModuleClientServerEntry",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1359,7 +1359,7 @@
       ],
       "attributes": {
         "eventSource": {
-          "type": "BswAsynchronous",
+          "type": "any (BswAsynchronous)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1484,7 +1484,7 @@
       ],
       "attributes": {
         "ackRequestRequest": {
-          "type": "BswModeSwitchAck",
+          "type": "BswModeSwitchAckRequest",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1741,22 +1741,22 @@
         }
       ],
       "attributes": {
-        "assignedData": {
-          "type": "RoleBasedData",
+        "assignedDatas": {
+          "type": "any (RoleBasedData)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the role of an associated data object (owned by module or cluster) in the context of the ServiceNeeds atpVariation"
         },
-        "assignedEntry": {
-          "type": "RoleBasedBswModule",
+        "assignedEntries": {
+          "type": "RoleBasedBswModuleEntryAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the role of an associated BswModuleEntry in the context of the ServiceNeeds element. atpVariation"
         },
         "ident": {
-          "type": "BswService",
+          "type": "any (BswService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswImplementation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswImplementation.classes.json
@@ -72,15 +72,15 @@
           "is_ref": false,
           "note": "The behavior of this implementation. is made as an association because follows the pattern of the SWCT ARElement cannot be splitted, but we want implementation later, the Bsw not aggregated in BswBehavior"
         },
-        "preconfigured": {
-          "type": "EcucModule",
+        "preconfigureds": {
+          "type": "any (EcucModule)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the set of preconfigured (i.e. fixed) configuration values for this BswImplementation. BswImplementation represents a cluster of several than one EcucModuleConfigurationValues be referred (at most one per module), most one such element can be referred."
         },
-        "recommended": {
-          "type": "EcucModule",
+        "recommendeds": {
+          "type": "any (EcucModule)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -93,7 +93,7 @@
           "is_ref": false,
           "note": "In driver modules which can be instantiated several times"
         },
-        "vendorSpecific": {
+        "vendorSpecifics": {
           "type": "EcucModuleDef",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
@@ -60,7 +60,7 @@
         }
       ],
       "attributes": {
-        "argument": {
+        "arguments": {
           "type": "SwServiceArg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -131,7 +131,7 @@
           "note": "Refers to the service identifier of the Standardized AUTOSAR basic software. For it can optionally be used for"
         },
         "swServiceImplPolicy": {
-          "type": "SwServiceImplPolicy",
+          "type": "SwServiceImplPolicyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -225,7 +225,7 @@
         }
       ],
       "attributes": {
-        "bswEntryRelationship": {
+        "bswEntryRelationships": {
           "type": "BswEntryRelationship",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
@@ -70,7 +70,7 @@
         }
       ],
       "attributes": {
-        "bswModule": {
+        "bswModules": {
           "type": "BswModuleDependency",
           "multiplicity": "*",
           "kind": "attribute",
@@ -84,21 +84,21 @@
           "is_ref": false,
           "note": "This adds a documentation to the BSW module. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "expectedEntry": {
+        "expectedEntries": {
           "type": "BswModuleEntry",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Indicates an entry which is required by this module. outgoingCallback / requiredEntry. atpVariation"
         },
-        "implemented": {
+        "implementeds": {
           "type": "BswModuleEntry",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Specifies an entry provided by this module which can be by other modules. This includes \"main\" functions, and callbacks. Replacement of expectedCallback. atpVariation"
         },
-        "internalBehavior": {
+        "internalBehaviors": {
           "type": "BswInternalBehavior",
           "multiplicity": "*",
           "kind": "attribute",
@@ -112,56 +112,56 @@
           "is_ref": false,
           "note": "Refers to the BSW Module Identifier defined by the For non-standardized modules, a can be optionally chosen."
         },
-        "providedClient": {
-          "type": "BswModuleClientServer",
+        "providedClients": {
+          "type": "BswModuleClientServerEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies that this module provides a client server entry which can be called from another partition or core.This declared locally to this context and will be the requiredClientServerEntry of another or module via the configuration of the BSW atpVariation"
         },
-        "providedData": {
+        "providedDatas": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies a data prototype provided by this module in be read from another partition or core.The declared locally to this context and will be the requiredData of another or the same the configuration of the BSW Scheduler. atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "providedMode": {
+        "providedModes": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "A set of modes which is owned and provided by this module or cluster. It can be connected to the required other modules or clusters via the the BswScheduler. It can also be modes provided via ports by an EcuAbstraction ComplexDeviceDriverSw atpVariation"
         },
-        "releasedTrigger": {
+        "releasedTriggers": {
           "type": "Trigger",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "A Trigger released by this module or cluster. It can be"
         },
-        "requiredClient": {
-          "type": "BswModuleClientServer",
+        "requiredClients": {
+          "type": "BswModuleClientServerEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies that this module requires a client server entry which can be implemented on another partition or is declared locally to this context and will to the providedClientServerEntry of another same module via the configuration of the BSW atpVariation"
         },
-        "requiredData": {
+        "requiredDatas": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies a data prototype required by this module in oder provided from another partition or core.The required declared locally to this context and will be the providedData of another or the same the configuration of the BswScheduler. atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "requiredMode": {
+        "requiredModes": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies that this module or cluster depends on a certain mode group. The requiredModeGroup is local to this will be connected to the providedModeGroup module or cluster via the configuration of the atpVariation"
         },
-        "requiredTrigger": {
+        "requiredTriggers": {
           "type": "Trigger",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Constants.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Constants.classes.json
@@ -75,7 +75,7 @@
           "is_ref": false,
           "note": "This represents the category of the RuleBasedValue"
         },
-        "swAxisCont": {
+        "swAxisConts": {
           "type": "RuleBasedAxisCont",
           "multiplicity": "*",
           "kind": "attribute",
@@ -160,7 +160,7 @@
         }
       ],
       "attributes": {
-        "element": {
+        "elements": {
           "type": "ValueSpecification",
           "multiplicity": "*",
           "kind": "attribute",
@@ -511,7 +511,7 @@
       ],
       "attributes": {
         "ruleBased": {
-          "type": "RuleBasedValue",
+          "type": "any (RuleBasedValue)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -663,7 +663,7 @@
           "is_ref": false,
           "note": "Specifies to which category of ApplicationDataType this"
         },
-        "swAxisCont": {
+        "swAxisConts": {
           "type": "SwAxisCont",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1189,7 +1189,7 @@
         }
       ],
       "attributes": {
-        "mapping": {
+        "mappings": {
           "type": "ConstantSpecification",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1292,14 +1292,14 @@
       ],
       "attributes": {
         "category": {
-          "type": "CalprmAxisCategory",
+          "type": "CalprmAxisCategoryEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This category specifies the particular axis types: STD_AXIS (swArraysize necessary)"
         },
         "ruleBased": {
-          "type": "RuleBasedValue",
+          "type": "any (RuleBasedValue)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1389,7 +1389,7 @@
       ],
       "attributes": {
         "ruleBased": {
-          "type": "RuleBasedValue",
+          "type": "any (RuleBasedValue)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1457,15 +1457,15 @@
         }
       ],
       "attributes": {
-        "argument": {
-          "type": "CompositeValue",
+        "arguments": {
+          "type": "CompositeValueSpecification",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the collection of aggregated Value Specifications. The last ValueSpecification in the be taken to execute the filling rule."
         },
-        "compound": {
-          "type": "CompositeRuleBased",
+        "compounds": {
+          "type": "any (CompositeRuleBased)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_FlatMap.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_FlatMap.classes.json
@@ -48,7 +48,7 @@
         }
       ],
       "attributes": {
-        "aliasName": {
+        "aliasNames": {
           "type": "AliasNameAssignment",
           "multiplicity": "*",
           "kind": "attribute",
@@ -104,7 +104,7 @@
           "note": "Assignment of a unique name to an Identifiable."
         },
         "label": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -250,7 +250,7 @@
         }
       ],
       "attributes": {
-        "instance": {
+        "instances": {
           "type": "FlatInstanceDescriptor",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Implementation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Implementation.classes.json
@@ -121,35 +121,35 @@
           "is_ref": false,
           "note": "A manifest specifying the intended build actions for the delivered with this implementation. atpVariation"
         },
-        "codeDescriptor": {
+        "codeDescriptors": {
           "type": "Code",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the provided implementation code."
         },
-        "compiler": {
+        "compilers": {
           "type": "Compiler",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the compiler for which this implementation has"
         },
-        "generated": {
+        "generateds": {
           "type": "DependencyOnArtifact",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Relates to an artifact that will be generated during the of this Implementation by an associated Note that this is an optional information might not always be in the scope of a single component to provide this information. atpVariation"
         },
-        "hwElement": {
+        "hwElements": {
           "type": "HwElement",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The hardware elements (e.g. the processor) required for"
         },
-        "linker": {
+        "linkers": {
           "type": "Linker",
           "multiplicity": "*",
           "kind": "attribute",
@@ -164,20 +164,20 @@
           "note": "The measurement & calibration support data belonging to The aggregtion is <<atpSplitable>> case of an already exisiting BSW this description will be added later process, namely at code generation time."
         },
         "programming": {
-          "type": "Programminglanguage",
+          "type": "ProgramminglanguageEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Programming language the implementation was created in."
         },
-        "requiredArtifact": {
+        "requiredArtifacts": {
           "type": "DependencyOnArtifact",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies that this Implementation depends on the another artifact (e.g. a library). This DependencyOnArtifact is subject to the purpose to support variability in the algorithms in the cause different dependencies, e.g. of used libraries. atpVariation"
         },
-        "required": {
+        "requireds": {
           "type": "DependencyOnArtifact",
           "multiplicity": "*",
           "kind": "attribute",
@@ -256,14 +256,14 @@
         }
       ],
       "attributes": {
-        "artifact": {
-          "type": "AutosarEngineering",
+        "artifacts": {
+          "type": "AutosarEngineeringObject",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Refers to the artifact belonging to this code descriptor."
         },
-        "callbackHeader": {
+        "callbackHeaders": {
           "type": "ServiceNeeds",
           "multiplicity": "*",
           "kind": "reference",
@@ -310,14 +310,14 @@
       ],
       "attributes": {
         "artifact": {
-          "type": "AutosarEngineering",
+          "type": "AutosarEngineeringObject",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "The specified artifact needs to exist."
         },
-        "usage": {
-          "type": "DependencyUsage",
+        "usages": {
+          "type": "DependencyUsageEnum",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ImplementationDataTypes.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ImplementationDataTypes.classes.json
@@ -89,8 +89,8 @@
           "is_ref": false,
           "note": "Specifies the profile which the array will follow in case this"
         },
-        "subElement": {
-          "type": "ImplementationData",
+        "subElements": {
+          "type": "any (ImplementationData)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -174,14 +174,14 @@
           "note": "This attribute controls the implementation of the payload array. It shall only be used if the enclosing an array. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
         "arraySize": {
-          "type": "ArraySizeSemantics",
+          "type": "ArraySizeSemanticsEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute controls the meaning of the value of the array size."
         },
         "arraySizeHandling": {
-          "type": "ArraySizeHandling",
+          "type": "ArraySizeHandlingEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -194,8 +194,8 @@
           "is_ref": false,
           "note": "This attribute represents the ability to declare the"
         },
-        "subElement": {
-          "type": "ImplementationData",
+        "subElements": {
+          "type": "any (ImplementationData)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_InternalBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_InternalBehavior.classes.json
@@ -70,42 +70,42 @@
         }
       ],
       "attributes": {
-        "constant": {
-          "type": "ParameterData",
+        "constants": {
+          "type": "ParameterDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Describes a read only memory object containing characteristic value(s) implemented by this Internal of ParameterDataPrototype has to be the ”C’ identifier of the described constant. value(s) might be shared between Sw the same SwComponentType. of constantMemory is subject to the purpose to support variability in the or module implementations. algorithms in the implementation are number of memory objects. atpVariation"
         },
-        "constantValue": {
+        "constantValues": {
           "type": "ConstantSpecification",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ConstantSpecificationMapping to be applied for the particular InternalBehavior"
         },
-        "dataType": {
+        "dataTypes": {
           "type": "DataTypeMappingSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the DataTypeMapping to be applied for the InternalBehavior"
         },
-        "exclusiveArea": {
+        "exclusiveAreas": {
           "type": "ExclusiveArea",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This specifies an ExclusiveArea for this InternalBehavior."
         },
-        "exclusiveAreaNesting": {
-          "type": "ExclusiveAreaNesting",
+        "exclusiveAreaNestings": {
+          "type": "ExclusiveAreaNestingOrder",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the set of ExclusiveAreaNestingOrder owned by the InternalBehavior. atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "staticMemory": {
+        "staticMemories": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -165,22 +165,22 @@
         }
       ],
       "attributes": {
-        "activation": {
+        "activations": {
           "type": "ExecutableEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "If the ExecutableEntity provides at least one activation Reason element the RTE resp. BSW Scheduler shall to read the activation vector of this execution. activationReason element is provided the feature of to determine the activating RTEEvent is this ExecutableEntity."
         },
-        "canEnter": {
+        "canEnters": {
           "type": "ExclusiveArea",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This means that the executable entity can enter/leave the"
         },
-        "exclusiveAreaNesting": {
-          "type": "ExclusiveAreaNesting",
+        "exclusiveAreaNestings": {
+          "type": "ExclusiveAreaNestingOrder",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -200,7 +200,7 @@
           "is_ref": false,
           "note": "The reentrancy level of this ExecutableEntity. See the the enumeration type ReentrancyLevel details. that nonReentrant interfaces can have also multicoreReentrant implementations, and can also have multicoreReentrant"
         },
-        "runsInside": {
+        "runsInsides": {
           "type": "ExclusiveArea",
           "multiplicity": "*",
           "kind": "reference",
@@ -285,7 +285,7 @@
         }
       ],
       "attributes": {
-        "exclusiveArea": {
+        "exclusiveAreas": {
           "type": "ExclusiveArea",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_McGroups.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_McGroups.classes.json
@@ -39,7 +39,7 @@
         }
       ],
       "attributes": {
-        "mcFunction": {
+        "mcFunctions": {
           "type": "McFunction",
           "multiplicity": "*",
           "kind": "reference",
@@ -60,7 +60,7 @@
           "is_ref": true,
           "note": "Refers to the set of measurable belonging to this Mc atpSplitable"
         },
-        "subGroup": {
+        "subGroups": {
           "type": "McGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -102,14 +102,14 @@
         }
       ],
       "attributes": {
-        "flatMapEntry": {
+        "flatMapEntries": {
           "type": "FlatInstanceDescriptor",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Refers to an entry in a FlatMap that is part of the set, for calibration parameter or measured variable. atpSplitable property has no atp.Splitkey due (PropertySetPattern)."
         },
-        "mcDataInstance": {
+        "mcDataInstances": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json
@@ -33,29 +33,29 @@
         }
       ],
       "attributes": {
-        "emulation": {
-          "type": "McSwEmulationMethod",
+        "emulations": {
+          "type": "McSwEmulationMethodSupport",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Describes the calibration method used by the RTE. This information is not needed for A2L generation, but to setup in the ECU. atpVariation"
         },
-        "mcParameter": {
+        "mcParameters": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A data instance to be used for calibration. atpSplitable; atpVariation"
         },
-        "mcVariable": {
+        "mcVariables": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A data instance to be used for measurement. atpSplitable; atpVariation"
         },
-        "measurable": {
-          "type": "SwSystemconstant",
+        "measurables": {
+          "type": "SwSystemconstantValueSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -129,7 +129,7 @@
           "note": "Reference to the corresponding entry in the ECU Flat allows to trace back to the original specification generated data instance. This link shall be added RTE generator mainly for documentation purposes. is optional because McDataInstance may represent an array or struct only the subElements correspond to FlatMap McDataInstance may represent a task local buffer prototyping access which is different from the used for measurement access."
         },
         "instanceIn": {
-          "type": "ImplementationElement",
+          "type": "ImplementationElementInParameterInstanceRef",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -142,8 +142,8 @@
           "is_ref": false,
           "note": "Refers to \"upstream\" information on how the RTE uses data instance. Use Case: Rapid Prototyping"
         },
-        "mcData": {
-          "type": "RoleBasedMcData",
+        "mcDatas": {
+          "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -157,7 +157,7 @@
           "note": "These are the generated properties resulting from"
         },
         "resultingRptSw": {
-          "type": "RptSwPrototyping",
+          "type": "RptSwPrototypingAccess",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -177,7 +177,7 @@
           "is_ref": false,
           "note": "Describes the implemented code preparation for rapid"
         },
-        "subElement": {
+        "subElements": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "attribute",
@@ -233,8 +233,8 @@
           "is_ref": false,
           "note": "Identifies the actual method. The possible names shall"
         },
-        "elementGroup": {
-          "type": "McParameterElement",
+        "elementGroups": {
+          "type": "McParameterElementGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -339,7 +339,7 @@
           "note": "The context for the referred element."
         },
         "target": {
-          "type": "AbstractImplementation",
+          "type": "any (AbstractImplementation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -414,7 +414,7 @@
           "is_ref": true,
           "note": "Refers to the set of adjustable data (= calibration by this function."
         },
-        "subFunction": {
+        "subFunctions": {
           "type": "McFunction",
           "multiplicity": "*",
           "kind": "reference",
@@ -449,14 +449,14 @@
         }
       ],
       "attributes": {
-        "rteEventRef": {
+        "rteEventRefs": {
           "type": "RTEEvent",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "by: RteEventInEcuInstance"
         },
-        "variableAccess": {
+        "variableAccesses": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
@@ -495,14 +495,14 @@
         }
       ],
       "attributes": {
-        "execution": {
+        "executions": {
           "type": "RptExecutionContext",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Determines the executionContext in which the McData describing a local (e.g Task-Local) buffer of a is valid."
         },
-        "mcDataInstance": {
+        "mcDataInstances": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport_RptSupport.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport_RptSupport.classes.json
@@ -37,14 +37,14 @@
         }
       ],
       "attributes": {
-        "flatMapEntry": {
+        "flatMapEntries": {
           "type": "FlatInstanceDescriptor",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Refers to an entry in a FlatMap that is part of the set, for calibration parameter or measured variable. atpSplitable property has no atp.Splitkey due (PropertySetPattern)."
         },
-        "mcDataInstance": {
+        "mcDataInstances": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "reference",
@@ -79,21 +79,21 @@
         }
       ],
       "attributes": {
-        "execution": {
+        "executions": {
           "type": "RptExecutionContext",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines an environment for the execution of Executable"
         },
-        "rptComponent": {
+        "rptComponents": {
           "type": "RptComponent",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Description of components for which rapid prototyping"
         },
-        "rptServicePoint": {
+        "rptServicePoints": {
           "type": "RptServicePoint",
           "multiplicity": "*",
           "kind": "attribute",
@@ -187,8 +187,8 @@
         }
       ],
       "attributes": {
-        "mcData": {
-          "type": "RoleBasedMcData",
+        "mcDatas": {
+          "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -201,7 +201,7 @@
           "is_ref": false,
           "note": "Describes the implemented code preparation for rapid"
         },
-        "rptExecutableEntity": {
+        "rptExecutableEntities": {
           "type": "RptExecutableEntity",
           "multiplicity": "*",
           "kind": "attribute",
@@ -239,22 +239,22 @@
         }
       ],
       "attributes": {
-        "rptExecutableEntity": {
+        "rptExecutableEntities": {
           "type": "RptExecutableEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "ExecutableEntity event instance activation the owning Rpt ExecutableEntity. atpVariation"
         },
-        "rptRead": {
-          "type": "RoleBasedMcData",
+        "rptReads": {
+          "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "read access to a variable atpSplitable; atpVariation"
         },
-        "rptWrite": {
-          "type": "RoleBasedMcData",
+        "rptWrites": {
+          "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -298,15 +298,15 @@
         }
       ],
       "attributes": {
-        "execution": {
+        "executions": {
           "type": "RptExecutionContext",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This describes the context in which the event of the entity is executed."
         },
-        "mcData": {
-          "type": "RoleBasedMcData",
+        "mcDatas": {
+          "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -333,7 +333,7 @@
           "is_ref": false,
           "note": "Describes the RptImplPolicy of a RptExecutableEvent for"
         },
-        "rptServicePoint": {
+        "rptServicePoints": {
           "type": "RptServicePoint",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ModeDeclaration.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ModeDeclaration.classes.json
@@ -65,7 +65,7 @@
       ],
       "attributes": {
         "swCalibrationAccess": {
-          "type": "SwCalibrationAccess",
+          "type": "SwCalibrationAccessEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -150,7 +150,7 @@
           "is_ref": false,
           "note": "The initial mode of the ModeDeclarationGroup. This active before any mode switches occurred."
         },
-        "mode": {
+        "modes": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "attribute",
@@ -164,7 +164,7 @@
           "is_ref": false,
           "note": "This represents the ability to define the error behavior by the mode manager in case of errors on the side (e.g. terminated mode user)."
         },
-        "modeTransitionModeDeclarationGroup": {
+        "modeTransitionModeDeclarationGroups": {
           "type": "ModeTransition",
           "multiplicity": "*",
           "kind": "attribute",
@@ -351,7 +351,7 @@
           "note": "This represents the ModeDeclaration that is considered mode in the context of the enclosing Mode"
         },
         "errorReaction": {
-          "type": "ModeErrorReaction",
+          "type": "ModeErrorReactionPolicyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption.classes.json
@@ -45,42 +45,42 @@
         }
       ],
       "attributes": {
-        "accessCountSet": {
+        "accessCountSets": {
           "type": "AccessCountSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Set of access count values atpSplitable; atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "executionTime": {
+        "executionTimes": {
           "type": "ExecutionTime",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of the execution time descriptions for this"
         },
-        "heapUsage": {
+        "heapUsages": {
           "type": "HeapUsage",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of the heap memory allocated by this"
         },
-        "memorySection": {
+        "memorySections": {
           "type": "MemorySection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An abstract memory section required by this"
         },
-        "sectionNamePrefix": {
+        "sectionNamePrefixes": {
           "type": "SectionNamePrefix",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A prefix to be used for the memory section symbol in the atpVariation"
         },
-        "stackUsage": {
+        "stackUsages": {
           "type": "StackUsage",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption_ExecutionTime.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption_ExecutionTime.classes.json
@@ -74,14 +74,14 @@
           "is_ref": false,
           "note": "The hardware element (e.g. type of ECU) for which the is specified."
         },
-        "includedLibrary": {
+        "includedLibraries": {
           "type": "DependencyOnArtifact",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "If this dependency is specified, the execution time of the is included in the execution time data for the"
         },
-        "memorySectionLocation": {
+        "memorySectionLocations": {
           "type": "MemorySectionLocation",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption_MemorySectionUsage.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ResourceConsumption_MemorySectionUsage.classes.json
@@ -49,14 +49,14 @@
           "is_ref": false,
           "note": "The attribute describes the typical alignment of objects memory section."
         },
-        "executableEntity": {
+        "executableEntities": {
           "type": "ExecutableEntity",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ExecutableEntitites located in this allows to locate different Executable different sections even if the associated Sw the same. applicable to code sections only."
         },
-        "option": {
+        "options": {
           "type": "Identifier",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ServiceNeeds.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_ServiceNeeds.classes.json
@@ -38,14 +38,14 @@
       ],
       "attributes": {
         "assignedData": {
-          "type": "RoleBasedDataType",
+          "type": "RoleBasedDataTypeAssignment",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is the role of the assignment data type in the given context. atpVariation"
         },
         "diagnostic": {
-          "type": "ServiceDiagnostic",
+          "type": "ServiceDiagnosticRelevanceEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -313,7 +313,7 @@
           "note": "Number of ROM Blocks to be provided by the NVRAM this block. Please note that these multiple are given in a contiguous area."
         },
         "ramBlockStatusControl": {
-          "type": "RamBlockStatusControl",
+          "type": "RamBlockStatusControlEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -425,7 +425,7 @@
           "note": "Provides the amount of updates to this block from the point of view. It has to be provided in \"number access per year\"."
         },
         "writingPriority": {
-          "type": "NvBlockNeedsWriting",
+          "type": "NvBlockNeedsWritingPriorityEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -477,8 +477,8 @@
           "is_ref": false,
           "note": "true/false: supervision activation status of Supervised"
         },
-        "checkpoints": {
-          "type": "SupervisedEntity",
+        "checkpointses": {
+          "type": "any (SupervisedEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -833,15 +833,15 @@
         }
       ],
       "attributes": {
-        "audience": {
-          "type": "DiagnosticAudience",
+        "audiences": {
+          "type": "DiagnosticAudienceEnum",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This specifies the intended audience for the diagnostic Note that this is not only for the documentation but audience specific implementation."
         },
         "diag": {
-          "type": "DiagRequirementId",
+          "type": "DiagRequirementIdString",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1012,7 +1012,7 @@
           "note": "This attribute is applicable only if the DiagnosticValue aggregated within a BswModuleDependency. represents the length of data (in bytes) this particular PID signal."
         },
         "diagnosticValueAccess": {
-          "type": "DiagnosticValueAccess",
+          "type": "DiagnosticValueAccessEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1026,7 +1026,7 @@
           "note": "This attribute is applicable only if the DiagnosticValue"
         },
         "processingStyle": {
-          "type": "DiagnosticProcessing",
+          "type": "DiagnosticProcessingStyleEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1079,7 +1079,7 @@
       ],
       "attributes": {
         "diagRoutine": {
-          "type": "DiagnosticRoutineType",
+          "type": "DiagnosticRoutineTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1239,7 +1239,7 @@
       ],
       "attributes": {
         "serviceRequest": {
-          "type": "DiagnosticService",
+          "type": "any (DiagnosticService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1368,7 +1368,7 @@
         }
       ],
       "attributes": {
-        "deferringFid": {
+        "deferringFids": {
           "type": "FunctionInhibitionNeeds",
           "multiplicity": "*",
           "kind": "reference",
@@ -1376,7 +1376,7 @@
           "note": "This reference contains the link to a function identifier FiM which is used by the monitor before result."
         },
         "diagEventDebounce": {
-          "type": "DiagEventDebounce",
+          "type": "any (DiagEventDebounce)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1389,7 +1389,7 @@
           "is_ref": false,
           "note": "This represents the primary Function Inhibition Identifier inhibition of the diagnostic monitor. The FID inhibit the monitoring of a symptom or the detected faults."
         },
-        "inhibiting": {
+        "inhibitings": {
           "type": "FunctionInhibitionNeeds",
           "multiplicity": "*",
           "kind": "reference",
@@ -1697,7 +1697,7 @@
         }
       ],
       "attributes": {
-        "tracedFailure": {
+        "tracedFailures": {
           "type": "TracedFailure",
           "multiplicity": "*",
           "kind": "attribute",
@@ -2236,7 +2236,7 @@
           "note": "Unit and scaling ID according to ISO 15031-5."
         },
         "updateKind": {
-          "type": "DiagnosticMonitor",
+          "type": "DiagnosticMonitorUpdateKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2467,7 +2467,7 @@
       ],
       "attributes": {
         "operationCycle": {
-          "type": "OperationCycleType",
+          "type": "any (OperationCycleType)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2508,7 +2508,7 @@
       ],
       "attributes": {
         "initialStatus": {
-          "type": "EventAcceptanceStatus",
+          "type": "EventAcceptanceStatusEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2549,7 +2549,7 @@
       ],
       "attributes": {
         "initialStatus": {
-          "type": "StorageConditionStatus",
+          "type": "StorageConditionStatusEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2589,7 +2589,7 @@
       ],
       "attributes": {
         "typeEnum": {
-          "type": "DiagnosticIndicatorType",
+          "type": "DiagnosticIndicatorTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2630,7 +2630,7 @@
       ],
       "attributes": {
         "notificationTime": {
-          "type": "DiagnosticClearDtc",
+          "type": "any (DiagnosticClearDtc)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2704,7 +2704,7 @@
       ],
       "attributes": {
         "connectionType": {
-          "type": "ObdRatioConnection",
+          "type": "ObdRatioConnectionKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2759,7 +2759,7 @@
       ],
       "attributes": {
         "denominator": {
-          "type": "DiagnosticDenominator",
+          "type": "DiagnosticDenominatorConditionEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3150,7 +3150,7 @@
       ],
       "attributes": {
         "verification": {
-          "type": "VerificationStatus",
+          "type": "VerificationStatusIndicationModeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3452,8 +3452,8 @@
         }
       ],
       "attributes": {
-        "possibleErrorReaction": {
-          "type": "PossibleErrorReaction",
+        "possibleErrorReactions": {
+          "type": "any (PossibleErrorReaction)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_SignalServiceTranslation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_SignalServiceTranslation.classes.json
@@ -42,21 +42,21 @@
         }
       ],
       "attributes": {
-        "control": {
+        "controls": {
           "type": "ConsumedEventGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the EventGroup which encapsulates the payload."
         },
-        "controlPnc": {
+        "controlPncs": {
           "type": "PncMappingIdent",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the PNCs which control the offer/subscribe the translated service instance."
         },
-        "controlProvided": {
+        "controlProvideds": {
           "type": "EventHandler",
           "multiplicity": "*",
           "kind": "reference",
@@ -64,14 +64,14 @@
           "note": "Reference to the provided event group (aka Event which is automatically available when service translationStart."
         },
         "serviceControl": {
-          "type": "SignalService",
+          "type": "any (SignalService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines how the service instance control shall behave."
         },
-        "signalServiceEventProps": {
-          "type": "SignalService",
+        "signalServiceEventPropses": {
+          "type": "any (SignalService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -113,8 +113,8 @@
         }
       ],
       "attributes": {
-        "signalServiceProps": {
-          "type": "SignalService",
+        "signalServicePropses": {
+          "type": "any (SignalService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -151,8 +151,8 @@
         }
       ],
       "attributes": {
-        "elementProps": {
-          "type": "SignalService",
+        "elementPropses": {
+          "type": "any (SignalService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_AbstractBlueprintStructure.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_AbstractBlueprintStructure.classes.json
@@ -78,7 +78,7 @@
         }
       ],
       "attributes": {
-        "blueprintPolicy": {
+        "blueprintPolicies": {
           "type": "BlueprintPolicy",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_Blueprint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_Blueprint.classes.json
@@ -33,7 +33,7 @@
         }
       ],
       "attributes": {
-        "consistencyNeeds": {
+        "consistencyNeedses": {
           "type": "ConsistencyNeeds",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_BlueprintDedicated_Port.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_BlueprintDedicated_Port.classes.json
@@ -51,7 +51,7 @@
         }
       ],
       "attributes": {
-        "initValue": {
+        "initValues": {
           "type": "PortPrototypeBlueprint",
           "multiplicity": "*",
           "kind": "attribute",
@@ -65,14 +65,14 @@
           "is_ref": false,
           "note": "This is the interface for which the blueprint is defined. It a blueprint itself or a standardized PortInterface"
         },
-        "providedCom": {
+        "providedComs": {
           "type": "PPortComSpec",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Provided communication attributes per interface element"
         },
-        "requiredCom": {
+        "requiredComs": {
           "type": "RPortComSpec",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_BlueprintMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_BlueprintMapping.classes.json
@@ -39,7 +39,7 @@
         }
       ],
       "attributes": {
-        "blueprintMap": {
+        "blueprintMaps": {
           "type": "AtpBlueprintMapping",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_ClientServerInterfaceToBsw.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_ClientServerInterfaceToBsw.classes.json
@@ -98,8 +98,8 @@
           "is_ref": false,
           "note": "between the ClientServerInterface and the BswModule atpVariation"
         },
-        "portDefinedArgument": {
-          "type": "PortDefinedArgument",
+        "portDefinedArguments": {
+          "type": "PortDefinedArgumentValue",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchange.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchange.classes.json
@@ -27,8 +27,8 @@
         }
       ],
       "attributes": {
-        "specificationDocument": {
-          "type": "SpecificationDocument",
+        "specificationDocuments": {
+          "type": "SpecificationDocumentScope",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -74,8 +74,8 @@
           "is_ref": false,
           "note": "reference to a custom defined specification."
         },
-        "document": {
-          "type": "DocumentElement",
+        "documents": {
+          "type": "DocumentElementScope",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -115,14 +115,14 @@
       ],
       "attributes": {
         "customDocument": {
-          "type": "TraceableElement",
+          "type": "any (TraceableElement)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a custom defined specification element."
         },
-        "tailoring": {
-          "type": "DataFormatElement",
+        "tailorings": {
+          "type": "any (DataFormatElement)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchangePoint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchangePoint.classes.json
@@ -89,21 +89,21 @@
         }
       ],
       "attributes": {
-        "customSdgDef": {
+        "customSdgDefs": {
           "type": "SdgDef",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to custom SdgDefs that extend the data format"
         },
-        "custom": {
+        "customs": {
           "type": "Documentation",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to custom specifications that extend this"
         },
-        "standard": {
+        "standards": {
           "type": "String",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchangePoint_Data.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_DataExchangePoint_Data.classes.json
@@ -307,22 +307,22 @@
         }
       ],
       "attributes": {
-        "classContent": {
-          "type": "ClassContent",
+        "classContents": {
+          "type": "ClassContentConditional",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the accepted / not accepted content of the"
         },
         "multiplicity": {
-          "type": "MultiplicityRestriction",
+          "type": "any (MultiplicityRestriction)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the multiplicity of the class in the current context."
         },
         "variation": {
-          "type": "VariationRestrictionWith",
+          "type": "VariationRestrictionWithSeverity",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -359,7 +359,7 @@
         }
       ],
       "attributes": {
-        "attribute": {
+        "attributes": {
           "type": "AttributeTailoring",
           "multiplicity": "*",
           "kind": "attribute",
@@ -373,14 +373,14 @@
           "is_ref": false,
           "note": "The rules on the content of this class are enabled if the to true."
         },
-        "constraint": {
+        "constraints": {
           "type": "ConstraintTailoring",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specification of tailorings of Constraints of that are owned this Meta Classes"
         },
-        "sdgTailoring": {
+        "sdgTailorings": {
           "type": "SdgTailoring",
           "multiplicity": "*",
           "kind": "attribute",
@@ -503,7 +503,7 @@
       ],
       "attributes": {
         "attribute": {
-          "type": "PrimitiveAttribute",
+          "type": "any (PrimitiveAttribute)",
           "multiplicity": "1",
           "kind": "reference",
           "is_ref": false,
@@ -629,14 +629,14 @@
       ],
       "attributes": {
         "multiplicity": {
-          "type": "MultiplicityRestriction",
+          "type": "any (MultiplicityRestriction)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Multiplicity restriction of the attribute Tags: xml.sequenceOffset=10"
         },
         "variation": {
-          "type": "VariationRestrictionWith",
+          "type": "VariationRestrictionWithSeverity",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -680,21 +680,21 @@
       ],
       "attributes": {
         "defaultValue": {
-          "type": "DefaultValueApplication",
+          "type": "DefaultValueApplicationStrategyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specification of how to handle AUTOSAR defined default values."
         },
-        "subAttribute": {
-          "type": "PrimitiveAttribute",
+        "subAttributes": {
+          "type": "any (PrimitiveAttribute)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Tailors the attribute of a <<primitive>> data type."
         },
         "valueRestrictionWithSeverity": {
-          "type": "ValueRestrictionWith",
+          "type": "ValueRestrictionWithSeverity",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -736,7 +736,7 @@
         }
       ],
       "attributes": {
-        "typeTailoring": {
+        "typeTailorings": {
           "type": "ClassTailoring",
           "multiplicity": "*",
           "kind": "attribute",
@@ -779,7 +779,7 @@
         }
       ],
       "attributes": {
-        "typeTailoring": {
+        "typeTailorings": {
           "type": "ClassTailoring",
           "multiplicity": "*",
           "kind": "attribute",
@@ -787,7 +787,7 @@
           "note": "Local class tailoring for content that is referenced by this"
         },
         "unresolvedRestriction": {
-          "type": "UnresolvedReference",
+          "type": "UnresolvedReferenceRestrictionWithSeverity",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -908,14 +908,14 @@
         }
       ],
       "attributes": {
-        "classTailoring": {
+        "classTailorings": {
           "type": "ClassTailoring",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specification of tailorings of Meta Classes"
         },
-        "constraint": {
+        "constraints": {
           "type": "ConstraintTailoring",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_Keyword.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_StandardizationTemplate_Keyword.classes.json
@@ -43,7 +43,7 @@
           "is_ref": false,
           "note": "This attribute specifies an abbreviated name of a"
         },
-        "classification": {
+        "classifications": {
           "type": "NameToken",
           "multiplicity": "*",
           "kind": "attribute",
@@ -87,7 +87,7 @@
         }
       ],
       "attributes": {
-        "keyword": {
+        "keywords": {
           "type": "Keyword",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_SwcBswMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_SwcBswMapping.classes.json
@@ -57,7 +57,7 @@
           "is_ref": false,
           "note": "The mapped BswInternalBehavior"
         },
-        "runnableMapping": {
+        "runnableMappings": {
           "type": "SwcBswRunnableMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -71,8 +71,8 @@
           "is_ref": false,
           "note": "The mapped SwcInternalBehavior."
         },
-        "synchronized": {
-          "type": "SwcBswSynchronized",
+        "synchronizeds": {
+          "type": "any (SwcBswSynchronized)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingCondition.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingCondition.classes.json
@@ -67,7 +67,7 @@
       ],
       "attributes": {
         "timingArgumentArgumentInstance": {
-          "type": "AutosarOperation",
+          "type": "AutosarOperationArgumentInstance",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -95,7 +95,7 @@
           "note": "This refers to a mode declaration."
         },
         "timingVariableInstance": {
-          "type": "AutosarVariable",
+          "type": "any (AutosarVariable)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -132,22 +132,22 @@
         }
       ],
       "attributes": {
-        "timingArgument": {
-          "type": "AutosarOperation",
+        "timingArguments": {
+          "type": "AutosarOperationArgumentInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This refers to an instance reference of an argument of an call. atpVariation 277 Document ID 411: AUTOSAR_CP_TPS_TimingExtensions Timing Extensions for Classic R23-11"
         },
-        "timingMode": {
+        "timingModes": {
           "type": "TimingModeInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This refers to an instance reference of a mode atpVariation"
         },
-        "timingVariable": {
-          "type": "AutosarVariable",
+        "timingVariables": {
+          "type": "any (AutosarVariable)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -186,7 +186,7 @@
       ],
       "attributes": {
         "modeInstance": {
-          "type": "ModeInSwcBsw",
+          "type": "any (ModeInSwcBsw)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -280,8 +280,8 @@
           "is_ref": false,
           "note": "Specifies the SW component representing the base of the"
         },
-        "context": {
-          "type": "SwComponent",
+        "contexts": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_EventTriggeringConstraint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_EventTriggeringConstraint.classes.json
@@ -206,7 +206,7 @@
         }
       ],
       "attributes": {
-        "offset": {
+        "offsets": {
           "type": "MultidimensionalTime",
           "multiplicity": "*",
           "kind": "attribute",
@@ -346,21 +346,21 @@
         }
       ],
       "attributes": {
-        "confidenceInterval": {
+        "confidenceIntervals": {
           "type": "ConfidenceInterval",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "List of confidence intervals. xml.sequenceOffset=30 277 Document ID 411: AUTOSAR_CP_TPS_TimingExtensions Timing Extensions for Classic R23-11"
         },
-        "maximum": {
+        "maximums": {
           "type": "MultidimensionalTime",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The nth array element describes the maximum distance can be observed for a sample of n+1 event an array with an identical number of elements as minimumDistance."
         },
-        "minimum": {
+        "minimums": {
           "type": "MultidimensionalTime",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_ExecutionOrderConstraint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_ExecutionOrderConstraint.classes.json
@@ -34,14 +34,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Specifies the composition SW-C type playing the role of a"
         },
         "executionOrder": {
-          "type": "ExecutionOrder",
+          "type": "any (ExecutionOrder)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -61,8 +61,8 @@
           "is_ref": false,
           "note": "Indicates whether the ExecutionOrderConstraint is only"
         },
-        "orderedElement": {
-          "type": "EOCExecutableEntity",
+        "orderedElements": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -114,8 +114,8 @@
         }
       ],
       "attributes": {
-        "directSuccessor": {
-          "type": "EOCExecutableEntity",
+        "directSuccessors": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -154,13 +154,13 @@
       ],
       "attributes": {
         "letDataExchange": {
-          "type": "LetDataExchange",
+          "type": "LetDataExchangeParadigmEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the data exchange paradigm between ExecutableEntitys within a LET interval. atp.Status=draft"
         },
-        "letInterval": {
+        "letIntervals": {
           "type": "TimingDescriptionEvent",
           "multiplicity": "*",
           "kind": "reference",
@@ -195,15 +195,15 @@
           "is_ref": false,
           "note": "Repetitive Execution Order Constraint only: number of ExecutableEntitys (slots) that are a given order within a cycle, for the Repetitive Constraint."
         },
-        "nestedElement": {
-          "type": "EOCExecutableEntity",
+        "nestedElements": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This association is used to establish hierarchies of EOCEER Groups and References."
         },
-        "successor": {
-          "type": "EOCExecutableEntity",
+        "successors": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -256,7 +256,7 @@
           "note": "Specifies the BSW module instance the BSW module belongs to."
         },
         "component": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -269,8 +269,8 @@
           "is_ref": false,
           "note": "The ExecutableEntity whose execution order is restricted contraint."
         },
-        "successor": {
-          "type": "EOCExecutableEntity",
+        "successors": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -316,7 +316,7 @@
           "note": "Specifies the BSW module instance the BSW event is to."
         },
         "component": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -329,8 +329,8 @@
           "is_ref": false,
           "note": "The AbstractEvent (event) whose execution order is the contraint."
         },
-        "successor": {
-          "type": "EOCExecutableEntity",
+        "successors": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_ExecutionTimeConstraint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_ExecutionTimeConstraint.classes.json
@@ -34,7 +34,7 @@
       ],
       "attributes": {
         "component": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -48,7 +48,7 @@
           "note": "The referenced ExecutableEntity for the ExecutionTime"
         },
         "executionTime": {
-          "type": "ExecutionTimeType",
+          "type": "ExecutionTimeTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_LatencyTimingConstraint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_LatencyTimingConstraint.classes.json
@@ -34,7 +34,7 @@
       ],
       "attributes": {
         "latency": {
-          "type": "LatencyConstraintType",
+          "type": "LatencyConstraintTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_SynchronizationPointConstraint.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_SynchronizationPointConstraint.classes.json
@@ -33,28 +33,28 @@
         }
       ],
       "attributes": {
-        "sourceEec": {
-          "type": "EOCExecutableEntity",
+        "sourceEecs": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The source executable entities cluster containing the entities that shall finish execution before the"
         },
-        "sourceEvent": {
+        "sourceEvents": {
           "type": "AbstractEvent",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The executable entities — referenced by their events — finish execution before the synchronization"
         },
-        "targetEec": {
-          "type": "EOCExecutableEntity",
+        "targetEecs": {
+          "type": "any (EOCExecutableEntity)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The target executable entities cluster containing the entities that shall start execution after the"
         },
-        "targetEvent": {
+        "targetEvents": {
           "type": "AbstractEvent",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_SynchronizationTiming.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingConstraint_SynchronizationTiming.classes.json
@@ -34,20 +34,20 @@
       ],
       "attributes": {
         "event": {
-          "type": "EventOccurrenceKind",
+          "type": "EventOccurrenceKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates whether the referenced events shall occur only once (single occurrence) or multiple times (multiple the given time interval."
         },
-        "scope": {
+        "scopes": {
           "type": "TimingDescriptionEvent",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The event chains that are in the scope of the constraint. exclusive to scopeEvent, see ([constr_4522])."
         },
-        "scopeEvent": {
+        "scopeEvents": {
           "type": "TimingDescriptionEvent",
           "multiplicity": "*",
           "kind": "reference",
@@ -55,7 +55,7 @@
           "note": "The events that are in the scope of the constraint. to scope, see ([constr_4522])"
         },
         "synchronization": {
-          "type": "SynchronizationType",
+          "type": "SynchronizationTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingCpSoftwareCluster.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingCpSoftwareCluster.classes.json
@@ -33,8 +33,8 @@
         }
       ],
       "attributes": {
-        "tdCpSoftware": {
-          "type": "TDCpSoftwareCluster",
+        "tdCpSoftwares": {
+          "type": "any (TDCpSoftwareCluster)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -78,7 +78,7 @@
           "is_ref": false,
           "note": "This is the software cluster that provides the temporal and"
         },
-        "requestor": {
+        "requestors": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingDescription.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingDescription.classes.json
@@ -45,7 +45,7 @@
           "is_ref": false,
           "note": "The response event representing the point in time where chain is terminated."
         },
-        "segment": {
+        "segments": {
           "type": "TimingDescriptionEvent",
           "multiplicity": "*",
           "kind": "reference",
@@ -151,7 +151,7 @@
           "note": "Optional reference to a clock that holds the time base for"
         },
         "occurrence": {
-          "type": "TDEventOccurrence",
+          "type": "any (TDEventOccurrence)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingDescription_TimingDescription.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingDescription_TimingDescription.classes.json
@@ -39,7 +39,7 @@
       ],
       "attributes": {
         "component": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -200,7 +200,7 @@
           "note": "The referenced VariableDataPrototype"
         },
         "tdEventVariableType": {
-          "type": "TDEventVariableData",
+          "type": "any (TDEventVariableData)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -249,7 +249,7 @@
           "note": "The referenced operation."
         },
         "tdEvent": {
-          "type": "TDEventOperationType",
+          "type": "TDEventOperationTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -312,7 +312,7 @@
           "note": "The referenced mode declaration group prototype."
         },
         "tdEventMode": {
-          "type": "TDEventMode",
+          "type": "any (TDEventMode)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -354,7 +354,7 @@
       ],
       "attributes": {
         "tdEventTrigger": {
-          "type": "TDEventTriggerType",
+          "type": "TDEventTriggerTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -407,7 +407,7 @@
       ],
       "attributes": {
         "component": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -455,7 +455,7 @@
           "note": "The scope of this timing event."
         },
         "tdEventSwcBehaviorType": {
-          "type": "TDEventSwcInternal",
+          "type": "any (TDEventSwcInternal)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -610,7 +610,7 @@
           "note": "The PhysicalChannel on which the ISignal is transmitted."
         },
         "tdEventTypeEnum": {
-          "type": "TDEventISignalType",
+          "type": "TDEventISignalTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -720,7 +720,7 @@
           "note": "The PhysicalChannel on which the Frame is transmitted."
         },
         "tdEventTypeEnum": {
-          "type": "TDEventFrameType",
+          "type": "TDEventFrameTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -774,14 +774,14 @@
           "is_ref": false,
           "note": "This is used to describe the specific event type of a"
         },
-        "tdHeaderIdFilter": {
+        "tdHeaderIdFilters": {
           "type": "TDHeaderIdRange",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the header identifier or a range of header if contained in the Ethernet frame let the"
         },
-        "tdPduTriggering": {
+        "tdPduTriggerings": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -1002,7 +1002,7 @@
           "note": "The scope of this timing event."
         },
         "tdEventBswBehaviorType": {
-          "type": "TDEventBswInternal",
+          "type": "any (TDEventBswInternal)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1112,7 +1112,7 @@
           "note": "The scope of this timing event. 277 Document ID 411: AUTOSAR_CP_TPS_TimingExtensions Timing Extensions for Classic R23-11"
         },
         "tdEventBswDeclarationType": {
-          "type": "TDEventBswMode",
+          "type": "any (TDEventBswMode)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1219,29 +1219,29 @@
         }
       ],
       "attributes": {
-        "argument": {
-          "type": "AutosarOperation",
+        "arguments": {
+          "type": "AutosarOperationArgumentInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An occurrence expression can reference an arbitrary of OperationArgumentPrototypes in its association aggregates instance OperationArgumentPrototypes which can in the expression."
         },
         "formula": {
-          "type": "TDEventOccurrence",
+          "type": "any (TDEventOccurrence)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is the expression formula which is used to describe occurrence expression."
         },
-        "mode": {
+        "modes": {
           "type": "TimingModeInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An occurrence expression can reference an arbitrary TimingModeInstances in its expression. This instance references to Mode can be referenced in the expression."
         },
-        "variable": {
-          "type": "AutosarVariable",
+        "variables": {
+          "type": "any (AutosarVariable)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -1277,7 +1277,7 @@
       ],
       "attributes": {
         "argument": {
-          "type": "AutosarOperation",
+          "type": "AutosarOperationArgumentInstance",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1298,7 +1298,7 @@
           "note": "This is one particular mode used in the expression"
         },
         "variable": {
-          "type": "AutosarVariable",
+          "type": "any (AutosarVariable)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingExtensions.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Timing_TimingExtensions.classes.json
@@ -211,7 +211,7 @@
         }
       ],
       "attributes": {
-        "implementation": {
+        "implementations": {
           "type": "BswImplementation",
           "multiplicity": "*",
           "kind": "reference",
@@ -308,28 +308,28 @@
         }
       ],
       "attributes": {
-        "timingClock": {
+        "timingClocks": {
           "type": "TimingClock",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A list of abstract model Clocks."
         },
-        "timingClockSync": {
-          "type": "TimingClockSync",
+        "timingClockSyncs": {
+          "type": "TimingClockSyncAccuracy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A list of accuracies - which may be used to specify synchronizations from one model clock to another model atpVariation"
         },
-        "timingCondition": {
+        "timingConditions": {
           "type": "TimingCondition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The timing condition specifies a specific condition. atpVariation 277 Document ID 411: AUTOSAR_CP_TPS_TimingExtensions Timing Extensions for Classic R23-11"
         },
-        "timing": {
+        "timings": {
           "type": "TimingConstraint",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_CommonDiagnostics.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_CommonDiagnostics.classes.json
@@ -159,7 +159,7 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -181,7 +181,7 @@
           "note": "This attributes indicates whether the specific Diagnostic"
         },
         "supportInfoByte": {
-          "type": "DiagnosticSupportInfo",
+          "type": "DiagnosticSupportInfoByte",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -363,7 +363,7 @@
           "is_ref": false,
           "note": "This attribute indicates that the enclosing Diagnostic an array and configures size in terms of the number of elements of the"
         },
-        "subElement": {
+        "subElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -408,7 +408,7 @@
         }
       ],
       "attributes": {
-        "subElement": {
+        "subElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -506,7 +506,7 @@
       ],
       "attributes": {
         "arraySize": {
-          "type": "ArraySizeSemantics",
+          "type": "ArraySizeSemanticsEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -571,7 +571,7 @@
       ],
       "attributes": {
         "access": {
-          "type": "DiagnosticAccess",
+          "type": "DiagnosticAccessPermission",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -620,7 +620,7 @@
           "note": "This is the numerical identifier used to identify the the scope of diagnostic workflow"
         },
         "requestResult": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -679,14 +679,14 @@
         }
       ],
       "attributes": {
-        "request": {
+        "requests": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the request parameters."
         },
-        "response": {
+        "responses": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -725,14 +725,14 @@
         }
       ],
       "attributes": {
-        "request": {
+        "requests": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the request parameters."
         },
-        "response": {
+        "responses": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -771,14 +771,14 @@
         }
       ],
       "attributes": {
-        "request": {
+        "requests": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the request parameters."
         },
-        "response": {
+        "responses": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -820,7 +820,7 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -842,7 +842,7 @@
           "note": "The size of the entire PID can be greater than the sum of elements because padding might be applied."
         },
         "supportInfoByte": {
-          "type": "DiagnosticSupportInfo",
+          "type": "DiagnosticSupportInfoByte",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -961,7 +961,7 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm.classes.json
@@ -41,7 +41,7 @@
           "is_ref": false,
           "note": "The existence of this aggregation indicates that an authentication is foreseen. The details are clarified by the"
         },
-        "diagnosticSession": {
+        "diagnosticSessions": {
           "type": "DiagnosticSession",
           "multiplicity": "*",
           "kind": "reference",
@@ -49,13 +49,13 @@
           "note": "This represents the associated DiagnosticSessions atpSplitable"
         },
         "environmental": {
-          "type": "Diagnostic",
+          "type": "any (Diagnostic)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the environmental conditions associated"
         },
-        "securityLevel": {
+        "securityLevels": {
           "type": "DiagnosticSecurityLevel",
           "multiplicity": "*",
           "kind": "reference",
@@ -105,7 +105,7 @@
           "note": "This is the numerical identifier used to identify the the scope of diagnostic workflow"
         },
         "jumpToBoot": {
-          "type": "DiagnosticJumpToBoot",
+          "type": "DiagnosticJumpToBootLoaderEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -223,7 +223,7 @@
         }
       ],
       "attributes": {
-        "authentication": {
+        "authentications": {
           "type": "DiagnosticAuthRole",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_Authentication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_Authentication.classes.json
@@ -50,7 +50,7 @@
       ],
       "attributes": {
         "authentication": {
-          "type": "Diagnostic",
+          "type": "any (Diagnostic)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -308,8 +308,8 @@
         }
       ],
       "attributes": {
-        "certificate": {
-          "type": "DiagnosticAuthTransmit",
+        "certificates": {
+          "type": "any (DiagnosticAuthTransmit)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ClearDiagnosticInfo.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ClearDiagnosticInfo.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "clearDiagnostic": {
-          "type": "DiagnosticClear",
+          "type": "any (DiagnosticClear)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CommonService.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CommonService.classes.json
@@ -187,7 +187,7 @@
       ],
       "attributes": {
         "access": {
-          "type": "DiagnosticAccess",
+          "type": "DiagnosticAccessPermission",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CommunicationControl.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CommunicationControl.classes.json
@@ -85,7 +85,7 @@
           "note": "This represents the affected CommunicationCluster in the"
         },
         "specificPhysical": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -134,28 +134,28 @@
         }
       ],
       "attributes": {
-        "allChannels": {
+        "allChannelses": {
           "type": "CommunicationCluster",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference represents the semantics that all available be affected. It is still necessary to refer to because there could CommunicationClusters in the System Extract not subject to the service \"communication to the applicable CommunicationClusters it made sure that only the affected Communication accessed."
         },
-        "allPhysical": {
-          "type": "EthernetPhysical",
+        "allPhysicals": {
+          "type": "any (EthernetPhysical)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference represents the semantics that all available channels shall be affected. It is still necessary to refer to because there could VLANs (and thus private EthernetPhysical the System Extract that are not subject to \"communication control\". to the applicable EthernetPhysicalChannels it made sure that only the affected EthernetPhysical accessed."
         },
-        "specificChannel": {
+        "specificChannels": {
           "type": "DiagnosticComControl",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the ability to add additional attributes to case that only specific channels are supposed to be"
         },
-        "subNode": {
+        "subNodes": {
           "type": "DiagnosticComControl",
           "multiplicity": "*",
           "kind": "attribute",
@@ -191,7 +191,7 @@
       ],
       "attributes": {
         "subNode": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ControlDTCSetting.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ControlDTCSetting.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "dtcSettingClass": {
-          "type": "DiagnosticControlDTC",
+          "type": "any (DiagnosticControlDTC)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CustomServiceInstance.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_CustomServiceInstance.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "customService": {
-          "type": "DiagnosticCustom",
+          "type": "any (DiagnosticCustom)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_DataByIdentifier.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_DataByIdentifier.classes.json
@@ -37,7 +37,7 @@
       ],
       "attributes": {
         "readClass": {
-          "type": "DiagnosticReadDataBy",
+          "type": "any (DiagnosticReadDataBy)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -81,7 +81,7 @@
       ],
       "attributes": {
         "writeClass": {
-          "type": "DiagnosticWriteDataBy",
+          "type": "any (DiagnosticWriteDataBy)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -167,7 +167,7 @@
       ],
       "attributes": {
         "dataIdentifier": {
-          "type": "DiagnosticAbstractData",
+          "type": "DiagnosticAbstractDataIdentifier",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -254,7 +254,7 @@
       ],
       "attributes": {
         "readScaling": {
-          "type": "DiagnosticReadScaling",
+          "type": "any (DiagnosticReadScaling)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_DynamicallyDefineDataIdentifier.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_DynamicallyDefineDataIdentifier.classes.json
@@ -36,14 +36,14 @@
       ],
       "attributes": {
         "dataIdentifier": {
-          "type": "DiagnosticDynamicData",
+          "type": "DiagnosticDynamicDataIdentifier",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the applicable DiagnosticDynamicData"
         },
         "dynamically": {
-          "type": "DiagnosticDynamically",
+          "type": "any (DiagnosticDynamically)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -100,14 +100,14 @@
           "note": "If set to TRUE, the Dcm module shall check the session,"
         },
         "configuration": {
-          "type": "DiagnosticHandleDDDI",
+          "type": "DiagnosticHandleDDDIConfigurationEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This configuration switch defines whether DDDID definition is handled as non-volatile information or not."
         },
-        "subfunction": {
-          "type": "DiagnosticDynamically",
+        "subfunctions": {
+          "type": "any (DiagnosticDynamically)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_EcuReset.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_EcuReset.classes.json
@@ -86,7 +86,7 @@
       ],
       "attributes": {
         "respondTo": {
-          "type": "DiagnosticResponseTo",
+          "type": "DiagnosticResponseToEcuResetEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_IOControl.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_IOControl.classes.json
@@ -35,8 +35,8 @@
         }
       ],
       "attributes": {
-        "controlEnable": {
-          "type": "DiagnosticControl",
+        "controlEnables": {
+          "type": "any (DiagnosticControl)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -57,7 +57,7 @@
           "note": "Setting this attribute to true represents the ability of the"
         },
         "ioControlClass": {
-          "type": "DiagnosticIoControl",
+          "type": "DiagnosticIOControl",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -147,7 +147,7 @@
           "is_ref": false,
           "note": "This attribute represents the bit number of the bit in the record. Bit number 0 is the most significant in the first byte of the CEMR in the network"
         },
-        "controlledData": {
+        "controlledDatas": {
           "type": "DiagnosticDataElement",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_MemoryByAddress.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_MemoryByAddress.classes.json
@@ -89,8 +89,8 @@
         }
       ],
       "attributes": {
-        "memoryRange": {
-          "type": "DiagnosticMemory",
+        "memoryRanges": {
+          "type": "any (DiagnosticMemory)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -132,7 +132,7 @@
       ],
       "attributes": {
         "access": {
-          "type": "DiagnosticAccess",
+          "type": "DiagnosticAccessPermission",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -198,7 +198,7 @@
       ],
       "attributes": {
         "writeClass": {
-          "type": "DiagnosticWriteMemory",
+          "type": "any (DiagnosticWriteMemory)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -278,7 +278,7 @@
       ],
       "attributes": {
         "readClass": {
-          "type": "DiagnosticReadMemory",
+          "type": "any (DiagnosticReadMemory)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -516,7 +516,7 @@
       ],
       "attributes": {
         "request": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -596,7 +596,7 @@
       ],
       "attributes": {
         "requestUpload": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ReadDTCInformation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ReadDTCInformation.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "read": {
-          "type": "DiagnosticReadDTC",
+          "type": "any (DiagnosticReadDTC)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ReadDataByPeriodicID.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ReadDataByPeriodicID.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "readDataClass": {
-          "type": "DiagnosticReadDataBy",
+          "type": "any (DiagnosticReadDataBy)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -85,7 +85,7 @@
           "is_ref": false,
           "note": "This represents the maximum number of data identifiers can be included in one request."
         },
-        "periodicRate": {
+        "periodicRates": {
           "type": "DiagnosticPeriodicRate",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_RequestFileTransfer.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_RequestFileTransfer.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "requestFile": {
-          "type": "DiagnosticRequestFile",
+          "type": "any (DiagnosticRequestFile)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ResponseOnEvent.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_ResponseOnEvent.classes.json
@@ -35,7 +35,7 @@
         }
       ],
       "attributes": {
-        "eventWindow": {
+        "eventWindows": {
           "type": "DiagnosticEventWindow",
           "multiplicity": "*",
           "kind": "attribute",
@@ -43,7 +43,7 @@
           "note": "This represents the applicable DiagnosticEventWindows"
         },
         "responseOn": {
-          "type": "DiagnosticResponseOn",
+          "type": "any (DiagnosticResponseOn)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_SecurityAccess.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_DiagnosticService_SecurityAccess.classes.json
@@ -43,7 +43,7 @@
           "note": "This would be 0x01, 0x03, 0x05, ... id can be computed by adding 1 to the"
         },
         "securityAccess": {
-          "type": "DiagnosticSecurity",
+          "type": "any (DiagnosticSecurity)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_EnvironmentalCondition.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_EnvironmentalCondition.classes.json
@@ -35,14 +35,14 @@
       ],
       "attributes": {
         "formula": {
-          "type": "DiagnosticEnvCondition",
+          "type": "any (DiagnosticEnvCondition)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute represents the formula part of the"
         },
-        "modeElement": {
-          "type": "DiagnosticEnvMode",
+        "modeElements": {
+          "type": "any (DiagnosticEnvMode)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -86,7 +86,7 @@
           "note": "This attribute represents the concrete NRC value that returned if the condition fails."
         },
         "op": {
-          "type": "DiagnosticLogical",
+          "type": "DiagnosticLogicalOperatorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -163,7 +163,7 @@
       ],
       "attributes": {
         "compareType": {
-          "type": "DiagnosticCompare",
+          "type": "DiagnosticCompareTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -295,7 +295,7 @@
       ],
       "attributes": {
         "modeElement": {
-          "type": "DiagnosticEnvMode",
+          "type": "any (DiagnosticEnvMode)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x01_RequestCurrentPowertrain.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x01_RequestCurrentPowertrain.classes.json
@@ -43,7 +43,7 @@
           "note": "This represents the PID associated with this instance of OBD mode 0x01 service."
         },
         "requestCurrent": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x02_RequestPowertrainFreeze.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x02_RequestPowertrainFreeze.classes.json
@@ -36,14 +36,14 @@
       ],
       "attributes": {
         "freezeFrameFreezeFrame": {
-          "type": "DiagnosticPowertrain",
+          "type": "DiagnosticPowertrainFreezeFrame",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the associated freeze-frame."
         },
         "request": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -119,7 +119,7 @@
         }
       ],
       "attributes": {
-        "pid": {
+        "pids": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x03_0x07_RequestEmission.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x03_0x07_RequestEmission.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "request": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x04_ClearResetEmission.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x04_ClearResetEmission.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "clearReset": {
-          "type": "DiagnosticClearReset",
+          "type": "any (DiagnosticClearReset)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x06_RequestOnBoard.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x06_RequestOnBoard.classes.json
@@ -35,7 +35,7 @@
         }
       ],
       "attributes": {
-        "diagnosticTestResult": {
+        "diagnosticTestResults": {
           "type": "DiagnosticTestResult",
           "multiplicity": "*",
           "kind": "reference",
@@ -43,7 +43,7 @@
           "note": "This reference identifies the applicable collection of test for setting up a request message for mode"
         },
         "requestOn": {
-          "type": "DiagnosticRequestOn",
+          "type": "any (DiagnosticRequestOn)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x08_RequestControlOfOnBoard.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x08_RequestControlOfOnBoard.classes.json
@@ -36,14 +36,14 @@
       ],
       "attributes": {
         "requestControl": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference substantiates that abstract reference in the role serviceClass for this specific concrete class. Thereby, the reference represents the ability to access among all DiagnosticRequestControlOf the given context."
         },
         "testIdIdentifier": {
-          "type": "DiagnosticTestRoutine",
+          "type": "DiagnosticTestRoutineIdentifier",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x09_RequestVehicleInformation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x09_RequestVehicleInformation.classes.json
@@ -43,7 +43,7 @@
           "note": "This represents the info type associated with the mode"
         },
         "requestVehicle": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x0A_RequestEmissionRelated.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dcm_ObdService_Mode_0x0A_RequestEmissionRelated.classes.json
@@ -36,7 +36,7 @@
       ],
       "attributes": {
         "request": {
-          "type": "DiagnosticRequest",
+          "type": "any (DiagnosticRequest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticAging.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticAging.classes.json
@@ -35,7 +35,7 @@
       ],
       "attributes": {
         "agingCycle": {
-          "type": "DiagnosticOperation",
+          "type": "any (DiagnosticOperation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticConditionGroup.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticConditionGroup.classes.json
@@ -75,8 +75,8 @@
         }
       ],
       "attributes": {
-        "enableCondition": {
-          "type": "DiagnosticEnable",
+        "enableConditions": {
+          "type": "any (DiagnosticEnable)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -118,8 +118,8 @@
         }
       ],
       "attributes": {
-        "storage": {
-          "type": "DiagnosticStorage",
+        "storages": {
+          "type": "any (DiagnosticStorage)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticEvent.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticEvent.classes.json
@@ -42,7 +42,7 @@
           "note": "This attribute represents the identification number that is with the enclosing DiagnosticEvent and allows identify it when placed into a snapshot record or record storage. can be reported as internal data element in or extended data records."
         },
         "clearEvent": {
-          "type": "DiagnosticClearEvent",
+          "type": "DiagnosticClearEventAllowedBehaviorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -55,22 +55,22 @@
           "is_ref": false,
           "note": "This attribute defines the number of operation cycles with failed result before a confirmed DTC is set to 1. The this attribute is a by \"1\" increased value the confirmation threshold of the \"trip in ISO 14229-1 in figure D.4. A value defines the immediate confirmation of the DTC the first reported failed. This is also sometimes trip DTC\". A value of \"2\" defines a DTC the operation cycle after the first occurred value of \"2\" is typically used in the US for OBD"
         },
-        "connected": {
-          "type": "DiagnosticConnected",
+        "connecteds": {
+          "type": "any (DiagnosticConnected)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Event specific description of Indicators. Stereotypes: atpSplitable; atpVariation"
         },
         "eventClear": {
-          "type": "DiagnosticEventClear",
+          "type": "DiagnosticEventClearAllowedEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute defines whether the Dem has access to a \"ClearEventAllowed\" callback."
         },
         "eventKind": {
-          "type": "DiagnosticEventKind",
+          "type": "DiagnosticEventKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -129,7 +129,7 @@
       ],
       "attributes": {
         "behaviorIndicatorBehaviorEnum": {
-          "type": "DiagnosticConnected",
+          "type": "any (DiagnosticConnected)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -199,7 +199,7 @@
           "note": "This reference represents the DiagnosticEvent that the IUMPR computation."
         },
         "ratioKind": {
-          "type": "DiagnosticIumprKind",
+          "type": "DiagnosticIumprKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -240,7 +240,7 @@
         }
       ],
       "attributes": {
-        "iumpr": {
+        "iumprs": {
           "type": "DiagnosticIumpr",
           "multiplicity": "*",
           "kind": "reference",
@@ -324,7 +324,7 @@
         }
       ],
       "attributes": {
-        "iumpr": {
+        "iumprs": {
           "type": "DiagnosticIumpr",
           "multiplicity": "*",
           "kind": "reference",
@@ -415,7 +415,7 @@
           "note": "This represents the reference to the actual diagnostic"
         },
         "aliasEventEvent": {
-          "type": "DiagnosticFimAlias",
+          "type": "any (DiagnosticFimAlias)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticExtendedDataRecord.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticExtendedDataRecord.classes.json
@@ -41,7 +41,7 @@
           "is_ref": false,
           "note": "This attribute shall be taken to verbally describe the"
         },
-        "recordElement": {
+        "recordElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -56,7 +56,7 @@
           "note": "This attribute specifies an unique identifier for an record."
         },
         "trigger": {
-          "type": "DiagnosticRecord",
+          "type": "DiagnosticRecordTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticFreezeFrame.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticFreezeFrame.classes.json
@@ -49,7 +49,7 @@
           "note": "This attribute defines a record number for a freeze frame"
         },
         "trigger": {
-          "type": "DiagnosticRecord",
+          "type": "DiagnosticRecordTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticIndicator.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticIndicator.classes.json
@@ -35,7 +35,7 @@
       ],
       "attributes": {
         "type": {
-          "type": "DiagnosticIndicatorType",
+          "type": "DiagnosticIndicatorTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticMemoryDestination.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticMemoryDestination.classes.json
@@ -48,7 +48,7 @@
           "note": "Defines whether the aging cycle counter is processed"
         },
         "clearDtc": {
-          "type": "DiagnosticClearDtc",
+          "type": "any (DiagnosticClearDtc)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -76,7 +76,7 @@
           "note": "This attribute fixes the maximum number of event entries the fault memory."
         },
         "memoryEntry": {
-          "type": "DiagnosticMemoryEntry",
+          "type": "DiagnosticMemoryEntryStorageTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -90,7 +90,7 @@
           "note": "This parameter is used to activate/deactivate the"
         },
         "typeOfFreeze": {
-          "type": "DiagnosticTypeOf",
+          "type": "any (DiagnosticTypeOf)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -133,7 +133,7 @@
       ],
       "attributes": {
         "typeOfDtc": {
-          "type": "DiagnosticTypeOfDtc",
+          "type": "DiagnosticTypeOfDtcSupportedEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -175,7 +175,7 @@
         }
       ],
       "attributes": {
-        "authRole": {
+        "authRoles": {
           "type": "DiagnosticAuthRole",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticOperationCycle.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticOperationCycle.classes.json
@@ -35,7 +35,7 @@
       ],
       "attributes": {
         "typeCycleTypeEnum": {
-          "type": "DiagnosticOperation",
+          "type": "any (DiagnosticOperation)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticTestResult.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticTestResult.classes.json
@@ -48,7 +48,7 @@
           "note": "This attribute represents the diagnostic event that is the diagnostic test result. atpVariation"
         },
         "monitored": {
-          "type": "Diagnostic",
+          "type": "any (Diagnostic)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticTroubleCode.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Dem_DiagnosticTroubleCode.classes.json
@@ -50,7 +50,7 @@
           "note": "Defined properties associated with the DemDTC."
         },
         "eventReadiness": {
-          "type": "EventObdReadiness",
+          "type": "EventObdReadinessGroup",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -71,7 +71,7 @@
           "note": "3 Byte OBD DTC value based on the definition from SAE The existence of this attribute is only required if and OBD DTC values are used for SAE this attribute does not exist, then UDS DTC used with J1979-2."
         },
         "severity": {
-          "type": "DiagnosticUdsSeverity",
+          "type": "DiagnosticUdsSeverityEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -85,7 +85,7 @@
           "note": "Unique Diagnostic Trouble Code value for UDS."
         },
         "wwhObdDtc": {
-          "type": "DiagnosticWwhObdDtc",
+          "type": "DiagnosticWwhObdDtcClassEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -142,7 +142,7 @@
           "note": "Defined properties associated with the DemDTC. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
         "eventReadiness": {
-          "type": "EventObdReadiness",
+          "type": "EventObdReadinessGroup",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -268,7 +268,7 @@
         }
       ],
       "attributes": {
-        "dtc": {
+        "dtcs": {
           "type": "DiagnosticTroubleCode",
           "multiplicity": "*",
           "kind": "reference",
@@ -325,20 +325,20 @@
           "note": "Reference to an aging algorithm in case that an aging/ the event is allowed."
         },
         "diagnosticMemory": {
-          "type": "DiagnosticMemory",
+          "type": "any (DiagnosticMemory)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the applicable DiagnosticMemory Destination. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "extendedData": {
-          "type": "DiagnosticExtended",
+        "extendedDatas": {
+          "type": "DiagnosticExtendedDataRecord",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Defines the links to an extended data class sampler. Stereotypes: atpSplitable; atpVariation"
         },
-        "freezeFrame": {
+        "freezeFrames": {
           "type": "DiagnosticFreezeFrame",
           "multiplicity": "*",
           "kind": "reference",
@@ -374,7 +374,7 @@
           "note": "Priority of the event, in view of full event buffer. A lower higher priority."
         },
         "significance": {
-          "type": "DiagnosticSignificance",
+          "type": "DiagnosticSignificanceEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -422,7 +422,7 @@
         }
       ],
       "attributes": {
-        "dataIdentifier": {
+        "dataIdentifiers": {
           "type": "DiagnosticDataIdentifier",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticCommonProps.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticCommonProps.classes.json
@@ -34,8 +34,8 @@
           "is_ref": false,
           "note": "This attribute defines the time (in seconds) that the state is maintained in default-session if no communication from the authenticated client. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "debounce": {
-          "type": "DiagnosticDebounce",
+        "debounces": {
+          "type": "any (DiagnosticDebounce)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -63,7 +63,7 @@
           "note": "Maximum number of negative responses with response 0x78 (requestCorrectlyReceived-ResponsePending) per request. DCM will send a negative response response code 0x10 (generalReject), in case the limit gets reached. Value 0xFF means that no limit of NRC 0x78 response apply."
         },
         "occurrence": {
-          "type": "DiagnosticOccurrence",
+          "type": "DiagnosticOccurrenceCounterProcessingEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticContribution.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticContribution.classes.json
@@ -34,20 +34,20 @@
       ],
       "attributes": {
         "common": {
-          "type": "DiagnosticCommon",
+          "type": "any (DiagnosticCommon)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute represents a collection of diagnostic properties that are shared among the entire Diagnostic"
         },
-        "element": {
-          "type": "DiagnosticCommon",
+        "elements": {
+          "type": "any (DiagnosticCommon)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents a DiagnosticCommonElement considered the context of the DiagnosticContributionSet atpVariation 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "serviceTable": {
+        "serviceTables": {
           "type": "DiagnosticServiceTable",
           "multiplicity": "*",
           "kind": "reference",
@@ -89,7 +89,7 @@
         }
       ],
       "attributes": {
-        "diagnostic": {
+        "diagnostics": {
           "type": "DiagnosticConnection",
           "multiplicity": "*",
           "kind": "reference",
@@ -159,7 +159,7 @@
         }
       ],
       "attributes": {
-        "diagnostic": {
+        "diagnostics": {
           "type": "DiagnosticConnection",
           "multiplicity": "*",
           "kind": "reference",
@@ -180,8 +180,8 @@
           "is_ref": false,
           "note": "This identifies the applicable protocol."
         },
-        "serviceInstance": {
-          "type": "DiagnosticService",
+        "serviceInstances": {
+          "type": "any (DiagnosticService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -222,7 +222,7 @@
         }
       ],
       "attributes": {
-        "ecuInstance": {
+        "ecuInstances": {
           "type": "EcuInstance",
           "multiplicity": "*",
           "kind": "reference",
@@ -230,7 +230,7 @@
           "note": "This represents the actual EcuInstance to which the in the DiagnosticEcuInstance"
         },
         "obdSupport": {
-          "type": "DiagnosticObdSupport",
+          "type": "DiagnosticObdSupportEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping.classes.json
@@ -235,15 +235,15 @@
         }
       ],
       "attributes": {
-        "cryptoService": {
-          "type": "CryptoService",
+        "cryptoServices": {
+          "type": "any (CryptoService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the description of the applicable crypto certificate."
         },
         "serviceInstance": {
-          "type": "DiagnosticAuthTransmit",
+          "type": "any (DiagnosticAuthTransmit)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -343,7 +343,7 @@
           "note": "Reference to a DiagnosticEvent to which an Operation assigned."
         },
         "operationCycle": {
-          "type": "DiagnosticOperation",
+          "type": "any (DiagnosticOperation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -386,7 +386,7 @@
       ],
       "attributes": {
         "debounce": {
-          "type": "DiagnosticDebounce",
+          "type": "any (DiagnosticDebounce)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -443,7 +443,7 @@
           "note": "Reference to a DiagnosticEvent to which an Enable assigned."
         },
         "enableCondition": {
-          "type": "DiagnosticEnable",
+          "type": "any (DiagnosticEnable)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -493,7 +493,7 @@
           "note": "Reference to a DiagnosticEvent to which a Storage assigned."
         },
         "storage": {
-          "type": "DiagnosticStorage",
+          "type": "any (DiagnosticStorage)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -537,7 +537,7 @@
       ],
       "attributes": {
         "bswService": {
-          "type": "BswService",
+          "type": "any (BswService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -551,14 +551,14 @@
           "note": "Reference to the DiagnosticEvent that is assigned to ports."
         },
         "swcFlatService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a SwcServiceDependencyType that links ServiceNeeds to SWC service ports."
         },
         "swcService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -602,21 +602,21 @@
       ],
       "attributes": {
         "operationCycle": {
-          "type": "DiagnosticOperation",
+          "type": "any (DiagnosticOperation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the DiagnosticOperationCycle that is to SWC service ports."
         },
         "swcFlatService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a SwcServiceDependencyType that links ServiceNeeds to SWC service ports."
         },
         "swcService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -660,21 +660,21 @@
       ],
       "attributes": {
         "enableCondition": {
-          "type": "DiagnosticEnable",
+          "type": "any (DiagnosticEnable)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the EnableCondition which is mapped to a service port."
         },
         "swcFlatService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a SwcServiceDependencyType that links ServiceNeeds to SWC service ports. This reference can in early stages of the development in order to SwcServiceDependency without a full System"
         },
         "swcService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -718,21 +718,21 @@
       ],
       "attributes": {
         "diagnosticStorage": {
-          "type": "DiagnosticStorage",
+          "type": "any (DiagnosticStorage)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the StorageCondition which is mapped to a SWC service port with DiagnosticStorageCondition"
         },
         "swcFlatService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a SwcServiceDependencyType that links ServiceNeeds to SWC service ports."
         },
         "swcService": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -832,7 +832,7 @@
           "note": "This reference identifies the applicable diagnostic event."
         },
         "securityEventContext": {
-          "type": "SecurityEventContext",
+          "type": "any (SecurityEventContext)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -875,7 +875,7 @@
       ],
       "attributes": {
         "function": {
-          "type": "DiagnosticFunction",
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -924,8 +924,8 @@
         }
       ],
       "attributes": {
-        "dataIdentifier": {
-          "type": "DiagnosticWriteDataBy",
+        "dataIdentifiers": {
+          "type": "any (DiagnosticWriteDataBy)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_CpSoftwareCluster.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_CpSoftwareCluster.classes.json
@@ -193,7 +193,7 @@
           "note": "This reference identifies the mapped CpSoftwareCluster Resource. atp.Status=draft"
         },
         "function": {
-          "type": "DiagnosticFunction",
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_DiagnosticJ1939Mapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_DiagnosticJ1939Mapping.classes.json
@@ -35,7 +35,7 @@
         }
       ],
       "attributes": {
-        "sendingNode": {
+        "sendingNodes": {
           "type": "DiagnosticJ1939Node",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_FimMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_FimMapping.classes.json
@@ -43,14 +43,14 @@
           "note": "This represents the reference to the diagnostic event. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
         "eventGroupGroup": {
-          "type": "DiagnosticFimEvent",
+          "type": "DiagnosticFimEventGroup",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the reference to the event group"
         },
         "inhibitionSource": {
-          "type": "DiagnosticFunction",
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -93,14 +93,14 @@
       ],
       "attributes": {
         "actualEvent": {
-          "type": "DiagnosticFimEvent",
+          "type": "DiagnosticFimEventGroup",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the reference to the actual summary"
         },
         "aliasEvent": {
-          "type": "DiagnosticFimAlias",
+          "type": "any (DiagnosticFimAlias)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_ServiceMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_DiagnosticMapping_ServiceMapping.classes.json
@@ -93,7 +93,7 @@
         }
       ],
       "attributes": {
-        "contextElement": {
+        "contextElements": {
           "type": "DiagnosticParameter",
           "multiplicity": "*",
           "kind": "reference",
@@ -195,21 +195,21 @@
           "note": "This represents the applicable payload that corresponds to the referenced DataPrototype in the role mappedData"
         },
         "mappedBsw": {
-          "type": "BswService",
+          "type": "any (BswService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This is supposed to represent a reference to a Bsw ServiceDependency. the latter is not derived from and therefore this detour needs to be still let BswServiceDependency become of a reference. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
         "mappedFlatSwc": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the ability to refer to an AtomicSw ComponentType that is available without the definition of it will be embedded into the component hierarchy."
         },
         "mappedSwc": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -223,7 +223,7 @@
           "note": "This aggregation represents the single point of access to the reference to one specific DiagnosticParameter"
         },
         "serviceInstance": {
-          "type": "DiagnosticService",
+          "type": "any (DiagnosticService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -309,7 +309,7 @@
           "note": "This reference identifies the data element that carries the the reporting mode."
         },
         "securityEventContext": {
-          "type": "SecurityEventContext",
+          "type": "any (SecurityEventContext)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -403,28 +403,28 @@
       ],
       "attributes": {
         "mappedBsw": {
-          "type": "BswService",
+          "type": "any (BswService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This is supposed to represent a reference to a Bsw ServiceDependency. the latter is not derived from and therefore this detour needs to be still let BswServiceDependency become of a reference."
         },
         "mappedFlatSwc": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the ability to refer to an AtomicSw ComponentType that is available without the definition of it will be embedded into the component hierarchy."
         },
         "mapped": {
-          "type": "DiagnosticFunction",
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the mapped FID. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
         "mappedSwc": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Fim.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_Fim.classes.json
@@ -104,21 +104,21 @@
       ],
       "attributes": {
         "function": {
-          "type": "DiagnosticFunction",
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the corresponding function identifier."
         },
         "inhibitionMask": {
-          "type": "DiagnosticInhibition",
+          "type": "DiagnosticInhibitionMaskEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the value of the inhibition mask behavior."
         },
-        "inhibitSource": {
-          "type": "DiagnosticFunction",
+        "inhibitSources": {
+          "type": "any (DiagnosticFunction)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -156,14 +156,14 @@
       ],
       "attributes": {
         "event": {
-          "type": "DiagnosticFimAlias",
+          "type": "any (DiagnosticFimAlias)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the alias event applicable for the inhibition source."
         },
         "eventGroup": {
-          "type": "DiagnosticFimAlias",
+          "type": "any (DiagnosticFimAlias)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -204,7 +204,7 @@
         }
       ],
       "attributes": {
-        "event": {
+        "events": {
           "type": "DiagnosticEvent",
           "multiplicity": "*",
           "kind": "reference",
@@ -247,8 +247,8 @@
         }
       ],
       "attributes": {
-        "groupedAlias": {
-          "type": "DiagnosticFimAlias",
+        "groupedAliases": {
+          "type": "any (DiagnosticFimAlias)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_DiagnosticExtract_InstanceRefs.classes.json
@@ -37,15 +37,15 @@
           "is_ref": false,
           "note": "This represents the base of the InstanceRef"
         },
-        "context": {
-          "type": "SwComponent",
+        "contexts": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Tags: xml.sequenceOffset=30"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -59,7 +59,7 @@
           "note": "This represents the PortPrototype that is contained in the"
         },
         "contextRoot": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -115,21 +115,21 @@
       ],
       "attributes": {
         "contextRootSw": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": ""
         },
-        "contextSwPrototype": {
-          "type": "SwComponent",
+        "contextSwPrototypes": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "ref"
         },
         "targetSwc": {
-          "type": "SwcService",
+          "type": "any (SwcService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -173,7 +173,7 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -187,7 +187,7 @@
           "note": "Tags: xml.sequenceOffset=50"
         },
         "contextPPortPrototype": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_ECUCDescriptionTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_ECUCDescriptionTemplate.classes.json
@@ -45,7 +45,7 @@
         }
       ],
       "attributes": {
-        "container": {
+        "containers": {
           "type": "EcucContainerValue",
           "multiplicity": "*",
           "kind": "attribute",
@@ -67,7 +67,7 @@
           "note": "This is the version info of the ModuleDef ECUC to which this values conform to / are Definition of ModuleDef ECUC Parameters the be used to express the semantic compatibility rules between the definition revision labels is up to the module’s vendor."
         },
         "implementation": {
-          "type": "EcucConfiguration",
+          "type": "any (EcucConfiguration)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -133,8 +133,8 @@
         }
       ],
       "attributes": {
-        "ecucValue": {
-          "type": "EcucModule",
+        "ecucValues": {
+          "type": "any (EcucModule)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -245,21 +245,21 @@
           "is_ref": false,
           "note": "Reference to the definition of this Container in the ECU Definition."
         },
-        "parameterValue": {
+        "parameterValues": {
           "type": "EcucParameterValue",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Aggregates all ECU Configuration Values within this atpVariation"
         },
-        "referenceValue": {
-          "type": "EcucAbstractReference",
+        "referenceValues": {
+          "type": "any (EcucAbstractReference)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Aggregates all References with this container. [RS_ECUC_00079] atpVariation"
         },
-        "subContainer": {
+        "subContainers": {
           "type": "EcucContainerValue",
           "multiplicity": "*",
           "kind": "attribute",
@@ -315,7 +315,7 @@
         }
       ],
       "attributes": {
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -506,7 +506,7 @@
         }
       ],
       "attributes": {
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -514,7 +514,7 @@
           "note": "Possibility to provide additional notes while defining a"
         },
         "definition": {
-          "type": "EcucAbstractReference",
+          "type": "any (EcucAbstractReference)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_ECUCParameterDefTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_ECUCParameterDefTemplate.classes.json
@@ -57,7 +57,7 @@
           "is_ref": false,
           "note": "For modules where several instances of the VSMD can"
         },
-        "container": {
+        "containers": {
           "type": "EcucContainerDef",
           "multiplicity": "*",
           "kind": "attribute",
@@ -78,8 +78,8 @@
           "is_ref": false,
           "note": "Optional reference from the Vendor Specific Module"
         },
-        "supported": {
-          "type": "EcucConfiguration",
+        "supporteds": {
+          "type": "any (EcucConfiguration)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -128,7 +128,7 @@
         }
       ],
       "attributes": {
-        "module": {
+        "modules": {
           "type": "EcucModuleDef",
           "multiplicity": "*",
           "kind": "reference",
@@ -189,15 +189,15 @@
         }
       ],
       "attributes": {
-        "destinationUri": {
+        "destinationUris": {
           "type": "EcucDestinationUriDef",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Several destinationUris can be defined for an Ecuc such destinationUris an Ecuc applicable for several EcucUriReference"
         },
-        "multiplicity": {
-          "type": "EcucMultiplicity",
+        "multiplicities": {
+          "type": "EcucMultiplicityConfigurationClass",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -262,21 +262,21 @@
         }
       ],
       "attributes": {
-        "parameter": {
+        "parameters": {
           "type": "EcucParameterDef",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The parameters defined within the EcucParamConf"
         },
-        "reference": {
-          "type": "EcucAbstractReference",
+        "references": {
+          "type": "any (EcucAbstractReference)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The references defined within the EcucParamConf"
         },
-        "subContainer": {
+        "subContainers": {
           "type": "EcucContainerDef",
           "multiplicity": "*",
           "kind": "attribute",
@@ -320,8 +320,8 @@
         }
       ],
       "attributes": {
-        "choice": {
-          "type": "EcucParamConf",
+        "choices": {
+          "type": "EcucParamConfContainerDef",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -373,14 +373,14 @@
       ],
       "attributes": {
         "ecucCond": {
-          "type": "EcucCondition",
+          "type": "any (EcucCondition)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "If it evaluates to true the Ecu Parameter definition shall be"
         },
-        "ecucValidation": {
-          "type": "EcucValidation",
+        "ecucValidations": {
+          "type": "EcucValidationCondition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -452,8 +452,8 @@
         }
       ],
       "attributes": {
-        "multiplicity": {
-          "type": "EcucMultiplicity",
+        "multiplicities": {
+          "type": "EcucMultiplicityConfigurationClass",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -480,8 +480,8 @@
           "is_ref": false,
           "note": "Used to define whether the value element for this"
         },
-        "valueConfig": {
-          "type": "EcucValueConfiguration",
+        "valueConfigs": {
+          "type": "EcucValueConfigurationClass",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -520,14 +520,14 @@
       ],
       "attributes": {
         "configClass": {
-          "type": "EcucConfigurationClass",
+          "type": "EcucConfigurationClassEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the ConfigurationClass for the given"
         },
         "configVariant": {
-          "type": "EcucConfiguration",
+          "type": "any (EcucConfiguration)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -646,7 +646,7 @@
       ],
       "attributes": {
         "derivation": {
-          "type": "EcucDerivation",
+          "type": "EcucDerivationSpecification",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1118,8 +1118,8 @@
           "is_ref": false,
           "note": "Default value of the enumeration configuration parameter."
         },
-        "literal": {
-          "type": "EcucEnumerationLiteral",
+        "literals": {
+          "type": "EcucEnumerationLiteralDef",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -1157,7 +1157,7 @@
       ],
       "attributes": {
         "ecucCond": {
-          "type": "EcucCondition",
+          "type": "any (EcucCondition)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1450,7 +1450,7 @@
         }
       ],
       "attributes": {
-        "destination": {
+        "destinations": {
           "type": "EcucContainerDef",
           "multiplicity": "*",
           "kind": "reference",
@@ -1642,7 +1642,7 @@
         }
       ],
       "attributes": {
-        "destinationUriDef": {
+        "destinationUriDefs": {
           "type": "EcucDestinationUriDef",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1681,7 +1681,7 @@
       ],
       "attributes": {
         "destinationUri": {
-          "type": "EcucDestinationUri",
+          "type": "any (EcucDestinationUri)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1715,7 +1715,7 @@
         }
       ],
       "attributes": {
-        "container": {
+        "containers": {
           "type": "EcucContainerDef",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1723,21 +1723,21 @@
           "note": "Description of the targetContainer in case that the set to targetContainer. In cases the subContainers of the target container here."
         },
         "destinationUri": {
-          "type": "EcucDestinationUri",
+          "type": "any (EcucDestinationUri)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute defines how the referenced target Ecuc ContainerDef is described."
         },
-        "parameter": {
+        "parameters": {
           "type": "EcucParameterDef",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Description of parameters that are contained in the target"
         },
-        "reference": {
-          "type": "EcucAbstractReference",
+        "references": {
+          "type": "any (EcucAbstractReference)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
@@ -1772,13 +1772,13 @@
       ],
       "attributes": {
         "calculation": {
-          "type": "EcucParameter",
+          "type": "any (EcucParameter)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of the formula used to calculate the value of the"
         },
-        "ecucQuery": {
+        "ecucQueries": {
           "type": "EcucQuery",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1939,7 +1939,7 @@
           "is_ref": false,
           "note": "Definition of the formula used to define existence"
         },
-        "ecucQuery": {
+        "ecucQueries": {
           "type": "EcucQuery",
           "multiplicity": "*",
           "kind": "attribute",
@@ -2021,7 +2021,7 @@
         }
       ],
       "attributes": {
-        "ecucQuery": {
+        "ecucQueries": {
           "type": "EcucQuery",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate.classes.json
@@ -52,21 +52,21 @@
         }
       ],
       "attributes": {
-        "hwElement": {
+        "hwElements": {
           "type": "HwElementConnector",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents one particular connection between two elements. atpVariation"
         },
-        "hwPinGroup": {
+        "hwPinGroups": {
           "type": "HwPinGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This aggregation is used to describe the connection a hardware element. Note that hardware no pins but only pingroups. atpVariation"
         },
-        "nestedElement": {
+        "nestedElements": {
           "type": "HwElement",
           "multiplicity": "*",
           "kind": "reference",
@@ -114,14 +114,14 @@
         }
       ],
       "attributes": {
-        "hwAttribute": {
+        "hwAttributes": {
           "type": "HwAttributeValue",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents a particular hardware value. atpVariation"
         },
-        "hwCategory": {
+        "hwCategories": {
           "type": "HwCategory",
           "multiplicity": "*",
           "kind": "reference",
@@ -255,7 +255,7 @@
         }
       ],
       "attributes": {
-        "functionName": {
+        "functionNames": {
           "type": "String",
           "multiplicity": "*",
           "kind": "attribute",
@@ -305,21 +305,21 @@
         }
       ],
       "attributes": {
-        "hwElement": {
+        "hwElements": {
           "type": "HwElement",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This association connects two hardware elements."
         },
-        "hwPin": {
+        "hwPins": {
           "type": "HwPinConnector",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents one particular connection between two"
         },
-        "hwPinGroup": {
+        "hwPinGroups": {
           "type": "HwPinGroupConnector",
           "multiplicity": "*",
           "kind": "attribute",
@@ -355,14 +355,14 @@
         }
       ],
       "attributes": {
-        "hwPin": {
+        "hwPins": {
           "type": "HwPinConnector",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents one particular connection between two"
         },
-        "hwPinGroup": {
+        "hwPinGroups": {
           "type": "HwPinGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -399,7 +399,7 @@
         }
       ],
       "attributes": {
-        "hwPin": {
+        "hwPins": {
           "type": "HwPin",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate_HwElementCategory.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate_HwElementCategory.classes.json
@@ -131,7 +131,7 @@
         }
       ],
       "attributes": {
-        "hwAttributeDef": {
+        "hwAttributeDefs": {
           "type": "HwAttributeDef",
           "multiplicity": "*",
           "kind": "attribute",
@@ -169,7 +169,7 @@
         }
       ],
       "attributes": {
-        "hwAttribute": {
+        "hwAttributes": {
           "type": "HwAttributeLiteralDef",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_FeatureModelTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_FeatureModelTemplate.classes.json
@@ -39,7 +39,7 @@
         }
       ],
       "attributes": {
-        "feature": {
+        "features": {
           "type": "FMFeature",
           "multiplicity": "*",
           "kind": "reference",
@@ -93,14 +93,14 @@
         }
       ],
       "attributes": {
-        "attributeDef": {
+        "attributeDefs": {
           "type": "FMAttributeDef",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This defines the attributes of the given feature."
         },
-        "decompositionDecomposition": {
+        "decompositionDecompositions": {
           "type": "FMFeature",
           "multiplicity": "*",
           "kind": "attribute",
@@ -121,14 +121,14 @@
           "is_ref": false,
           "note": "Defines a lower bound for the binding time of the variation that are associated with the FMFeature. This is meant as a hint for the development process."
         },
-        "relation": {
+        "relations": {
           "type": "FMFeatureRelation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines relations for FMFeatures, for example other FMFeatures, or conflicts with A FMFeature can only be part of a all its relations are fulfilled."
         },
-        "restriction": {
+        "restrictions": {
           "type": "FMFeatureRestriction",
           "multiplicity": "*",
           "kind": "attribute",
@@ -222,7 +222,7 @@
           "is_ref": false,
           "note": "The category of a FMFeatureDecomposition defines the"
         },
-        "feature": {
+        "features": {
           "type": "FMFeature",
           "multiplicity": "*",
           "kind": "reference",
@@ -275,7 +275,7 @@
       ],
       "attributes": {
         "restrictionAndAttributes": {
-          "type": "FMConditionByFeatures",
+          "type": "any (FMConditionByFeatures)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -312,7 +312,7 @@
         }
       ],
       "attributes": {
-        "feature": {
+        "features": {
           "type": "FMFeature",
           "multiplicity": "*",
           "kind": "reference",
@@ -320,7 +320,7 @@
           "note": "The FMFeature that is targeted by this FMFeature"
         },
         "restriction": {
-          "type": "FMConditionByFeatures",
+          "type": "any (FMConditionByFeatures)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -357,7 +357,7 @@
         }
       ],
       "attributes": {
-        "attributeValue": {
+        "attributeValues": {
           "type": "FMAttributeValue",
           "multiplicity": "*",
           "kind": "attribute",
@@ -440,21 +440,21 @@
         }
       ],
       "attributes": {
-        "featureModel": {
+        "featureModels": {
           "type": "FMFeatureModel",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "All FMFeatures in this FMFeatureSelectionSet shall be the referenced FMFeatureModel."
         },
-        "include": {
+        "includes": {
           "type": "FMFeatureSelectionSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Each FMFeatureSelectionSet may include one or more establishes a hierarchy See constr_5003 and details."
         },
-        "selection": {
+        "selections": {
           "type": "FMFeatureSelection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -495,7 +495,7 @@
         }
       ],
       "attributes": {
-        "mapping": {
+        "mappings": {
           "type": "FMFeatureMapElement",
           "multiplicity": "*",
           "kind": "attribute",
@@ -533,29 +533,29 @@
         }
       ],
       "attributes": {
-        "assertion": {
+        "assertions": {
           "type": "FMFeatureMap",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines a boolean expression based on features and"
         },
-        "condition": {
+        "conditions": {
           "type": "FMFeatureMap",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines a condition which needs to be fulfilled for this"
         },
-        "postBuildVariant": {
-          "type": "PostBuildVariant",
+        "postBuildVariants": {
+          "type": "any (PostBuildVariant)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Selects a set of values for postbuild variant criterions."
         },
-        "swValueSet": {
-          "type": "SwSystemconstant",
+        "swValueSets": {
+          "type": "SwSystemconstantValueSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -593,7 +593,7 @@
       ],
       "attributes": {
         "fmCondAndAttributes": {
-          "type": "FMConditionByFeatures",
+          "type": "any (FMConditionByFeatures)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -631,7 +631,7 @@
       ],
       "attributes": {
         "fmSyscondAndSwSystemconsts": {
-          "type": "FMConditionByFeatures",
+          "type": "any (FMConditionByFeatures)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_AbstractStructure.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_AbstractStructure.classes.json
@@ -93,7 +93,7 @@
           "is_ref": false,
           "note": "This is the base from which the navigaion path starts."
         },
-        "atpContext": {
+        "atpContexts": {
           "type": "AtpPrototype",
           "multiplicity": "*",
           "kind": "reference",
@@ -139,7 +139,7 @@
         }
       ],
       "attributes": {
-        "atpFeature": {
+        "atpFeatures": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_BuildActionManifest.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_BuildActionManifest.classes.json
@@ -48,28 +48,28 @@
         }
       ],
       "attributes": {
-        "buildAction": {
+        "buildActions": {
           "type": "BuildActionEnvironment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents a build action environment. atpSplitable; atpVariation"
         },
-        "dynamicAction": {
+        "dynamicActions": {
           "type": "BuildAction",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This denotes an Action which is to be executed as part of action set."
         },
-        "startAction": {
+        "startActions": {
           "type": "BuildAction",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This specifies the list of actions to be performed at the the process. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "tearDownAction": {
+        "tearDownActions": {
           "type": "BuildAction",
           "multiplicity": "*",
           "kind": "reference",
@@ -117,35 +117,35 @@
         }
       ],
       "attributes": {
-        "createdData": {
+        "createdDatas": {
           "type": "BuildActionIoElement",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the artifacts which are created by the"
         },
-        "followUpAction": {
+        "followUpActions": {
           "type": "BuildAction",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This association specifies a set of follow up actions."
         },
-        "inputData": {
+        "inputDatas": {
           "type": "BuildActionIoElement",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the artifacts which are read by the"
         },
-        "modifiedData": {
+        "modifiedDatas": {
           "type": "BuildActionIoElement",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This denotes the data which are modified by the action."
         },
-        "predecessor": {
+        "predecessors": {
           "type": "BuildAction",
           "multiplicity": "*",
           "kind": "reference",
@@ -210,7 +210,7 @@
           "is_ref": false,
           "note": "This attribute allows to denote a particular role of the"
         },
-        "sdg": {
+        "sdgs": {
           "type": "Sdg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -257,7 +257,7 @@
         }
       ],
       "attributes": {
-        "sdg": {
+        "sdgs": {
           "type": "Sdg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -300,8 +300,8 @@
         }
       ],
       "attributes": {
-        "deliveryArtifact": {
-          "type": "AutosarEngineering",
+        "deliveryArtifacts": {
+          "type": "AutosarEngineeringObject",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_DocumentationOnM1.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_DocumentationOnM1.classes.json
@@ -47,7 +47,7 @@
         }
       ],
       "attributes": {
-        "context": {
+        "contexts": {
           "type": "DocumentationContext",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_FormulaLanguage.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_FormulaLanguage.classes.json
@@ -45,14 +45,14 @@
         }
       ],
       "attributes": {
-        "atpReference": {
+        "atpReferences": {
           "type": "Referrable",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "The referable object shall yield a numerical / boolean"
         },
-        "atpString": {
+        "atpStrings": {
           "type": "Referrable",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ARPackage.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ARPackage.classes.json
@@ -412,21 +412,21 @@
         }
       ],
       "attributes": {
-        "arPackage": {
+        "arPackages": {
           "type": "ARPackage",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents a sub package within an ARPackage, for an unlimited package hierarchy. atpVariation"
         },
-        "element": {
+        "elements": {
           "type": "PackageableElement",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Elements that are part of this package atpVariation"
         },
-        "referenceBase": {
+        "referenceBases": {
           "type": "ReferenceBase",
           "multiplicity": "*",
           "kind": "attribute",
@@ -512,14 +512,14 @@
         }
       ],
       "attributes": {
-        "globalElement": {
-          "type": "ReferrableSubtypes",
+        "globalElements": {
+          "type": "ReferrableSubtypesEnum",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This attribute represents a meta-class for which the global is supported via this reference base."
         },
-        "globalIn": {
+        "globalIns": {
           "type": "ARPackage",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_AnyInstanceRef.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_AnyInstanceRef.classes.json
@@ -63,7 +63,7 @@
           "is_ref": false,
           "note": "This is the base from which navigation path begins."
         },
-        "contextElement": {
+        "contextElements": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ElementCollection.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ElementCollection.classes.json
@@ -52,7 +52,7 @@
           "is_ref": false,
           "note": "This attribute reflects how far the referenced objects are the collection."
         },
-        "collected": {
+        "collecteds": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",
@@ -66,7 +66,7 @@
           "is_ref": false,
           "note": "Provides the ability to express the semantics of a"
         },
-        "element": {
+        "elements": {
           "type": "Identifiable",
           "multiplicity": "*",
           "kind": "reference",
@@ -80,14 +80,14 @@
           "is_ref": false,
           "note": "This attribute allows to denote a particular role of the"
         },
-        "sourceElement": {
+        "sourceElements": {
           "type": "Identifiable",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Only if Category = \"RELATION\". This represents the"
         },
-        "sourceInstance": {
+        "sourceInstances": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_EngineeringObject.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_EngineeringObject.classes.json
@@ -96,7 +96,7 @@
           "is_ref": false,
           "note": "This denotes the domain in which the engineering object"
         },
-        "revisionLabelString": {
+        "revisionLabelStrings": {
           "type": "RevisionLabelString",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_GeneralAnnotation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_GeneralAnnotation.classes.json
@@ -66,7 +66,7 @@
           "note": "This is the text of the annotation."
         },
         "label": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_Identifiable.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_Identifiable.classes.json
@@ -97,7 +97,7 @@
           "note": "The category is a keyword that specializes the semantics"
         },
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -661,7 +661,7 @@
           "is_ref": false,
           "note": "This represents the administrative data for the identifiable 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -676,7 +676,7 @@
           "note": "The category is a keyword that specializes the semantics"
         },
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -847,7 +847,7 @@
           "is_ref": false,
           "note": "This specifies an identifying shortName for the object. It"
         },
-        "shortNameFragment": {
+        "shortNameFragments": {
           "type": "ShortNameFragment",
           "multiplicity": "*",
           "kind": "attribute",
@@ -932,7 +932,7 @@
       ],
       "attributes": {
         "longName": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -976,7 +976,7 @@
       ],
       "attributes": {
         "longName1": {
-          "type": "SingleLanguageLong",
+          "type": "SingleLanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ModelRestrictionTypes.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ModelRestrictionTypes.classes.json
@@ -106,7 +106,7 @@
         }
       ],
       "attributes": {
-        "validBinding": {
+        "validBindings": {
           "type": "FullBindingTimeEnum",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_SpecialDataDef.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_SpecialDataDef.classes.json
@@ -39,7 +39,7 @@
         }
       ],
       "attributes": {
-        "sdgClass": {
+        "sdgClasses": {
           "type": "SdgClass",
           "multiplicity": "*",
           "kind": "attribute",
@@ -127,7 +127,7 @@
         }
       ],
       "attributes": {
-        "attribute": {
+        "attributes": {
           "type": "SdgAttribute",
           "multiplicity": "*",
           "kind": "attribute",
@@ -148,7 +148,7 @@
           "is_ref": false,
           "note": "The AUTOSAR Meta-Class that may be extended by this"
         },
-        "sdgConstraint": {
+        "sdgConstraints": {
           "type": "TraceableText",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_LifeCycles.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_LifeCycles.classes.json
@@ -42,7 +42,7 @@
         }
       ],
       "attributes": {
-        "lcState": {
+        "lcStates": {
           "type": "LifeCycleState",
           "multiplicity": "*",
           "kind": "attribute",
@@ -142,7 +142,7 @@
           "is_ref": false,
           "note": "Default expiry date, i.e. default end point of period for all specified lifeCycleInfo apply. Note that the can be overridden for each lifeCycleInfo"
         },
-        "lifeCycleInfo": {
+        "lifeCycleInfos": {
           "type": "LifeCycleInfo",
           "multiplicity": "*",
           "kind": "attribute",
@@ -150,7 +150,7 @@
           "note": "This represents one particular life cycle information."
         },
         "usedLifeCycle": {
-          "type": "LifeCycleStateDefinition",
+          "type": "LifeCycleStateDefinitionGroup",
           "multiplicity": "1",
           "kind": "reference",
           "is_ref": false,
@@ -277,7 +277,7 @@
           "is_ref": false,
           "note": "Remark describing for example the element was given the specified life cycle semantics of useInstead"
         },
-        "useInstead": {
+        "useInsteads": {
           "type": "Referrable",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_RolesAndRights.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_RolesAndRights.classes.json
@@ -42,28 +42,28 @@
         }
       ],
       "attributes": {
-        "aclContext": {
+        "aclContexts": {
           "type": "NameToken",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute is intended to specify the context under"
         },
-        "aclObjectSet": {
+        "aclObjectSets": {
           "type": "AclObjectSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "This denotes an object to which the AclPermission"
         },
-        "aclOperation": {
+        "aclOperations": {
           "type": "AclOperation",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This denotes an operation which is granted by the given"
         },
-        "aclRole": {
+        "aclRoles": {
           "type": "AclRole",
           "multiplicity": "*",
           "kind": "reference",
@@ -120,8 +120,8 @@
         }
       ],
       "attributes": {
-        "aclObjectClass": {
-          "type": "ReferrableSubtypes",
+        "aclObjectClasses": {
+          "type": "ReferrableSubtypesEnum",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
@@ -141,15 +141,15 @@
           "is_ref": true,
           "note": "This indicates that the relevant objects are specified via a"
         },
-        "derivedFrom": {
+        "derivedFroms": {
           "type": "AtpBlueprint",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This association indicates that the considered objects are"
         },
-        "engineering": {
-          "type": "AutosarEngineering",
+        "engineerings": {
+          "type": "AutosarEngineeringObject",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -229,7 +229,7 @@
         }
       ],
       "attributes": {
-        "implied": {
+        "implieds": {
           "type": "AclOperation",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_VariantHandling.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_VariantHandling.classes.json
@@ -100,7 +100,7 @@
         }
       ],
       "attributes": {
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -115,7 +115,7 @@
           "note": "This is the particular value of the post-build variant"
         },
         "variantCriterion": {
-          "type": "PostBuildVariant",
+          "type": "any (PostBuildVariant)",
           "multiplicity": "1",
           "kind": "reference",
           "is_ref": false,
@@ -167,22 +167,22 @@
         }
       ],
       "attributes": {
-        "includedVariant": {
+        "includedVariants": {
           "type": "PredefinedVariant",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The associated variants are considered part of this means the settings of the are included in the settings of the Nevertheless the included be included in several predefined variants."
         },
-        "postBuildVariant": {
-          "type": "PostBuildVariant",
+        "postBuildVariants": {
+          "type": "any (PostBuildVariant)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This is the postBuildVariantCriterionValueSet contributing to the predefinded variant."
         },
-        "sw": {
-          "type": "SwSystemconstant",
+        "sws": {
+          "type": "SwSystemconstantValueSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -252,7 +252,7 @@
         }
       ],
       "attributes": {
-        "sw": {
+        "sws": {
           "type": "SwSystemconstValue",
           "multiplicity": "*",
           "kind": "attribute",
@@ -427,7 +427,7 @@
       ],
       "attributes": {
         "matching": {
-          "type": "PostBuildVariant",
+          "type": "any (PostBuildVariant)",
           "multiplicity": "1",
           "kind": "reference",
           "is_ref": false,
@@ -486,8 +486,8 @@
         }
       ],
       "attributes": {
-        "postBuildVariant": {
-          "type": "PostBuildVariant",
+        "postBuildVariants": {
+          "type": "any (PostBuildVariant)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -591,7 +591,7 @@
         }
       ],
       "attributes": {
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -653,7 +653,7 @@
           "is_ref": false,
           "note": "Defines the approval status of a predefined variant. Two"
         },
-        "evaluated": {
+        "evaluateds": {
           "type": "PredefinedVariant",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_VariantHandling_AttributeValueVariationPoints.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_VariantHandling_AttributeValueVariationPoints.classes.json
@@ -493,8 +493,8 @@
         }
       ],
       "attributes": {
-        "entry": {
-          "type": "EnumerationMapping",
+        "entries": {
+          "type": "any (EnumerationMapping)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_ViewMapSet.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_ViewMapSet.classes.json
@@ -36,7 +36,7 @@
         }
       ],
       "attributes": {
-        "firstElement": {
+        "firstElements": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",
@@ -50,7 +50,7 @@
           "is_ref": false,
           "note": "This attribute is used to describe specific mapping"
         },
-        "secondElement": {
+        "secondElements": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",
@@ -97,7 +97,7 @@
         }
       ],
       "attributes": {
-        "viewMap": {
+        "viewMaps": {
           "type": "ViewMap",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_LogAndTraceExtract.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_LogAndTraceExtract.classes.json
@@ -37,7 +37,7 @@
         }
       ],
       "attributes": {
-        "dltArgument": {
+        "dltArguments": {
           "type": "DltArgument",
           "multiplicity": "*",
           "kind": "attribute",
@@ -130,7 +130,7 @@
           "is_ref": false,
           "note": "This attribute identifies the SW-C/BSW module in the log"
         },
-        "context": {
+        "contexts": {
           "type": "DltContext",
           "multiplicity": "*",
           "kind": "reference",
@@ -193,7 +193,7 @@
           "is_ref": false,
           "note": "This attribute is used to group log and trace messages"
         },
-        "dltMessage": {
+        "dltMessages": {
           "type": "DltMessage",
           "multiplicity": "*",
           "kind": "reference",
@@ -242,7 +242,7 @@
         }
       ],
       "attributes": {
-        "application": {
+        "applications": {
           "type": "DltApplication",
           "multiplicity": "*",
           "kind": "attribute",
@@ -293,7 +293,7 @@
         }
       ],
       "attributes": {
-        "dltArgument": {
+        "dltArguments": {
           "type": "DltArgument",
           "multiplicity": "*",
           "kind": "attribute",
@@ -371,7 +371,7 @@
         }
       ],
       "attributes": {
-        "dltMessage": {
+        "dltMessages": {
           "type": "DltMessage",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Communication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Communication.classes.json
@@ -131,8 +131,8 @@
         }
       ],
       "attributes": {
-        "compositeNetwork": {
-          "type": "CompositeNetwork",
+        "compositeNetworks": {
+          "type": "CompositeNetworkRepresentation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -146,7 +146,7 @@
           "note": "Data element these attributes belong to."
         },
         "handleOutOfRange": {
-          "type": "HandleOutOfRange",
+          "type": "any (HandleOutOfRange)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -166,8 +166,8 @@
           "is_ref": false,
           "note": "Number of Data required for validating the consistency of that shall be received with a valid counter (i.e. the allowed lock-in range) after the an unexpected behavior of a received E2E wrapper approach involves are not subjected to the AUTOSAR is superseded by the superior E2E (which is fully standardized by new projects (without legacy to carry-over parts) shall use the fully transformer approach."
         },
-        "transformationCom": {
-          "type": "TransformationCom",
+        "transformationComs": {
+          "type": "any (TransformationCom)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -401,8 +401,8 @@
         }
       ],
       "attributes": {
-        "compositeNetwork": {
-          "type": "CompositeNetwork",
+        "compositeNetworks": {
+          "type": "CompositeNetworkRepresentation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -416,7 +416,7 @@
           "note": "Data element these quality of service attributes apply to."
         },
         "handleOutOfRange": {
-          "type": "HandleOutOfRange",
+          "type": "any (HandleOutOfRange)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -430,14 +430,14 @@
           "note": "A networkRepresentation is used to define how the data"
         },
         "transmission": {
-          "type": "Transmission",
+          "type": "any (Transmission)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Requested transmission acknowledgement for data"
         },
         "transmissionComSpec": {
-          "type": "TransmissionComSpec",
+          "type": "TransmissionComSpecProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -580,7 +580,7 @@
           "note": "This attribute defines the minimum interval between two transmissions of the respective data the assumed to ensure."
         },
         "transmission": {
-          "type": "TransmissionMode",
+          "type": "any (TransmissionMode)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -651,14 +651,14 @@
       ],
       "attributes": {
         "leafElementElementInPortInterfaceInstanceRef": {
-          "type": "ApplicationComposite",
+          "type": "any (ApplicationComposite)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "data type. by: ApplicationComposite"
         },
         "networkRepresentation": {
-          "type": "SwDataDefPropsRepresentation",
+          "type": "any (SwDataDefPropsRepresentation)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -708,8 +708,8 @@
           "is_ref": false,
           "note": "This represents the corresponding ClientServerOperation."
         },
-        "transformationCom": {
-          "type": "TransformationCom",
+        "transformationComs": {
+          "type": "any (TransformationCom)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -759,8 +759,8 @@
           "is_ref": false,
           "note": "Length of call queue on the server side. The queue is the RTE. The value shall be greater or 1. Setting the value of queueLength to 1 implies requests are rejected while another request earlier is being processed."
         },
-        "transformationCom": {
-          "type": "TransformationCom",
+        "transformationComs": {
+          "type": "any (TransformationCom)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -811,7 +811,7 @@
           "note": "ModeDeclarationGroupPrototype (of the same Port to which these communication attributes apply."
         },
         "modeSwitchedAck": {
-          "type": "ModeSwitchedAck",
+          "type": "any (ModeSwitchedAck)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components.classes.json
@@ -164,7 +164,7 @@
         }
       ],
       "attributes": {
-        "hardware": {
+        "hardwares": {
           "type": "HwDescriptionEntity",
           "multiplicity": "*",
           "kind": "reference",
@@ -230,7 +230,7 @@
         }
       ],
       "attributes": {
-        "hardware": {
+        "hardwares": {
           "type": "HwDescriptionEntity",
           "multiplicity": "*",
           "kind": "reference",
@@ -421,7 +421,7 @@
         }
       ],
       "attributes": {
-        "clientServer": {
+        "clientServers": {
           "type": "ClientServerAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -429,48 +429,48 @@
           "note": "Annotation of this PortPrototype with respect to client/ communication."
         },
         "delegatedPort": {
-          "type": "DelegatedPort",
+          "type": "DelegatedPortAnnotation",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Annotations on this delegated port."
         },
-        "ioHwAbstractionServerAnnotation": {
-          "type": "IoHwAbstractionServer",
+        "ioHwAbstractionServerAnnotations": {
+          "type": "IoHwAbstractionServerAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Annotations on this IO Hardware Abstraction port."
         },
-        "modePortAnnotation": {
+        "modePortAnnotations": {
           "type": "ModePortAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Annotations on this mode port."
         },
-        "nvDataPortAnnotation": {
+        "nvDataPortAnnotations": {
           "type": "NvDataPortAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Annotations on this non voilatile data port."
         },
-        "parameterPort": {
-          "type": "ParameterPort",
+        "parameterPorts": {
+          "type": "ParameterPortAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Annotations on this parameter port."
         },
-        "senderReceiver": {
-          "type": "SenderReceiver",
+        "senderReceivers": {
+          "type": "any (SenderReceiver)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of annotations of this ports sender/receiver communication."
         },
-        "triggerPortAnnotation": {
+        "triggerPortAnnotations": {
           "type": "TriggerPortAnnotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -751,29 +751,29 @@
         }
       ],
       "attributes": {
-        "consistencyNeeds": {
+        "consistencyNeedses": {
           "type": "ConsistencyNeeds",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the collection of ConsistencyNeeds by the enclosing SwComponentType. atpVariation"
         },
-        "port": {
+        "ports": {
           "type": "PortPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The PortPrototypes through which this SwComponent communicate. of PortPrototype is subject to variability purpose to support the conditional existence of atpVariation"
         },
-        "portGroup": {
+        "portGroups": {
           "type": "PortGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "A port group being part of this component. atpVariation"
         },
-        "swcMapping": {
-          "type": "SwComponentMapping",
+        "swcMappings": {
+          "type": "any (SwComponentMapping)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
@@ -786,7 +786,7 @@
           "is_ref": false,
           "note": "This adds a documentation to the SwComponentType."
         },
-        "unitGroup": {
+        "unitGroups": {
           "type": "UnitGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -839,22 +839,22 @@
         }
       ],
       "attributes": {
-        "constant": {
+        "constants": {
           "type": "ConstantSpecification",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ConstantSpecificationMapping to be applied for the particular ParameterSwComponentType"
         },
-        "dataType": {
+        "dataTypes": {
           "type": "DataTypeMappingSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the DataTypeMapping to be applied for the ParameterSwComponentType"
         },
-        "instantiationDataDef": {
-          "type": "InstantiationDataDef",
+        "instantiationDataDefs": {
+          "type": "InstantiationDataDefProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -915,7 +915,7 @@
         }
       ],
       "attributes": {
-        "requiredCom": {
+        "requiredComs": {
           "type": "RPortComSpec",
           "multiplicity": "*",
           "kind": "attribute",
@@ -964,7 +964,7 @@
         }
       ],
       "attributes": {
-        "providedCom": {
+        "providedComs": {
           "type": "PPortComSpec",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1089,14 +1089,14 @@
         }
       ],
       "attributes": {
-        "innerGroup": {
+        "innerGroups": {
           "type": "PortGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "defined in a component which is part of this by: InnerPortGroupIn"
         },
-        "outerPort": {
+        "outerPorts": {
           "type": "PortPrototype",
           "multiplicity": "*",
           "kind": "reference",
@@ -1303,14 +1303,14 @@
         }
       ],
       "attributes": {
-        "bulkNvData": {
+        "bulkNvDatas": {
           "type": "BulkNvDataDescriptor",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation formally defines the bulk Nv Blocks that provided to the application software by the enclosing atpVariation"
         },
-        "nvBlock": {
+        "nvBlocks": {
           "type": "NvBlockDescriptor",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components_InstanceRefs.classes.json
@@ -39,7 +39,7 @@
           "note": "Stereotypes: atpAbstract xml.sequenceOffset=30"
         },
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -85,7 +85,7 @@
       ],
       "attributes": {
         "contextRPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -130,7 +130,7 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -144,7 +144,7 @@
           "note": "Tags: xml.sequenceOffset=30"
         },
         "contextPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -188,14 +188,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived"
         },
-        "context": {
-          "type": "SwComponent",
+        "contexts": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -243,7 +243,7 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -296,7 +296,7 @@
       ],
       "attributes": {
         "contextRPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -342,7 +342,7 @@
       ],
       "attributes": {
         "contextPPortPrototype": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -390,7 +390,7 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -442,7 +442,7 @@
       ],
       "attributes": {
         "contextRPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -488,7 +488,7 @@
       ],
       "attributes": {
         "contextPPortPrototype": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -533,7 +533,7 @@
       ],
       "attributes": {
         "contextRPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -581,7 +581,7 @@
       ],
       "attributes": {
         "contextPPortPrototype": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -631,7 +631,7 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Composition.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Composition.classes.json
@@ -75,36 +75,36 @@
         }
       ],
       "attributes": {
-        "component": {
-          "type": "SwComponent",
+        "components": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The instantiated components that are part of this"
         },
-        "connector": {
+        "connectors": {
           "type": "SwConnector",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "SwConnectors have the principal ability to establish a"
         },
-        "constantValue": {
+        "constantValues": {
           "type": "ConstantSpecification",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ConstantSpecificationMapping to be applied for initValues of PPortComSpecs and 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "dataType": {
+        "dataTypes": {
           "type": "DataTypeMappingSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the DataTypeMappingSet to be applied the used ApplicationDataTypes in developing subsystems it may happen are used on the surface In this case it reasonable to be able to also provide the to the ImplementationDataTypes. mapping shall be informal and not for the implementors mainly because generator is not concerned about the the mapping of ApplicationDataTypes delegated and inner PortPrototype matches mapping to ImplementationDataTypes is not"
         },
-        "instantiationRTEEvent": {
-          "type": "InstantiationRTEEvent",
+        "instantiationRTEEvents": {
+          "type": "InstantiationRTEEventProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -263,14 +263,14 @@
       ],
       "attributes": {
         "providerInstanceRef": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "implemented by: PPortInComposition"
         },
         "requesterInstanceRef": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -440,14 +440,14 @@
       ],
       "attributes": {
         "providedOuter": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the provided outer delegation Port Prototype of the PassThroughSwConnector."
         },
         "requiredOuter": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Composition_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Composition_InstanceRefs.classes.json
@@ -41,21 +41,21 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived"
         },
-        "context": {
-          "type": "SwComponent",
+        "contexts": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The context for the scope of this timing event."
         },
         "target": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -98,14 +98,14 @@
       ],
       "attributes": {
         "abstractContext": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpAbstract"
         },
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -151,14 +151,14 @@
       ],
       "attributes": {
         "context": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Tags: xml.sequenceOffset=20"
         },
         "targetPPortPrototype": {
-          "type": "AbstractProvidedPort",
+          "type": "AbstractProvidedPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -204,14 +204,14 @@
       ],
       "attributes": {
         "context": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Tags: xml.sequenceOffset=20"
         },
         "targetRPortPrototype": {
-          "type": "AbstractRequiredPort",
+          "type": "AbstractRequiredPortPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -248,14 +248,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived"
         },
-        "contextPrototype": {
-          "type": "SwComponent",
+        "contextPrototypes": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Datatype_DataPrototypes.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Datatype_DataPrototypes.classes.json
@@ -330,21 +330,21 @@
       ],
       "attributes": {
         "arraySizeHandling": {
-          "type": "ArraySizeHandling",
+          "type": "ArraySizeHandlingEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "The way how the size of the array is handled."
         },
         "arraySize": {
-          "type": "ArraySizeSemantics",
+          "type": "ArraySizeSemanticsEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute controls how the information about the array size shall be interpreted."
         },
         "indexDataType": {
-          "type": "ApplicationPrimitive",
+          "type": "ApplicationPrimitiveDataType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Datatype_Datatypes.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Datatype_Datatypes.classes.json
@@ -204,14 +204,14 @@
         }
       ],
       "attributes": {
-        "dataTypeMap": {
+        "dataTypeMaps": {
           "type": "DataTypeMap",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is one particular association between an Application"
         },
-        "modeRequestTypeMap": {
+        "modeRequestTypeMaps": {
           "type": "ModeRequestTypeMap",
           "multiplicity": "*",
           "kind": "attribute",
@@ -444,7 +444,7 @@
           "note": "Specifies the profile which the array will follow if it is a"
         },
         "element": {
-          "type": "ApplicationArray",
+          "type": "any (ApplicationArray)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -504,8 +504,8 @@
         }
       ],
       "attributes": {
-        "element": {
-          "type": "ApplicationRecord",
+        "elements": {
+          "type": "any (ApplicationRecord)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_EndToEndProtection.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_EndToEndProtection.classes.json
@@ -122,7 +122,7 @@
         }
       ],
       "attributes": {
-        "endToEnd": {
+        "endToEnds": {
           "type": "EndToEndProtection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -166,7 +166,7 @@
         }
       ],
       "attributes": {
-        "endToEnd": {
+        "endToEnds": {
           "type": "EndToEndProtection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -207,7 +207,7 @@
         }
       ],
       "attributes": {
-        "receiver": {
+        "receivers": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_ImplicitCommunicationBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_ImplicitCommunicationBehavior.classes.json
@@ -40,28 +40,28 @@
         }
       ],
       "attributes": {
-        "dpgDoesNot": {
+        "dpgDoesNots": {
           "type": "DataPrototypeGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This group of VariableDataPrototypes does not require with respect to the implicit communication atpVariation 1228 Document ID 62: AUTOSAR_CP_TPS_SoftwareComponentTemplate Template R23-11"
         },
-        "dpgRequires": {
+        "dpgRequireses": {
           "type": "DataPrototypeGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This group of VariableDataPrototypes requires coherency respect to the implicit communication behavior, i.e. and write access to VariableDataPrototypes in the the RunnableEntitys of the to be handled in a coherent atpVariation"
         },
-        "regDoesNot": {
+        "regDoesNots": {
           "type": "RunnableEntityGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This group of RunnableEntities does not require stability respect to the implicit communication behavior. atpVariation"
         },
-        "regRequires": {
+        "regRequireses": {
           "type": "RunnableEntityGroup",
           "multiplicity": "*",
           "kind": "attribute",
@@ -111,14 +111,14 @@
         }
       ],
       "attributes": {
-        "runnableEntity": {
+        "runnableEntities": {
           "type": "RunnableEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents a collection of RunnableEntitys that"
         },
-        "runnableEntityGroupGroupInCompositionInstanceRef": {
+        "runnableEntityGroupGroupInCompositionInstanceRefs": {
           "type": "RunnableEntityGroup",
           "multiplicity": "*",
           "kind": "attribute",
@@ -168,14 +168,14 @@
         }
       ],
       "attributes": {
-        "dataPrototypeGroupGroupInCompositionInstanceRef": {
+        "dataPrototypeGroupGroupInCompositionInstanceRefs": {
           "type": "DataPrototypeGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "atpVariation by: InnerDataPrototype"
         },
-        "implicitData": {
+        "implicitDatas": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_ImplicitCommunicationBehavior_InstanceRef.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_ImplicitCommunicationBehavior_InstanceRef.classes.json
@@ -30,14 +30,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the base of the instanceRef."
         },
-        "contextSw": {
-          "type": "SwComponent",
+        "contextSws": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -81,14 +81,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the base of the InstanceRef."
         },
-        "contextSw": {
-          "type": "SwComponent",
+        "contextSws": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -132,14 +132,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This represents the base of the InstanceRef."
         },
-        "contextSw": {
-          "type": "SwComponent",
+        "contextSws": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -183,7 +183,7 @@
       ],
       "attributes": {
         "base": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -196,8 +196,8 @@
           "is_ref": true,
           "note": "This represents a reference to a context PortPrototype. xml.sequenceOffset=30"
         },
-        "contextSw": {
-          "type": "SwComponent",
+        "contextSws": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_MeasurementAndCalibration_CalibrationParameter.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_MeasurementAndCalibration_CalibrationParameter.classes.json
@@ -33,8 +33,8 @@
         }
       ],
       "attributes": {
-        "calibration": {
-          "type": "CalibrationParameter",
+        "calibrations": {
+          "type": "any (CalibrationParameter)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_MeasurementAndCalibration_InterpolationRoutine.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_MeasurementAndCalibration_InterpolationRoutine.classes.json
@@ -39,7 +39,7 @@
         }
       ],
       "attributes": {
-        "interpolationRoutine": {
+        "interpolationRoutines": {
           "type": "InterpolationRoutine",
           "multiplicity": "*",
           "kind": "attribute",
@@ -80,7 +80,7 @@
         }
       ],
       "attributes": {
-        "interpolationRoutine": {
+        "interpolationRoutines": {
           "type": "InterpolationRoutine",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_NvBlockComponent.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_NvBlockComponent.classes.json
@@ -35,42 +35,42 @@
         }
       ],
       "attributes": {
-        "clientServerPort": {
-          "type": "RoleBasedPort",
+        "clientServerPorts": {
+          "type": "RoleBasedPortAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The RoleBasedPortAssignement defines which client port of the NvBlockSwComponentType serves for of service or notification. In case of common callback function is provided by for each individual kind of notification defined by of RoleBasedPortAssignment is subject with the purpose to support the conditional ports. atpVariation"
         },
-        "constantValue": {
+        "constantValues": {
           "type": "ConstantSpecification",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ConstantSpecificationMapping to be applied for the particular NVRAM Block"
         },
-        "dataType": {
+        "dataTypes": {
           "type": "DataTypeMappingSet",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Reference to the DataTypeMapping to be applied for the NVRAM Block."
         },
-        "instantiationDataDef": {
-          "type": "InstantiationDataDef",
+        "instantiationDataDefs": {
+          "type": "InstantiationDataDefProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The purpose of InstantiationDataDefProps are the refinement of some data def properties of individual the context of a NvBlockSw of InstantiationDataDefProps is subject with the purpose to support the conditional ports, component internal memory objects attributes. atpVariation"
         },
-        "modeSwitchEvent": {
-          "type": "ModeSwitchEvent",
+        "modeSwitchEvents": {
+          "type": "any (ModeSwitchEvent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the collection of ModeSwitchEvent TriggeredActivities related to the enclosing NvBlock atpVariation 1228 Document ID 62: AUTOSAR_CP_TPS_SoftwareComponentTemplate Template R23-11"
         },
-        "nvBlockData": {
+        "nvBlockDatas": {
           "type": "NvBlockDataMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -112,8 +112,8 @@
           "is_ref": false,
           "note": "this reference can be taken to identify the TimingEvent to by the RTE for implementing a cyclic writing this block"
         },
-        "writingStrategy": {
-          "type": "RoleBasedData",
+        "writingStrategies": {
+          "type": "any (RoleBasedData)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -268,7 +268,7 @@
           "is_ref": true,
           "note": "This aggregation represents the actual bulk NVBlock."
         },
-        "nvBlockData": {
+        "nvBlockDatas": {
           "type": "NvBlockDataMapping",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_PortInterface.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_PortInterface.classes.json
@@ -67,14 +67,14 @@
       ],
       "attributes": {
         "direction": {
-          "type": "ArgumentDirection",
+          "type": "ArgumentDirectionEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute specifies the direction of the argument"
         },
         "serverArgumentImpl": {
-          "type": "ServerArgumentImpl",
+          "type": "ServerArgumentImplPolicyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -144,14 +144,14 @@
         }
       ],
       "attributes": {
-        "operation": {
+        "operations": {
           "type": "ClientServerOperation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "ClientServerOperation(s) of this ClientServerInterface. atpVariation"
         },
-        "possibleError": {
+        "possibleErrors": {
           "type": "ApplicationError",
           "multiplicity": "*",
           "kind": "attribute",
@@ -245,7 +245,7 @@
         }
       ],
       "attributes": {
-        "argument": {
+        "arguments": {
           "type": "ArgumentDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -259,7 +259,7 @@
           "is_ref": false,
           "note": "This attribute shall only be used in the implementation of"
         },
-        "possibleError": {
+        "possibleErrors": {
           "type": "ApplicationError",
           "multiplicity": "*",
           "kind": "reference",
@@ -337,21 +337,21 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The data elements of this SenderReceiverInterface."
         },
-        "invalidationPolicyPolicy": {
+        "invalidationPolicyPolicies": {
           "type": "InvalidationPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "InvalidationPolicy for a particular dataElement"
         },
-        "metaDataItemSet": {
+        "metaDataItemSets": {
           "type": "MetaDataItemSet",
           "multiplicity": "*",
           "kind": "attribute",
@@ -470,7 +470,7 @@
         }
       ],
       "attributes": {
-        "nvData": {
+        "nvDatas": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -618,7 +618,7 @@
         }
       ],
       "attributes": {
-        "parameter": {
+        "parameters": {
           "type": "ParameterDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -749,14 +749,14 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "This reference identifies the dataElement for which the of meta-data items is defined."
         },
-        "metaDataItem": {
+        "metaDataItems": {
           "type": "MetaDataItem",
           "multiplicity": "*",
           "kind": "attribute",
@@ -853,7 +853,7 @@
         }
       ],
       "attributes": {
-        "trigger": {
+        "triggers": {
           "type": "Trigger",
           "multiplicity": "*",
           "kind": "attribute",
@@ -956,7 +956,7 @@
         }
       ],
       "attributes": {
-        "portInterface": {
+        "portInterfaces": {
           "type": "PortInterfaceMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1059,7 +1059,7 @@
         }
       ],
       "attributes": {
-        "dataMapping": {
+        "dataMappings": {
           "type": "DataPrototypeMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1129,7 +1129,7 @@
           "is_ref": false,
           "note": "This defines the need to execute the reverse Data <Mip>_Inv_<transformerId> functions of transformation chain when communicating from the the Data"
         },
-        "subElement": {
+        "subElements": {
           "type": "SubElementMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1178,14 +1178,14 @@
         }
       ],
       "attributes": {
-        "errorMapping": {
-          "type": "ClientServerApplication",
+        "errorMappings": {
+          "type": "ClientServerApplicationErrorMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Map two different ApplicationErrors defined in the context two different ClientServerInterfaces."
         },
-        "operation": {
+        "operations": {
           "type": "ClientServerOperation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1220,7 +1220,7 @@
         }
       ],
       "attributes": {
-        "argument": {
+        "arguments": {
           "type": "DataPrototypeMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1369,7 +1369,7 @@
         }
       ],
       "attributes": {
-        "mode": {
+        "modes": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1412,7 +1412,7 @@
         }
       ],
       "attributes": {
-        "firstMode": {
+        "firstModes": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "reference",
@@ -1461,7 +1461,7 @@
         }
       ],
       "attributes": {
-        "triggerMapping": {
+        "triggerMappings": {
           "type": "TriggerMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1582,14 +1582,14 @@
       ],
       "attributes": {
         "implementation": {
-          "type": "ArVariableIn",
+          "type": "any (ArVariableIn)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the referenced implementationDataType"
         },
         "parameter": {
-          "type": "ArParameterIn",
+          "type": "ArParameterInImplementationDataInstanceRef",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1626,7 +1626,7 @@
       ],
       "attributes": {
         "application": {
-          "type": "ApplicationComposite",
+          "type": "any (ApplicationComposite)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1694,7 +1694,7 @@
           "is_ref": true,
           "note": "Specifies the conversion direction for which the TextTable is applicable."
         },
-        "valuePair": {
+        "valuePairs": {
           "type": "TextTableValuePair",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_PortInterface_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_PortInterface_InstanceRefs.classes.json
@@ -37,8 +37,8 @@
           "is_ref": false,
           "note": "This represents the SenderReceiverInterface that acts as in this InstanceRef definition"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -52,7 +52,7 @@
           "note": "This refers to the dataPrototype which is typed by the in which which the target can be"
         },
         "targetData": {
-          "type": "ApplicationComposite",
+          "type": "any (ApplicationComposite)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_RPTScenario.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_RPTScenario.classes.json
@@ -37,7 +37,7 @@
       ],
       "attributes": {
         "rptEnablerImpl": {
-          "type": "RptEnablerImplType",
+          "type": "RptEnablerImplTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -100,7 +100,7 @@
           "note": "Lowest RPT event id usable for RTE generated service attribute is relevant, if dedicated id range applied to the ExecutableEntitys of a software specific ExecutableEntitys."
         },
         "rptExecutionControl": {
-          "type": "RptExecutionControl",
+          "type": "RptExecutionControlEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -160,14 +160,14 @@
           "is_ref": false,
           "note": "System which describes the software components of the"
         },
-        "rptContainer": {
+        "rptContainers": {
           "type": "RptContainer",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Top-level rptContainer definitions of this specific rapid atpVariation"
         },
-        "rptProfile": {
+        "rptProfiles": {
           "type": "RptProfile",
           "multiplicity": "*",
           "kind": "attribute",
@@ -263,21 +263,21 @@
         }
       ],
       "attributes": {
-        "byPassPoint": {
+        "byPassPoints": {
           "type": "AtpFeature",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "byPassPoint describes the required preparation of the"
         },
-        "explicitRpt": {
+        "explicitRpts": {
           "type": "RptProfile",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This attribute defines the applicable RptProfiles for the"
         },
-        "rptContainer": {
+        "rptContainers": {
           "type": "RptContainer",
           "multiplicity": "*",
           "kind": "attribute",
@@ -306,7 +306,7 @@
           "note": "Describes the required code preparation for rapid"
         },
         "rptSw": {
-          "type": "RptSwPrototyping",
+          "type": "RptSwPrototypingAccess",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -361,7 +361,7 @@
           "is_ref": false,
           "note": "This describes the hook with the means of another"
         },
-        "sdg": {
+        "sdgs": {
           "type": "Sdg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -495,7 +495,7 @@
           "note": "Complete symbol of the function implementing the pre"
         },
         "stimEnabler": {
-          "type": "RptEnablerImplType",
+          "type": "RptEnablerImplTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SoftwareComponentDocumentation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SoftwareComponentDocumentation.classes.json
@@ -40,7 +40,7 @@
         }
       ],
       "attributes": {
-        "chapter": {
+        "chapters": {
           "type": "Chapter",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcImplementation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcImplementation.classes.json
@@ -53,7 +53,7 @@
           "is_ref": false,
           "note": "The internal behavior implemented by this 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "perInstanceMemory": {
+        "perInstanceMemories": {
           "type": "PerInstanceMemory",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json
@@ -66,15 +66,15 @@
         }
       ],
       "attributes": {
-        "argument": {
+        "arguments": {
           "type": "RunnableEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the formal definition of a an argument to"
         },
-        "asynchronousServer": {
-          "type": "AsynchronousServer",
+        "asynchronousServers": {
+          "type": "any (AsynchronousServer)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -87,77 +87,77 @@
           "is_ref": false,
           "note": "If the value of this attribute is set to \"true\" the enclosing"
         },
-        "dataRead": {
+        "dataReads": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "RunnableEntity has implicit read access to dataElement"
         },
-        "dataReceive": {
+        "dataReceives": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "RunnableEntity has explicit read access to dataElement"
         },
-        "dataSendPoint": {
+        "dataSendPoints": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "RunnableEntity has explicit write access to dataElement"
         },
-        "dataWrite": {
+        "dataWrites": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "RunnableEntity has implicit write access to dataElement"
         },
-        "external": {
+        "externals": {
           "type": "ExternalTriggeringPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The aggregation of ExternalTriggeringPoint is subject to with the purpose to support the conditional trigger ports or the variant existence of points in the implementation. atpVariation"
         },
-        "internal": {
+        "internals": {
           "type": "InternalTriggeringPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The aggregation of InternalTriggeringPoint is subject to with the purpose to support the variant internal triggering points in the atpVariation"
         },
-        "modeAccessPoint": {
+        "modeAccessPoints": {
           "type": "ModeAccessPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The runnable has a mode access point. The aggregation ModeAccessPoint is subject to variability with the support the conditional existence of mode the variant existence of mode access points in atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "modeSwitchPoint": {
+        "modeSwitchPoints": {
           "type": "ModeSwitchPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The runnable has a mode switch point. The aggregation ModeSwitchPoint is subject to variability with the support the conditional existence of mode the variant existence of mode switch points in the atpVariation"
         },
-        "parameterAccess": {
+        "parameterAccesses": {
           "type": "ParameterAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The presence of a ParameterAccess implies that a needs read only access to a Parameter may either be local or within a Port of ParameterAccess is subject to the purpose to support the conditional parameter ports and component local well as the variant existence of Parameter in the implementation. atpVariation"
         },
-        "readLocal": {
+        "readLocals": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The presence of a readLocalVariable implies that a"
         },
-        "serverCallPoint": {
+        "serverCallPoints": {
           "type": "ServerCallPoint",
           "multiplicity": "*",
           "kind": "attribute",
@@ -171,14 +171,14 @@
           "is_ref": false,
           "note": "The symbol describing this RunnableEntity’s entry point."
         },
-        "waitPoint": {
+        "waitPoints": {
           "type": "WaitPoint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The WaitPoint associated with the RunnableEntity."
         },
-        "writtenLocal": {
+        "writtenLocals": {
           "type": "VariableAccess",
           "multiplicity": "*",
           "kind": "attribute",
@@ -252,99 +252,99 @@
         }
       ],
       "attributes": {
-        "arTypedPer": {
+        "arTypedPers": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Defines an AUTOSAR typed memory-block that needs to available for each instance of the SW-component. is typically only useful if supportsMultipleInstantiation to \"true\" or if the component defines NVRAM permanent blocks. of arTypedPerInstanceMemory is subject with the purpose to support variability in the implementations. Typically different the implementation are requiring different memory objects. atpVariation 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "event": {
+        "events": {
           "type": "RTEEvent",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is a RTEEvent specified for the particular Swc of RTEEvent is subject to variability with to support the conditional existence of RTE the number of RTE events might vary due conditional existence of PortPrototypes using Data due to different scheduling needs of atpVariation"
         },
-        "exclusiveArea": {
-          "type": "SwcExclusiveArea",
+        "exclusiveAreas": {
+          "type": "SwcExclusiveAreaPolicy",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Options how to generate the ExclusiveArea related APIs. When no SwcExclusiveAreaPolicy is specified for an default values apply. atpVariation"
         },
-        "explicitInter": {
+        "explicitInters": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Implement state message semantics for establishing among runnables of the same The aggregation of explicitInterRunnable subject to variability with the purpose to in the software components different algorithms in the requiring different number of memory atpVariation"
         },
-        "implicitInter": {
+        "implicitInters": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Implement state message semantics for establishing among runnables of the same The aggregation of implicitInterRunnable subject to variability with the purpose to in the software components different algorithms in the requiring different number of memory atpVariation"
         },
-        "includedDataTypeSet": {
+        "includedDataTypeSets": {
           "type": "IncludedDataTypeSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The includedDataTypeSet is used by a software for its implementation."
         },
-        "includedMode": {
-          "type": "IncludedMode",
+        "includedModes": {
+          "type": "IncludedModeDeclarationGroupSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the included Mode DeclarationGroups atpSplitable 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "instantiationDataDef": {
-          "type": "InstantiationDataDef",
+        "instantiationDataDefs": {
+          "type": "InstantiationDataDefProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The purpose of this is that within the context of a given SwComponentType some data def properties of individual be modified. The aggregation of subject to variability with the support the conditional existence of Port component local memories like \"per \"arTypedPerInstanceMemory\". atpVariation"
         },
-        "perInstanceMemory": {
+        "perInstanceMemories": {
           "type": "PerInstanceMemory",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines a per-instance memory object needed by this component. The aggregation of PerInstance subject to variability with the purpose to in the software components different algorithms in the requiring different number of memory atpVariation"
         },
-        "perInstance": {
-          "type": "ParameterData",
+        "perInstances": {
+          "type": "ParameterDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines parameter(s) or characteristic value(s) that needs to be available for each instance of the is typically only useful if set to \"true\". The perInstanceParameter is subject to the purpose to support variability in the implementations. Typically different the implementation are requiring different memory objects. atpVariation"
         },
-        "portAPIOption": {
+        "portAPIOptions": {
           "type": "PortAPIOption",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Options for generating the signature of port-related calls"
         },
-        "runnable": {
+        "runnables": {
           "type": "RunnableEntity",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is a RunnableEntity specified for the particular Swc"
         },
-        "service": {
-          "type": "SwcService",
+        "services": {
+          "type": "any (SwcService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the requirements on AUTOSAR Services for a particular item. of SwcServiceDependency is subject to the purpose to support the conditional ports as well as the conditional existence of owned by an SwcInternal be located in a different physical file in order that SwcServiceDependency might be later development steps or even by different (e.g OBD expert for Obd related Service Therefore the aggregation is <<atp atpVariation"
         },
-        "shared": {
-          "type": "ParameterData",
+        "shareds": {
+          "type": "ParameterDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -357,7 +357,7 @@
           "is_ref": false,
           "note": "Indicate whether the corresponding software-component"
         },
-        "variationPointProxy": {
+        "variationPointProxies": {
           "type": "VariationPointProxy",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_AccessCount.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_AccessCount.classes.json
@@ -27,7 +27,7 @@
         }
       ],
       "attributes": {
-        "accessCount": {
+        "accessCounts": {
           "type": "AccessCount",
           "multiplicity": "*",
           "kind": "attribute",
@@ -141,7 +141,7 @@
       ],
       "attributes": {
         "returnValue": {
-          "type": "RteApiReturnValue",
+          "type": "RteApiReturnValueProvisionEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json
@@ -92,7 +92,7 @@
       ],
       "attributes": {
         "autosarVariable": {
-          "type": "ArVariableIn",
+          "type": "any (ArVariableIn)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -232,7 +232,7 @@
           "note": "This denotes the accessed variable."
         },
         "scope": {
-          "type": "VariableAccessScope",
+          "type": "VariableAccessScopeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -267,8 +267,8 @@
         }
       ],
       "attributes": {
-        "contextData": {
-          "type": "AbstractImplementation",
+        "contextDatas": {
+          "type": "any (AbstractImplementation)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -289,7 +289,7 @@
           "note": "This refers to the VariableDataPrototype typed by the in which the target can be found."
         },
         "targetData": {
-          "type": "AbstractImplementation",
+          "type": "any (AbstractImplementation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -323,8 +323,8 @@
         }
       ],
       "attributes": {
-        "contextData": {
-          "type": "AbstractImplementation",
+        "contextDatas": {
+          "type": "any (AbstractImplementation)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -338,14 +338,14 @@
           "note": "This reference points to the PortPrototype providing/ root of the parameter."
         },
         "rootParameter": {
-          "type": "ParameterData",
+          "type": "ParameterDataPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This refers to the ParameterDataPrototype typed by the implementationDataType in which the target can be"
         },
         "targetData": {
-          "type": "AbstractImplementation",
+          "type": "any (AbstractImplementation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json
@@ -30,14 +30,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived xml.sequenceOffset=10"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -95,14 +95,14 @@
       ],
       "attributes": {
         "base": {
-          "type": "AtomicSwComponent",
+          "type": "AtomicSwComponentType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived xml.sequenceOffset=10"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_IncludedDataTypes.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_IncludedDataTypes.classes.json
@@ -28,7 +28,7 @@
         }
       ],
       "attributes": {
-        "dataType": {
+        "dataTypes": {
           "type": "AutosarDataType",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ModeDeclarationGroup.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ModeDeclarationGroup.classes.json
@@ -126,7 +126,7 @@
         }
       ],
       "attributes": {
-        "mode": {
+        "modes": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_PortAPIOptions.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_PortAPIOptions.classes.json
@@ -47,7 +47,7 @@
           "note": "Specifies the actual value."
         },
         "valueType": {
-          "type": "ImplementationData",
+          "type": "any (ImplementationData)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -115,14 +115,14 @@
           "is_ref": true,
           "note": "The option is valid for generated functions related to this port"
         },
-        "portArgValue": {
-          "type": "PortDefinedArgument",
+        "portArgValues": {
+          "type": "PortDefinedArgumentValue",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An argument value defined by this port."
         },
-        "supported": {
+        "supporteds": {
           "type": "SwcSupportedFeature",
           "multiplicity": "*",
           "kind": "attribute",
@@ -197,7 +197,7 @@
       ],
       "attributes": {
         "supportBufferLocking": {
-          "type": "SupportBufferLocking",
+          "type": "SupportBufferLockingEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RTEEvents.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RTEEvents.classes.json
@@ -139,7 +139,7 @@
         }
       ],
       "attributes": {
-        "disabledModeInstanceRef": {
+        "disabledModeInstanceRefs": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "attribute",
@@ -250,7 +250,7 @@
       ],
       "attributes": {
         "eventSource": {
-          "type": "AsynchronousServer",
+          "type": "any (AsynchronousServer)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServerCall.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServerCall.classes.json
@@ -43,7 +43,7 @@
       ],
       "attributes": {
         "asynchronousServer": {
-          "type": "AsynchronousServer",
+          "type": "any (AsynchronousServer)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -163,7 +163,7 @@
       ],
       "attributes": {
         "calledFrom": {
-          "type": "ExclusiveAreaNesting",
+          "type": "ExclusiveAreaNestingOrder",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServiceMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServiceMapping.classes.json
@@ -41,7 +41,7 @@
           "note": "This is the role of the associated data type in the given"
         },
         "used": {
-          "type": "ImplementationData",
+          "type": "any (ImplementationData)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -152,15 +152,15 @@
         }
       ],
       "attributes": {
-        "assignedData": {
-          "type": "RoleBasedData",
+        "assignedDatas": {
+          "type": "any (RoleBasedData)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the role of an associated data object of the same atpVariation"
         },
-        "assignedPort": {
-          "type": "RoleBasedPort",
+        "assignedPorts": {
+          "type": "RoleBasedPortAssignment",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_VariantHandling.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_VariantHandling.classes.json
@@ -52,7 +52,7 @@
           "note": "This association to ImplementationDataType shall be"
         },
         "postBuildValue": {
-          "type": "PostBuildVariant",
+          "type": "any (PostBuildVariant)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SecurityExtractTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SecurityExtractTemplate.classes.json
@@ -37,14 +37,14 @@
       ],
       "attributes": {
         "contextData": {
-          "type": "SecurityEventContext",
+          "type": "any (SecurityEventContext)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the definition of optional data for security events. atpVariation"
         },
         "default": {
-          "type": "SecurityEventReporting",
+          "type": "any (SecurityEventReporting)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -122,7 +122,7 @@
       ],
       "attributes": {
         "eventSymbolName": {
-          "type": "SymbolPropsName",
+          "type": "any (SymbolPropsName)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -171,7 +171,7 @@
         }
       ],
       "attributes": {
-        "element": {
+        "elements": {
           "type": "IdsCommonElement",
           "multiplicity": "*",
           "kind": "reference",
@@ -216,14 +216,14 @@
       ],
       "attributes": {
         "aggregation": {
-          "type": "SecurityEvent",
+          "type": "any (SecurityEvent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the aggregation filter in the chain."
         },
         "oneEveryN": {
-          "type": "SecurityEventOneEvery",
+          "type": "SecurityEventOneEveryNFilter",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -237,7 +237,7 @@
           "note": "This aggregation represents the state filter in the event 97 Document ID 980: AUTOSAR_FO_TPS_SecurityExtractTemplate Template R23-11"
         },
         "threshold": {
-          "type": "SecurityEventThreshold",
+          "type": "SecurityEventThresholdFilter",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -313,7 +313,7 @@
         }
       ],
       "attributes": {
-        "blockIfState": {
+        "blockIfStates": {
           "type": "BlockState",
           "multiplicity": "*",
           "kind": "reference",
@@ -392,7 +392,7 @@
       ],
       "attributes": {
         "contextData": {
-          "type": "SecurityEventContext",
+          "type": "any (SecurityEventContext)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -592,7 +592,7 @@
       ],
       "attributes": {
         "filterChain": {
-          "type": "SecurityEventFilter",
+          "type": "any (SecurityEventFilter)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -605,8 +605,8 @@
           "is_ref": false,
           "note": "This reference defines the IdsmInstance onto which the are mapped. atpVariation 97 Document ID 980: AUTOSAR_FO_TPS_SecurityExtractTemplate Template R23-11"
         },
-        "mappedSecurity": {
-          "type": "SecurityEventContext",
+        "mappedSecurities": {
+          "type": "any (SecurityEventContext)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -743,7 +743,7 @@
         }
       ],
       "attributes": {
-        "commConnector": {
+        "commConnectors": {
           "type": "CommunicationConnector",
           "multiplicity": "*",
           "kind": "reference",
@@ -833,7 +833,7 @@
         }
       ],
       "attributes": {
-        "blockState": {
+        "blockStates": {
           "type": "BlockState",
           "multiplicity": "*",
           "kind": "attribute",
@@ -855,7 +855,7 @@
           "note": "This attribute is used to provide a source identification in of reporting security events.."
         },
         "idsmModule": {
-          "type": "IdsmModule",
+          "type": "IdsmModuleInstantiation",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -869,7 +869,7 @@
           "note": "This reference identifies the applicable rate limitation filter all security events on the related EcuInstance. atpVariation"
         },
         "signature": {
-          "type": "IdsmSignatureSupport",
+          "type": "any (IdsmSignatureSupport)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1043,14 +1043,14 @@
         }
       ],
       "attributes": {
-        "rateLimitation": {
+        "rateLimitations": {
           "type": "IdsmRateLimitation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the collection of rate filters for security events in the enclosing 97 Document ID 980: AUTOSAR_FO_TPS_SecurityExtractTemplate Template R23-11"
         },
-        "trafficLimitation": {
+        "trafficLimitations": {
           "type": "IdsmTrafficLimitation",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate.classes.json
@@ -76,7 +76,7 @@
         }
       ],
       "attributes": {
-        "clientId": {
+        "clientIds": {
           "type": "ClientIdDefinitionSet",
           "multiplicity": "*",
           "kind": "reference",
@@ -84,7 +84,7 @@
           "note": "Set of Client Identifiers that are used for inter-ECU communication in the System."
         },
         "containerIPduHeaderByte": {
-          "type": "ByteOrderEnumOrder",
+          "type": "any (ByteOrderEnumOrder)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -97,28 +97,28 @@
           "is_ref": false,
           "note": "Version number of the Ecu Extract."
         },
-        "fibexElement": {
+        "fibexElements": {
           "type": "FibexElement",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to ASAM FIBEX elements specifying Topology. Elements used within a System Description shall from the System Element. order to describe a product-line, all Fibex be optional. atpVariation"
         },
-        "interpolationRoutine": {
+        "interpolationRoutines": {
           "type": "InterpolationRoutine",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the InterpolationRoutineMapping Sets that are relevant in the context of the enclosing"
         },
-        "j1939SharedAddress": {
-          "type": "J1939SharedAddress",
+        "j1939SharedAddresses": {
+          "type": "J1939SharedAddressCluster",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of J1939Clusters that share a common address space for the routing of messages. atpVariation"
         },
-        "mapping": {
+        "mappings": {
           "type": "SystemMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -140,20 +140,20 @@
           "note": "Absolute offset (with respect to the NM-PDU) of the request release information vector that in bytes as an index starting with 0."
         },
         "rootSoftware": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Aggregation of the root software composition, containing all software components in the System in a hierarchical element is not required when the System used for a network-only use-case. RootSwCompositionPrototype can vary. atpVariation"
         },
-        "swCluster": {
+        "swClusters": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "CP Software Clusters of this System atpVariation"
         },
-        "system": {
+        "systems": {
           "type": "Chapter",
           "multiplicity": "*",
           "kind": "attribute",
@@ -220,8 +220,8 @@
         }
       ],
       "attributes": {
-        "calibration": {
-          "type": "CalibrationParameter",
+        "calibrations": {
+          "type": "any (CalibrationParameter)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -235,7 +235,7 @@
           "note": "The FlatMap used in the scope of this RootSw"
         },
         "software": {
-          "type": "CompositionSw",
+          "type": "CompositionSwComponentType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -275,7 +275,7 @@
         }
       ],
       "attributes": {
-        "clientId": {
+        "clientIds": {
           "type": "ClientIdDefinition",
           "multiplicity": "*",
           "kind": "attribute",
@@ -358,162 +358,162 @@
         }
       ],
       "attributes": {
-        "application": {
-          "type": "ApplicationPartitionTo",
+        "applications": {
+          "type": "ApplicationPartitionToEcuPartitionMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Mapping of ApplicationPartitions to EcuPartitions Stereotypes: atpSplitable; atpVariation Partition Tags: Mapping atp.Splitkey=applicationPartitionToEcuPartition"
         },
-        "appOsTask": {
-          "type": "AppOsTaskProxyToEcu",
+        "appOsTasks": {
+          "type": "AppOsTaskProxyToEcuTaskProxyMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Mapping of an OsTaskProxy that was created in the context of a SwComponent to an OsTaskProxy that was in the context of an Ecu."
         },
-        "com": {
-          "type": "ComManagement",
+        "coms": {
+          "type": "ComManagementMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Mappings between Mode Management PortGroups and"
         },
-        "cryptoService": {
+        "cryptoServices": {
           "type": "CryptoServiceMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This aggregation represents the collection of crypto mappings in the context of the enclosing System atpVariation"
         },
-        "dataMapping": {
+        "dataMappings": {
           "type": "DataMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The data mappings defined. atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "ddsISignalTo": {
-          "type": "DdsCpISignalToDds",
+        "ddsISignalTos": {
+          "type": "DdsCpISignalToDdsTopicMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of DdsISignalToDdsTopicMappings. Stereotypes: atpSplitable; atpVariation"
         },
-        "ecuResource": {
+        "ecuResources": {
           "type": "ECUMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Mapping of hardware related topology elements onto their definitions in the ECU Resource Template. ECU Resource type might be variable. atpVariation"
         },
-        "j1939Controller": {
-          "type": "J1939Controller",
+        "j1939Controllers": {
+          "type": "any (J1939Controller)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Mapping of a J1939ControllerApplication to a J1939Nm Node."
         },
-        "mapping": {
+        "mappings": {
           "type": "MappingConstraint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Constraints that limit the mapping freedom for the of SW components to ECUs. atpVariation"
         },
-        "pncMapping": {
+        "pncMappings": {
           "type": "PncMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Mappings between Virtual Function Clusters and Partial atpVariation"
         },
-        "portElementTo": {
-          "type": "PortElementTo",
+        "portElementTos": {
+          "type": "PortElementToCommunicationResourceMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "maps a communication resource to CP Software Clusters"
         },
-        "resource": {
+        "resources": {
           "type": "EcuResourceEstimation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Resource estimations for this set of mappings, zero or per ECU instance. ECUs are variable. atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "resourceTo": {
+        "resourceTos": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Maps a Software Cluster resource to an Application Partition to restrict the usage. Stereotypes: atpSplitable; atpVariation Mapping Tags:"
         },
-        "rteEventInSystem": {
-          "type": "RteEventInSystem",
+        "rteEventInSystems": {
+          "type": "any (RteEventInSystem)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Separation constraint that limits the mapping freedom for the mapping of RteEvents to OsTasks in the System"
         },
-        "rteEventToOs": {
-          "type": "RteEventInSystemToOs",
+        "rteEventToOses": {
+          "type": "RteEventInSystemToOsTaskProxyMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Constraint that enforces a mapping of RteEvent to a particular OsTask in the System context."
         },
-        "signalPath": {
+        "signalPaths": {
           "type": "SignalPathConstraint",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Constraints that limit the mapping freedom for the of data elements to signals. atpVariation"
         },
-        "softwareCluster": {
-          "type": "CpSoftwareClusterTo",
+        "softwareClusters": {
+          "type": "any (CpSoftwareClusterTo)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "maps a service resource to CP Software Clusters Stereotypes: atpSplitable; atpVariation Mapping Tags:"
         },
-        "swCluster": {
-          "type": "CpSoftwareClusterTo",
+        "swClusters": {
+          "type": "any (CpSoftwareClusterTo)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The mappings of SW cluster to ECUs. Stereotypes: atpSplitable; atpVariation"
         },
-        "swcTo": {
-          "type": "SwcToApplication",
+        "swcTos": {
+          "type": "SwcToApplicationPartitionMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Allows to map a given SwComponentPrototype to a formally defined partition at a point in time when the EcuInstance is not yet known or defined. atpSplitable; atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "swImplMapping": {
+        "swImplMappings": {
           "type": "SwcToImplMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The mappings of AtomicSoftwareComponent Instances to because SwcToEcuMapping is atpVariation"
         },
-        "swMapping": {
+        "swMappings": {
           "type": "SwcToEcuMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "The mappings of SW components to ECUs. shall be mapped to other ECUs. atpVariation"
         },
-        "systemSignalGroupTo": {
-          "type": "SystemSignalGroupTo",
+        "systemSignalGroupTos": {
+          "type": "SystemSignalGroupToCommunicationResourceMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Mapping of a communication resource to a SystemSignal Group. Stereotypes: atpSplitable; atpVariation Mapping Tags:"
         },
-        "systemSignalTo": {
-          "type": "SystemSignalTo",
+        "systemSignalTos": {
+          "type": "SystemSignalToCommunicationResourceMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -550,14 +550,14 @@
         }
       ],
       "attributes": {
-        "com": {
+        "coms": {
           "type": "PortGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "channel. This reference is optional in that the System Description doesn’t use a complete Description (VFB View). This inclusion of legacy systems. by: PortGroupInSystem"
         },
-        "physicalChannel": {
+        "physicalChannels": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "reference",
@@ -595,7 +595,7 @@
         }
       ],
       "attributes": {
-        "participating": {
+        "participatings": {
           "type": "J1939Cluster",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_BusMirror.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_BusMirror.classes.json
@@ -64,7 +64,7 @@
           "is_ref": false,
           "note": "Defines the targetChannel to which frames are forwarded."
         },
-        "targetPdu": {
+        "targetPdus": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -149,22 +149,22 @@
         }
       ],
       "attributes": {
-        "canIdRange": {
-          "type": "BusMirrorCanIdRange",
+        "canIdRanges": {
+          "type": "BusMirrorCanIdRangeMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Rules for remapping of a set of CAN IDs."
         },
-        "canIdToCanId": {
-          "type": "BusMirrorCanIdToCanId",
+        "canIdToCanIds": {
+          "type": "BusMirrorCanIdToCanIdMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Rules for remapping of single CanIds."
         },
-        "linPidToCanId": {
-          "type": "BusMirrorLinPidToCan",
+        "linPidToCanIds": {
+          "type": "BusMirrorLinPidToCanIdMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DataMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DataMapping.classes.json
@@ -159,7 +159,7 @@
           "note": "Reference to the signal group, which contain all primitive the composite type"
         },
         "typeMapping": {
-          "type": "SenderRecComposite",
+          "type": "SenderRecCompositeTypeMapping",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -233,8 +233,8 @@
         }
       ],
       "attributes": {
-        "arrayElement": {
-          "type": "SenderRecArray",
+        "arrayElements": {
+          "type": "any (SenderRecArray)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -286,8 +286,8 @@
         }
       ],
       "attributes": {
-        "recordElement": {
-          "type": "SenderRecRecord",
+        "recordElements": {
+          "type": "any (SenderRecRecord)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -322,21 +322,21 @@
       ],
       "attributes": {
         "applicationRecord": {
-          "type": "ApplicationRecord",
+          "type": "any (ApplicationRecord)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to an ApplicationRecordElement in the context of the dataElement or in the context of a composite"
         },
         "complexType": {
-          "type": "SenderRecComposite",
+          "type": "SenderRecCompositeTypeMapping",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation will be used if the element is composite."
         },
         "implementation": {
-          "type": "ImplementationData",
+          "type": "any (ImplementationData)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -392,7 +392,7 @@
       ],
       "attributes": {
         "complexType": {
-          "type": "SenderRecComposite",
+          "type": "SenderRecCompositeTypeMapping",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -441,14 +441,14 @@
       ],
       "attributes": {
         "applicationArray": {
-          "type": "ApplicationArray",
+          "type": "any (ApplicationArray)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to an ApplicationArrayElement in an array."
         },
         "implementation": {
-          "type": "ImplementationData",
+          "type": "any (ImplementationData)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -555,7 +555,7 @@
           "note": "Reference to the SystemSignal to which one primitive of"
         },
         "typeMapping": {
-          "type": "SenderRecComposite",
+          "type": "SenderRecCompositeTypeMapping",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DiagnosticConnection.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DiagnosticConnection.classes.json
@@ -39,14 +39,14 @@
         }
       ],
       "attributes": {
-        "functionalRequest": {
+        "functionalRequests": {
           "type": "TpConnectionIdent",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to functional request messages. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "periodicResponseUudt": {
+        "periodicResponseUudts": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Dlt.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Dlt.classes.json
@@ -34,7 +34,7 @@
           "is_ref": false,
           "note": "Reference to the Ecu representation in the Log And Trace"
         },
-        "dltLogChannel": {
+        "dltLogChannels": {
           "type": "DltLogChannel",
           "multiplicity": "*",
           "kind": "attribute",
@@ -86,7 +86,7 @@
         }
       ],
       "attributes": {
-        "application": {
+        "applications": {
           "type": "DltContext",
           "multiplicity": "*",
           "kind": "reference",
@@ -94,13 +94,13 @@
           "note": "Reference to the Swc that produces the log or trace"
         },
         "defaultTrace": {
-          "type": "DltDefaultTraceState",
+          "type": "DltDefaultTraceStateEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attributes defines the default trace status."
         },
-        "dltMessage": {
+        "dltMessages": {
           "type": "DltMessage",
           "multiplicity": "*",
           "kind": "reference",
@@ -115,7 +115,7 @@
           "note": "This attribute identifies the Channel for usage within the"
         },
         "logTraceDefaultLog": {
-          "type": "LogTraceDefaultLog",
+          "type": "LogTraceDefaultLogLevelEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DoIP.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_DoIP.classes.json
@@ -27,7 +27,7 @@
         }
       ],
       "attributes": {
-        "doipInterface": {
+        "doipInterfaces": {
           "type": "DoIpInterface",
           "multiplicity": "*",
           "kind": "attribute",
@@ -86,14 +86,14 @@
           "is_ref": false,
           "note": "Configuration of DoIPChannels available in an DoIp"
         },
-        "doipConnection": {
+        "doipConnections": {
           "type": "SocketConnection",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "DoIP Connections in the DoIpInterface that define the Do Pdus that are sent and received via SoAd over TCP or"
         },
-        "doIpRouting": {
+        "doIpRoutings": {
           "type": "DoIpRoutingActivation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -135,7 +135,7 @@
           "is_ref": false,
           "note": "Maximum amount of tester connections that shall be at one time before alive check is performed."
         },
-        "socket": {
+        "sockets": {
           "type": "StaticSocketConnection",
           "multiplicity": "*",
           "kind": "reference",
@@ -194,8 +194,8 @@
         }
       ],
       "attributes": {
-        "doIpTarget": {
-          "type": "DoIpLogicTarget",
+        "doIpTargets": {
+          "type": "DoIpLogicTargetAddressProps",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -300,7 +300,7 @@
         }
       ],
       "attributes": {
-        "doIpTester": {
+        "doIpTesters": {
           "type": "DoIpRoutingActivation",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_ECUResourceMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_ECUResourceMapping.classes.json
@@ -30,8 +30,8 @@
         }
       ],
       "attributes": {
-        "commController": {
-          "type": "Communication",
+        "commControllers": {
+          "type": "any (Communication)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanCommunication.classes.json
@@ -65,36 +65,36 @@
         }
       ],
       "attributes": {
-        "absolutely": {
-          "type": "TtcanAbsolutely",
+        "absolutelies": {
+          "type": "TtcanAbsolutelyScheduledTiming",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Each frame in TTCAN is identified by its slot id and communication cycle. A description is provided by the of AbsolutelyScheduledTiming."
         },
         "canAddressing": {
-          "type": "CanAddressingMode",
+          "type": "CanAddressingModeType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "The CAN protocol supports two types of frame formats. The standard frame format uses 11-bit identifiers and is the CAN specification 2.0 A. Additionally the format allows 29-bit identifiers and is the CAN specification 2.0 B."
         },
         "canFrameRxBehavior": {
-          "type": "CanFrameRxBehavior",
+          "type": "CanFrameRxBehaviorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines which CAN protocol shall be expected for frame reception."
         },
         "canFrameTxBehavior": {
-          "type": "CanFrameTxBehavior",
+          "type": "CanFrameTxBehaviorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines which CAN protocol shall be used for frame transmission."
         },
         "canXlFrame": {
-          "type": "CanXlFrameTriggering",
+          "type": "CanXlFrameTriggeringProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanTopology.classes.json
@@ -108,7 +108,7 @@
       ],
       "attributes": {
         "busOffRecovery": {
-          "type": "CanClusterBusOff",
+          "type": "CanClusterBusOffRecovery",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -299,7 +299,7 @@
       ],
       "attributes": {
         "canControllerControllerAttributes": {
-          "type": "AbstractCan",
+          "type": "any (AbstractCan)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -340,14 +340,14 @@
       ],
       "attributes": {
         "canControllerFd": {
-          "type": "CanControllerFd",
+          "type": "any (CanControllerFd)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Additional CanFD ranges of the bit timing related configuration of a CanFD controller. If this element exists controller supports CanFD frames and the ECU take these ranges as requirements for the the CanFD controller."
         },
         "canControllerXl": {
-          "type": "CanControllerXl",
+          "type": "any (CanControllerXl)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -441,7 +441,7 @@
       ],
       "attributes": {
         "maxNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -462,7 +462,7 @@
           "note": "The max. Synchronization Jump Width value as a"
         },
         "minNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -589,7 +589,7 @@
       ],
       "attributes": {
         "maxNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -617,7 +617,7 @@
           "note": "Specifies the maximum Transceiver Delay Compensation in seconds. If not specified Transceiver Delay is disabled. 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
         "minNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -794,7 +794,7 @@
           "note": "Specifies if error signaling shall be enabled. This is not"
         },
         "maxNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -843,7 +843,7 @@
           "note": "Specifies the maximum Transceiver Delay Compensation in seconds. If not specified Transceiver Delay is disabled."
         },
         "minNumberOfTimeQuantaPer": {
-          "type": "IntegerBit",
+          "type": "any (IntegerBit)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_Dds.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_Dds.classes.json
@@ -168,14 +168,14 @@
           "is_ref": false,
           "note": "Minor Version of the Service that is provided by this Dds"
         },
-        "providedDds": {
+        "providedDdses": {
           "type": "DdsCpServiceInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of provided events. Stereotypes: atpSplitable; atpVariation Event Tags:"
         },
-        "staticRemote": {
+        "staticRemotes": {
           "type": "ApplicationEndpoint",
           "multiplicity": "*",
           "kind": "reference",
@@ -215,7 +215,7 @@
         }
       ],
       "attributes": {
-        "consumedDds": {
+        "consumedDdses": {
           "type": "DdsCpServiceInstance",
           "multiplicity": "*",
           "kind": "attribute",
@@ -363,14 +363,14 @@
         }
       ],
       "attributes": {
-        "ddsDomain": {
+        "ddsDomains": {
           "type": "DdsCpDomain",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of DDS Domain definitions."
         },
-        "ddsQosProfile": {
+        "ddsQosProfiles": {
           "type": "DdsCpQosProfile",
           "multiplicity": "*",
           "kind": "attribute",
@@ -408,14 +408,14 @@
         }
       ],
       "attributes": {
-        "ddsPartition": {
+        "ddsPartitions": {
           "type": "DdsCpPartition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of DDS Partition definitions."
         },
-        "ddsTopic": {
+        "ddsTopics": {
           "type": "DdsCpTopic",
           "multiplicity": "*",
           "kind": "attribute",
@@ -831,7 +831,7 @@
       ],
       "attributes": {
         "ownershipKind": {
-          "type": "DdsOwnershipKind",
+          "type": "DdsOwnershipKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_EthernetTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_EthernetTopology.classes.json
@@ -37,7 +37,7 @@
         }
       ],
       "attributes": {
-        "networkEndpoint": {
+        "networkEndpoints": {
           "type": "NetworkEndpoint",
           "multiplicity": "*",
           "kind": "attribute",
@@ -103,7 +103,7 @@
           "is_ref": false,
           "note": "Switch off delay for CouplingPorts in seconds. It denotes delay of switching off couplingPorts after the request off a couplingPort was issued. (e.g. switch off of ports)."
         },
-        "macMulticastGroup": {
+        "macMulticastGroups": {
           "type": "MacMulticastGroup",
           "multiplicity": "*",
           "kind": "attribute",
@@ -234,7 +234,7 @@
           "is_ref": false,
           "note": "Definition of details for this specific CouplingElement. Stereotypes: atpSplitable; atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "couplingPort": {
+        "couplingPorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "attribute",
@@ -255,7 +255,7 @@
           "is_ref": false,
           "note": "Optional reference to the ECU where the Coupling located."
         },
-        "firewallRule": {
+        "firewallRules": {
           "type": "StateDependentFirewall",
           "multiplicity": "*",
           "kind": "reference",
@@ -295,7 +295,7 @@
       ],
       "attributes": {
         "connection": {
-          "type": "EthernetConnection",
+          "type": "EthernetConnectionNegotiationEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -316,27 +316,27 @@
           "note": "Defines the role this CouplingPort takes in the context of CouplingElement."
         },
         "defaultVlan": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "The vLanIdentifier of the referenced VLAN is the (port VLAN ID). A Port VLAN ID is a default that is assigned to an access CouplingPort to VLAN segment to which this port is if a CouplingPort has not been any VLAN memberships, the virtual VLAN ID (pvid) becomes the default VLAN the ports connection. is added for incoming untagged the port (ingress tagging). For outgoing this identifier, the tag is removed at the untagging, depending on the Vlan"
         },
         "macLayerTypeEnum": {
-          "type": "EthernetMacLayerType",
+          "type": "EthernetMacLayerTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the mac layer type of the CouplingPort."
         },
-        "macMulticastGroup": {
+        "macMulticastGroups": {
           "type": "MacMulticastGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "Assigns a set of MAC-Multicast-Addresses which are via this CouplingPort. This is a static further addresses may be learned"
         },
-        "macSecProps": {
+        "macSecPropses": {
           "type": "MacSecProps",
           "multiplicity": "*",
           "kind": "attribute",
@@ -344,7 +344,7 @@
           "note": "Properties to configure MACsec (Media access control"
         },
         "physicalLayer": {
-          "type": "EthernetPhysicalLayer",
+          "type": "EthernetPhysicalLayerTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -357,7 +357,7 @@
           "is_ref": false,
           "note": "Optional properties for configuration of PLCA (Physical"
         },
-        "pncMappingIdent": {
+        "pncMappingIdents": {
           "type": "PncMappingIdent",
           "multiplicity": "*",
           "kind": "reference",
@@ -365,13 +365,13 @@
           "note": "Reference to the partial networks this CouplingPort"
         },
         "receiveActivity": {
-          "type": "EthernetSwitchVlan",
+          "type": "any (EthernetSwitchVlan)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the handling of frames at the ingress port."
         },
-        "vlan": {
+        "vlans": {
           "type": "VlanMembership",
           "multiplicity": "*",
           "kind": "attribute",
@@ -379,14 +379,14 @@
           "note": "Messages of VLANs that are defined here can be"
         },
         "vlanModifier": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "All incoming messages at this CouplingPort shall be with this VLAN Id. This tagging is performed the message already has a VLAN tag untagged, an existing VLAN tag will be overwritten. is XOR with CoupligPort.defaultVlan. 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
         "wakeupSleep": {
-          "type": "EthernetWakeupSleep",
+          "type": "any (EthernetWakeupSleep)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -428,21 +428,21 @@
           "note": "Standard output-priority outgoing Frames will be tagged priority that received frames are assigned the VLAN Id (defaultVlan). The values from effort) to 7 (highest) are allowed. modifyVlan and an already tagged received actual priority of the received frame is not"
         },
         "dhcpAddress": {
-          "type": "DhcpServer",
+          "type": "any (DhcpServer)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the IP Address which will be assigned to a DHCP Client at this SwitchPort. If no dhcpAddress provided all DHCP-Discover messages this Port will be discarded by the DHCP"
         },
         "sendActivity": {
-          "type": "EthernetSwitchVlan",
+          "type": "any (EthernetSwitchVlan)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Attribute denotes whether a VLAN tagged ethernet frame be with its VLAN tag (sentTagged) without a VLAN tag (sentUntagged) be dropped at this port (notSent or VLAN not this list)"
         },
         "vlan": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -483,7 +483,7 @@
           "is_ref": false,
           "note": "Reference to the first CouplingPort that is connected via 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "nodePort": {
+        "nodePorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "reference",
@@ -545,13 +545,13 @@
       ],
       "attributes": {
         "canXlConfig": {
-          "type": "AbstractCan",
+          "type": "any (AbstractCan)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "If the Ethernet frames handled by this Ethernet"
         },
-        "couplingPort": {
+        "couplingPorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "attribute",
@@ -559,7 +559,7 @@
           "note": "Optional CouplingPort that can be used to connect the a CouplingElement (e.g. a switch)."
         },
         "macLayerType": {
-          "type": "EthernetMacLayerType",
+          "type": "EthernetMacLayerTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -689,29 +689,29 @@
         }
       ],
       "attributes": {
-        "couplingPort": {
-          "type": "CouplingPortStructural",
+        "couplingPorts": {
+          "type": "CouplingPortStructuralElement",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collects all the structural parts at which a CouplingPort may be configurable."
         },
         "ethernetPriority": {
-          "type": "EthernetPriority",
+          "type": "EthernetPriorityRegeneration",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
           "note": "is replaced by regenerated priority."
         },
         "ethernetTraffic": {
-          "type": "CouplingPortTraffic",
+          "type": "CouplingPortTrafficClassAssignment",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
           "note": ""
         },
         "globalTimeCoupling": {
-          "type": "GlobalTimeCoupling",
+          "type": "GlobalTimeCouplingPortProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -724,7 +724,7 @@
           "is_ref": false,
           "note": "Defines which CouplingPortScheduler is the last in the port structure."
         },
-        "ratePolicy": {
+        "ratePolicies": {
           "type": "CouplingPortRatePolicy",
           "multiplicity": "*",
           "kind": "attribute",
@@ -802,14 +802,14 @@
       ],
       "attributes": {
         "portSchedulerSchedulerEnum": {
-          "type": "EthernetCouplingPort",
+          "type": "EthernetCouplingPortSchedulerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the schedule algorithm to be used."
         },
-        "predecessor": {
-          "type": "CouplingPortStructural",
+        "predecessors": {
+          "type": "CouplingPortStructuralElement",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -908,7 +908,7 @@
           "note": "FIFO minimum length in Byte. An actual configuration/ may use a bigger value."
         },
         "shaper": {
-          "type": "CouplingPortAbstract",
+          "type": "any (CouplingPortAbstract)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -970,8 +970,8 @@
           "is_ref": false,
           "note": "Time interval used to define the base of the rate policy."
         },
-        "vLan": {
-          "type": "EthernetPhysical",
+        "vLans": {
+          "type": "any (EthernetPhysical)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -1092,14 +1092,14 @@
       ],
       "attributes": {
         "ipv4DhcpServer": {
-          "type": "Ipv4DhcpServer",
+          "type": "Ipv4DhcpServerConfiguration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of a IPv4 DHCP server that runs on the network endpoint."
         },
         "ipv6DhcpServer": {
-          "type": "Ipv6DhcpServer",
+          "type": "Ipv6DhcpServerConfiguration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1155,7 +1155,7 @@
           "is_ref": false,
           "note": "Amount of time in seconds that a client may keep the IP"
         },
-        "dnsServer": {
+        "dnsServers": {
           "type": "Ip4AddressString",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1219,7 +1219,7 @@
           "is_ref": false,
           "note": "Amount of time in seconds that a client may keep the IP"
         },
-        "dnsServer": {
+        "dnsServers": {
           "type": "Ip6AddressString",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1299,36 +1299,36 @@
         }
       ],
       "attributes": {
-        "flowMetering": {
-          "type": "SwitchFlowMetering",
+        "flowMeterings": {
+          "type": "SwitchFlowMeteringEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of Flow Metering Entries. atp.Status=candidate"
         },
-        "streamFilter": {
+        "streamFilters": {
           "type": "SwitchStreamFilterEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of Stream Filter Entries. atp.Status=candidate"
         },
-        "streamGate": {
+        "streamGates": {
           "type": "SwitchStreamGateEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of Stream Gate Entries."
         },
-        "switchStream": {
-          "type": "SwitchStream",
+        "switchStreams": {
+          "type": "any (SwitchStream)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of switch stream identification entries. Tags: atp.Status=candidate (ordered)"
         },
-        "trafficShaper": {
-          "type": "SwitchAsynchronous",
+        "trafficShapers": {
+          "type": "SwitchAsynchronousTrafficShaperGroupEntry",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -1365,7 +1365,7 @@
         }
       ],
       "attributes": {
-        "egressPort": {
+        "egressPorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "reference",
@@ -1380,7 +1380,7 @@
           "note": "Enables Blocking all frames from the MAC address."
         },
         "filterActionDest": {
-          "type": "SwitchStreamFilter",
+          "type": "any (SwitchStreamFilter)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1400,7 +1400,7 @@
           "is_ref": false,
           "note": "Defines the action to modify the VLAN-ID within a VLAN of an Ethernet frame."
         },
-        "ingressPort": {
+        "ingressPorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "reference",
@@ -1446,14 +1446,14 @@
       ],
       "attributes": {
         "dataLinkLayer": {
-          "type": "StreamFilterRuleData",
+          "type": "StreamFilterRuleDataLinkLayer",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of a filter rule on the data link layer. Tags: atp.Status=candidate"
         },
         "ieee1722Tp": {
-          "type": "StreamFilterIEEE1722",
+          "type": "StreamFilterIEEE1722Tp",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1495,7 +1495,7 @@
       ],
       "attributes": {
         "destinationMac": {
-          "type": "StreamFilterMAC",
+          "type": "StreamFilterMACAddress",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1509,7 +1509,7 @@
           "note": "Filter to match packets based on the EtherType field in frame."
         },
         "sourceMac": {
-          "type": "StreamFilterMAC",
+          "type": "StreamFilterMACAddress",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1594,13 +1594,13 @@
       ],
       "attributes": {
         "destination": {
-          "type": "StreamFilterIpv6",
+          "type": "StreamFilterIpv6Address",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Filter to match packets with the destination IPv6 address range."
         },
-        "destinationPort": {
+        "destinationPorts": {
           "type": "StreamFilterPortRange",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1608,13 +1608,13 @@
           "note": "Filter to match packets with the set of destination UDP/ ranges."
         },
         "source": {
-          "type": "StreamFilterIpv6",
+          "type": "StreamFilterIpv6Address",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Filter to match packets with the source IPv6 address range."
         },
-        "sourcePort": {
+        "sourcePorts": {
           "type": "StreamFilterPortRange",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1802,7 +1802,7 @@
         }
       ],
       "attributes": {
-        "egressPort": {
+        "egressPorts": {
           "type": "CouplingPort",
           "multiplicity": "*",
           "kind": "reference",
@@ -1810,7 +1810,7 @@
           "note": "Reference to the egress ports used as the target of the to modify the egress port."
         },
         "modification": {
-          "type": "SwitchStreamFilter",
+          "type": "any (SwitchStreamFilter)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1862,7 +1862,7 @@
           "note": "Defines the Priority of this Stream Filter Entry."
         },
         "flowMetering": {
-          "type": "SwitchFlowMetering",
+          "type": "SwitchFlowMeteringEntry",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1997,7 +1997,7 @@
       ],
       "attributes": {
         "colorMode": {
-          "type": "FlowMeteringColor",
+          "type": "FlowMeteringColorModeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2131,7 +2131,7 @@
           "note": "Configuration options for Auto-IP (automatic private IP"
         },
         "fragmentation": {
-          "type": "Ipv4Fragmentation",
+          "type": "Ipv4FragmentationProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2313,7 +2313,7 @@
           "note": "Configuration properties for DHCPv6."
         },
         "fragmentation": {
-          "type": "Ipv6Fragmentation",
+          "type": "Ipv6FragmentationProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2678,7 +2678,7 @@
           "note": "The maximal time an acknowledgement is delayed for in seconds."
         },
         "tcpFastRecovery": {
-          "type": "BooleanRecovery",
+          "type": "any (BooleanRecovery)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3009,8 +3009,8 @@
         }
       ],
       "attributes": {
-        "ethernet": {
-          "type": "EthernetWakeupSleep",
+        "ethernets": {
+          "type": "any (EthernetWakeupSleep)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -3089,8 +3089,8 @@
         }
       ],
       "attributes": {
-        "consumedService": {
-          "type": "ConsumedService",
+        "consumedServices": {
+          "type": "any (ConsumedService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -3117,22 +3117,22 @@
           "is_ref": false,
           "note": "Defines the frame priority where values from 0 (best 7 (highest) are allowed."
         },
-        "providedService": {
-          "type": "ProvidedService",
+        "providedServices": {
+          "type": "any (ProvidedService)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Provided service instances. Tags: atp.Status=obsolete"
         },
         "tlsCryptoService": {
-          "type": "TlsCryptoService",
+          "type": "TlsCryptoServiceMapping",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the applicable TlsCryptoService Mapping that adds the ability for TLS-based encryption enclosing ApplicationEndpoint."
         },
         "tpConfigurationConfiguration": {
-          "type": "TransportProtocol",
+          "type": "TransportProtocolConfiguration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3521,7 +3521,7 @@
           "note": "HTTP Protocol version (e.g. 1.1)"
         },
         "requestMethodEnum": {
-          "type": "RequestMethodEnum",
+          "type": "any (RequestMethodEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3636,7 +3636,7 @@
           "is_ref": false,
           "note": "Optional IPSec configuration that provides security"
         },
-        "networkEndpoint": {
+        "networkEndpoints": {
           "type": "NetworkEndpoint",
           "multiplicity": "*",
           "kind": "attribute",
@@ -3728,7 +3728,7 @@
           "is_ref": false,
           "note": "IP address of the default gateway."
         },
-        "dnsServer": {
+        "dnsServers": {
           "type": "Ip4AddressString",
           "multiplicity": "*",
           "kind": "attribute",
@@ -3750,7 +3750,7 @@
           "note": "IPv4 Address. Notation: 255.255.255.255. The IP be declared in case the ipv4AddressSource and thus no auto-configuration mechanism is"
         },
         "ipv4AddressSource": {
-          "type": "Ipv4AddressSource",
+          "type": "Ipv4AddressSourceEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3813,7 +3813,7 @@
           "is_ref": false,
           "note": "IP address of the default router."
         },
-        "dnsServer": {
+        "dnsServers": {
           "type": "Ip6AddressString",
           "multiplicity": "*",
           "kind": "attribute",
@@ -3856,7 +3856,7 @@
           "note": "IPv6 Address. Notation: FFFF:...:FFFF. The IP Address declared in case the ipv6AddressSource is thus no auto-configuration mechanism is"
         },
         "ipv6AddressSource": {
-          "type": "Ipv6AddressSource",
+          "type": "Ipv6AddressSourceEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -3969,14 +3969,14 @@
       ],
       "attributes": {
         "timeSyncClientConfiguration": {
-          "type": "TimeSyncClient",
+          "type": "TimeSyncClientConfiguration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of the time synchronisation client."
         },
         "timeSyncServerConfiguration": {
-          "type": "TimeSyncServer",
+          "type": "TimeSyncServerConfiguration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -4010,7 +4010,7 @@
         }
       ],
       "attributes": {
-        "orderedMaster": {
+        "orderedMasters": {
           "type": "OrderedMaster",
           "multiplicity": "*",
           "kind": "attribute",
@@ -4018,7 +4018,7 @@
           "note": "Defines a list of ordered NetworkEndpoints."
         },
         "timeSync": {
-          "type": "TimeSyncTechnology",
+          "type": "TimeSyncTechnologyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -4075,7 +4075,7 @@
           "note": "Identifier of the TimeSyncServer."
         },
         "timeSync": {
-          "type": "TimeSyncTechnology",
+          "type": "TimeSyncTechnologyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -4117,7 +4117,7 @@
           "note": "Defines the order of the network endpoint list (e.g. 0, 1, 2,"
         },
         "timeSyncServerConfiguration": {
-          "type": "TimeSyncServer",
+          "type": "TimeSyncServerConfiguration",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -4240,7 +4240,7 @@
           "note": "Defines the rate at which the token bucket is refilled with in bit per second."
         },
         "trafficShaper": {
-          "type": "SwitchAsynchronous",
+          "type": "SwitchAsynchronousTrafficShaperGroupEntry",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_IPv6HeaderFilterList.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_IPv6HeaderFilterList.classes.json
@@ -33,7 +33,7 @@
         }
       ],
       "attributes": {
-        "extHeaderFilter": {
+        "extHeaderFilters": {
           "type": "IPv6ExtHeaderFilterList",
           "multiplicity": "*",
           "kind": "attribute",
@@ -71,7 +71,7 @@
         }
       ],
       "attributes": {
-        "allowedIPv6Ext": {
+        "allowedIPv6Exts": {
           "type": "PositiveInteger",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_ObsoleteModel.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_ObsoleteModel.classes.json
@@ -34,7 +34,7 @@
       ],
       "attributes": {
         "eventGroup": {
-          "type": "EventGroupControlType",
+          "type": "EventGroupControlTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -91,8 +91,8 @@
           "is_ref": false,
           "note": "If set to true the Server \"learns\" the client Port on"
         },
-        "pdu": {
-          "type": "SocketConnectionIpdu",
+        "pdus": {
+          "type": "SocketConnectionIpduIdentifierSet",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -106,14 +106,14 @@
           "note": "Defines the time in seconds which shall pass before a with Pdu collection enabled shall be transmitted to layer after the first Pdu has been put into the"
         },
         "runtimeIp": {
-          "type": "RuntimeAddress",
+          "type": "any (RuntimeAddress)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute determines which protocol is used by the"
         },
         "runtimePort": {
-          "type": "RuntimeAddress",
+          "type": "any (RuntimeAddress)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_ServiceInstances.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_ServiceInstances.classes.json
@@ -57,15 +57,15 @@
           "is_ref": false,
           "note": "EventGroup ID. Shall be unique within one system to service discovery."
         },
-        "eventMulticast": {
+        "eventMulticasts": {
           "type": "ApplicationEndpoint",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference defines the multicast address or a address resource where the events of the event received. multicast address is determined via configuration at runtime via service discovery this reference the multicast address over which the events will multicast address is determined at runtime via this reference shall be used to define local multicast address resources, i.e. in the TcpIp module in which the multicast stored at runtime. Please note that in this case address may be defined as ANY UDP port IP address since the multicast address will be runtime. If several multicast addresses are be used the ConsumedEventGroup shall different ApplicationEndpoint objects to reserve resources in the configuration. atpVariation"
         },
-        "pduActivationRouting": {
-          "type": "PduActivationRouting",
+        "pduActivationRoutings": {
+          "type": "PduActivationRoutingGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -78,7 +78,7 @@
           "is_ref": false,
           "note": "Defines the frame priority where values from 0 (best 7 (highest) are allowed."
         },
-        "routingGroup": {
+        "routingGroups": {
           "type": "SoAdRoutingGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -86,14 +86,14 @@
           "note": "The ServiceDiscovery module is able to activate and PDU routing for receiving events."
         },
         "sdClientConfig": {
-          "type": "SdClientConfig",
+          "type": "any (SdClientConfig)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "The readiness to receive events is defined by the Service"
         },
         "sdClientTimer": {
-          "type": "SomeipSdClientEvent",
+          "type": "SomeipSdClientEventGroupTimingConfig",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -138,7 +138,7 @@
         }
       ],
       "attributes": {
-        "allowedService": {
+        "allowedServices": {
           "type": "NetworkEndpoint",
           "multiplicity": "*",
           "kind": "reference",
@@ -152,14 +152,14 @@
           "is_ref": false,
           "note": "Defines that this ConsumedServiceInstance shall be"
         },
-        "blocklisted": {
+        "blocklisteds": {
           "type": "SomeipServiceVersion",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of blocklisted versions atp.Status=draft"
         },
-        "consumedEventGroup": {
+        "consumedEventGroups": {
           "type": "ConsumedEventGroup",
           "multiplicity": "*",
           "kind": "attribute",
@@ -195,7 +195,7 @@
           "note": "Minor Version of the ServiceInterface. Value can be set to that represents the Minor Version of the or to ANY."
         },
         "providedService": {
-          "type": "ProvidedService",
+          "type": "any (ProvidedService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -209,14 +209,14 @@
           "note": "provider is located. This reference shall ONLY be the remote address is determined from the not at runtime from the Service atpVariation"
         },
         "sdClientConfig": {
-          "type": "SdClientConfig",
+          "type": "any (SdClientConfig)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Service Discovery Client configuration."
         },
         "sdClientTimer": {
-          "type": "SomeipSdClientService",
+          "type": "SomeipSdClientServiceInstanceConfig",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -230,7 +230,7 @@
           "note": "This attribute represents the ability to describe the SOME/ ID that is searched."
         },
         "versionDriven": {
-          "type": "ServiceVersion",
+          "type": "any (ServiceVersion)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -275,7 +275,7 @@
         }
       ],
       "attributes": {
-        "allowedService": {
+        "allowedServices": {
           "type": "NetworkEndpoint",
           "multiplicity": "*",
           "kind": "reference",
@@ -289,7 +289,7 @@
           "is_ref": false,
           "note": "Defines that this ProvidedServiceInstance shall be"
         },
-        "eventHandler": {
+        "eventHandlers": {
           "type": "EventHandler",
           "multiplicity": "*",
           "kind": "attribute",
@@ -331,14 +331,14 @@
           "is_ref": false,
           "note": "Defines the frame priority where values from 0 (best 7 (highest) are allowed."
         },
-        "remoteMulticast": {
+        "remoteMulticasts": {
           "type": "ApplicationEndpoint",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference defines the remote multicast subscribed of service consumers. This reference shall be used if the remote address of the clients is the configuration and not at runtime. atpVariation"
         },
-        "remoteUnicast": {
+        "remoteUnicasts": {
           "type": "ApplicationEndpoint",
           "multiplicity": "*",
           "kind": "reference",
@@ -346,14 +346,14 @@
           "note": "This reference defines the remote addresses of service This reference shall ONLY be used if the of the clients is determined from the not at runtime. atpVariation 1228 Document ID 62: AUTOSAR_CP_TPS_SoftwareComponentTemplate Template R23-11"
         },
         "sdServerConfig": {
-          "type": "SdServerConfig",
+          "type": "any (SdServerConfig)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Service Discovery Server configuration."
         },
         "sdServerTimer": {
-          "type": "SomeipSdServer",
+          "type": "any (SomeipSdServer)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -394,14 +394,14 @@
         }
       ],
       "attributes": {
-        "connection": {
+        "connections": {
           "type": "SocketConnection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of SocketConnectionBundles. Stereotypes: atpSplitable; atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "socketAddress": {
+        "socketAddresses": {
           "type": "SocketAddress",
           "multiplicity": "*",
           "kind": "attribute",
@@ -461,7 +461,7 @@
           "note": "Application addressing"
         },
         "connector": {
-          "type": "EthernetCommunication",
+          "type": "any (EthernetCommunication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -481,8 +481,8 @@
           "is_ref": false,
           "note": "The 20-bit Flow Label field in the IPv6 header may be a source to label sequences of packets for which special handling by the IPv6 routers, such as of service. If not set a Flow Label of used to indicate packets that have not been 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "multicast": {
-          "type": "EthernetCommunication",
+        "multicasts": {
+          "type": "any (EthernetCommunication)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -502,7 +502,7 @@
           "is_ref": false,
           "note": "Defines the time in seconds which shall pass before a with Pdu collection enabled shall be transmitted to layer after the first Pdu has been put into the"
         },
-        "staticSocket": {
+        "staticSockets": {
           "type": "StaticSocketConnection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -510,7 +510,7 @@
           "note": "Definition of a static SocketConnection. atpSplitable; atpVariation"
         },
         "udpChecksum": {
-          "type": "UdpChecksum",
+          "type": "UdpChecksumCalculationEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -550,8 +550,8 @@
         }
       ],
       "attributes": {
-        "serviceInstance": {
-          "type": "AbstractService",
+        "serviceInstances": {
+          "type": "AbstractServiceInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -596,7 +596,7 @@
         }
       ],
       "attributes": {
-        "capability": {
+        "capabilities": {
           "type": "TagWithOptionalValue",
           "multiplicity": "*",
           "kind": "attribute",
@@ -611,13 +611,13 @@
           "note": "Major Version of the ServiceInterface. Value can be set to that represents the Major Version of the service."
         },
         "method": {
-          "type": "PduActivationRouting",
+          "type": "PduActivationRoutingGroup",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "The ServiceDiscovery module is able to activate and deactivate the PDU routing for ClientServerOperations methods). atpVariation"
         },
-        "routingGroup": {
+        "routingGroups": {
           "type": "SoAdRoutingGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -658,13 +658,13 @@
       ],
       "attributes": {
         "eventGroup": {
-          "type": "EventGroupControlType",
+          "type": "EventGroupControlTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
           "note": "This attribute defines the type of a RoutingGroup. There are RoutingGroups that activate the data path for unicast events of an event group. And there are activate the data path for initial are triggered, namely events that are sent out server side after a client got subscribed. Please this attribute is only valid for event Receiver communication) and omitted in MethodActivationRoutingGroups."
         },
-        "iPduIdentifier": {
+        "iPduIdentifiers": {
           "type": "SoConIPduIdentifier",
           "multiplicity": "*",
           "kind": "reference",
@@ -708,14 +708,14 @@
           "note": "If multiple Pdus are transmitted over the same connection can be used to distinguish between the constraints on constructing the headerId for see PRS_SOMEIP_00245."
         },
         "pduCollection": {
-          "type": "PduCollection",
+          "type": "any (PduCollection)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
           "note": "Specifies if the referenced PduTriggering shall be collected using a queued (i.e. all PDU instances) or only the last PDU instance) semantics. If is not present the behavior of \"queued\" is"
         },
         "pduCollectionTrigger": {
-          "type": "PduCollectionTrigger",
+          "type": "PduCollectionTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -765,7 +765,7 @@
         }
       ],
       "attributes": {
-        "iPduIdentifier": {
+        "iPduIdentifiers": {
           "type": "SoConIPduIdentifier",
           "multiplicity": "*",
           "kind": "attribute",
@@ -803,7 +803,7 @@
         }
       ],
       "attributes": {
-        "consumedEventGroup": {
+        "consumedEventGroups": {
           "type": "ConsumedEventGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -831,14 +831,14 @@
           "is_ref": false,
           "note": "Specifies the number of subscribed clients that trigger the to change the transmission of events to multicast. to 0 only unicast will be used. If configured the first client will be already served by multicast. If 2 the first client will be server with unicast soon as the second client arrives both will be multicast. not influence the handling of initial events, served using unicast only."
         },
-        "pduActivationRouting": {
-          "type": "PduActivationRouting",
+        "pduActivationRoutings": {
+          "type": "PduActivationRoutingGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The ServiceDiscovery module is able to activate and deactivate the PDU routing for events."
         },
-        "routingGroup": {
+        "routingGroups": {
           "type": "SoAdRoutingGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -846,14 +846,14 @@
           "note": "The ServiceDiscovery module is able to activate and PDU routing for events."
         },
         "sdServerConfig": {
-          "type": "SdServerConfig",
+          "type": "any (SdServerConfig)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Server configuration parameter for Service-Discovery."
         },
         "sdServerEg": {
-          "type": "SomeipSdServerEvent",
+          "type": "SomeipSdServerEventGroupTimingConfig",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1162,15 +1162,15 @@
         }
       ],
       "attributes": {
-        "consumedService": {
-          "type": "ConsumedService",
+        "consumedServices": {
+          "type": "any (ConsumedService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference assigns a set of ProvidedServiceInstances to the ConsumedProvidedServiceInstanceGroup. atpVariation"
         },
-        "providedService": {
-          "type": "ProvidedService",
+        "providedServices": {
+          "type": "any (ProvidedService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -1207,7 +1207,7 @@
         }
       ],
       "attributes": {
-        "iPduIdentifier": {
+        "iPduIdentifiers": {
           "type": "SoConIPduIdentifier",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_TcpOptionFilterSet.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Ethernet_TcpOptionFilterSet.classes.json
@@ -33,7 +33,7 @@
         }
       ],
       "attributes": {
-        "tcpOptionFilterList": {
+        "tcpOptionFilterLists": {
           "type": "TcpOptionFilterList",
           "multiplicity": "*",
           "kind": "attribute",
@@ -71,7 +71,7 @@
         }
       ],
       "attributes": {
-        "allowedTcpOption": {
+        "allowedTcpOptions": {
           "type": "PositiveInteger",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Flexray_FlexrayCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Flexray_FlexrayCommunication.classes.json
@@ -65,8 +65,8 @@
         }
       ],
       "attributes": {
-        "absolutely": {
-          "type": "FlexrayAbsolutely",
+        "absolutelies": {
+          "type": "FlexrayAbsolutelyScheduledTiming",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -87,7 +87,7 @@
           "note": "The first two bytes of the payload segment of the FlexRay for frames transmitted in the dynamic be used as receiver filterable data called the"
         },
         "payloadPreamble": {
-          "type": "BooleanIndicator",
+          "type": "any (BooleanIndicator)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Flexray_FlexrayTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Flexray_FlexrayTopology.classes.json
@@ -377,8 +377,8 @@
           "is_ref": false,
           "note": "Flag indicating whether a Time Gateway Sink node will"
         },
-        "flexrayFifo": {
-          "type": "FlexrayFifo",
+        "flexrayFifos": {
+          "type": "any (FlexrayFifo)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -566,7 +566,7 @@
           "is_ref": false,
           "note": "FrFifoDepth configures the maximum number of"
         },
-        "fifoRange": {
+        "fifoRanges": {
           "type": "FlexrayFifoRange",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Lin_LinCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Lin_LinCommunication.classes.json
@@ -194,7 +194,7 @@
         }
       ],
       "attributes": {
-        "substituted": {
+        "substituteds": {
           "type": "LinUnconditionalFrame",
           "multiplicity": "*",
           "kind": "reference",
@@ -244,7 +244,7 @@
           "is_ref": false,
           "note": "Reference to the schedule table, which resolves a"
         },
-        "linUnconditionalFrame": {
+        "linUnconditionalFrames": {
           "type": "LinUnconditionalFrame",
           "multiplicity": "*",
           "kind": "reference",
@@ -296,7 +296,7 @@
           "is_ref": false,
           "note": "The schedule table can be executed in two different"
         },
-        "tableEntry": {
+        "tableEntries": {
           "type": "ScheduleTableEntry",
           "multiplicity": "*",
           "kind": "attribute",
@@ -808,7 +808,7 @@
         }
       ],
       "attributes": {
-        "byteValue": {
+        "byteValues": {
           "type": "Integer",
           "multiplicity": "*",
           "kind": "attribute",
@@ -845,7 +845,7 @@
         }
       ],
       "attributes": {
-        "byteValue": {
+        "byteValues": {
           "type": "Integer",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Lin_LinTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Lin_LinTopology.classes.json
@@ -113,7 +113,7 @@
         }
       ],
       "attributes": {
-        "linSlave": {
+        "linSlaves": {
           "type": "LinSlaveConfig",
           "multiplicity": "*",
           "kind": "attribute",
@@ -190,7 +190,7 @@
           "is_ref": false,
           "note": "Initial NAD of the LIN slave."
         },
-        "linConfigurableFrame": {
+        "linConfigurableFrames": {
           "type": "LinConfigurableFrame",
           "multiplicity": "*",
           "kind": "attribute",
@@ -204,8 +204,8 @@
           "is_ref": false,
           "note": "Each slave node shall publish one response error in one its transmitted unconditional frames."
         },
-        "linOrdered": {
-          "type": "LinOrderedConfigurable",
+        "linOrdereds": {
+          "type": "LinOrderedConfigurableFrame",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -390,15 +390,15 @@
           "is_ref": false,
           "note": "Initial NAD of the LIN slave."
         },
-        "linConfigurableFrame": {
+        "linConfigurableFrames": {
           "type": "LinConfigurableFrame",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "LinConfigurableFrames shall list all frames (unconditional event-triggered frames and sporadic frames) the slave node. This element is necessary LIN 2.0 Assign-Frame command."
         },
-        "linOrdered": {
-          "type": "LinOrderedConfigurable",
+        "linOrdereds": {
+          "type": "LinOrderedConfigurableFrame",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -536,7 +536,7 @@
           "is_ref": false,
           "note": "This attribute shall be used to set an idle timeout period the enclosing LinPhysicalChannel. 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "scheduleTable": {
+        "scheduleTables": {
           "type": "LinScheduleTable",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Multiplatform.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Multiplatform.classes.json
@@ -40,21 +40,21 @@
           "is_ref": false,
           "note": "Reference to one ECU instance that implements the"
         },
-        "frameMapping": {
+        "frameMappings": {
           "type": "FrameMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "Frame Gateway: The entire source frame is mapped as it the target frame (what in general is only possible a common platform). In this case source and should be the identical object. frames are variable in clusters, the mapping needs to be variable, too. atpVariation"
         },
-        "iPduMapping": {
+        "iPduMappings": {
           "type": "IPduMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "IPdu Gateway: Arranges those IPdus that are transferred gateway from one channel to the other in pairs and mapping between them. PDUs are variable in clusters, the gateway needs to be variable, too. atpVariation"
         },
-        "signalMapping": {
+        "signalMappings": {
           "type": "ISignalMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -202,7 +202,7 @@
       ],
       "attributes": {
         "defaultValue": {
-          "type": "PduMappingDefault",
+          "type": "PduMappingDefaultValue",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -243,7 +243,7 @@
         }
       ],
       "attributes": {
-        "defaultValue": {
+        "defaultValues": {
           "type": "DefaultValueElement",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
@@ -117,8 +117,8 @@
           "is_ref": false,
           "note": "Defines and enables the ComTimeoutSubstituition for this"
         },
-        "transformationISignal": {
-          "type": "TransformationISignal",
+        "transformationISignals": {
+          "type": "any (TransformationISignal)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -171,21 +171,21 @@
           "is_ref": false,
           "note": "This attribute defines the use-case for this ISignalIPdu"
         },
-        "contained": {
+        "containeds": {
           "type": "ISignalIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "An I-Pdu group can be included in other I-Pdu groups. I-Pdu groups shall not be referenced by the"
         },
-        "iSignalIPdu": {
+        "iSignalIPdus": {
           "type": "ISignalIPdu",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to a set of Signal I-Pdus, which are contained"
         },
-        "nmPdu": {
+        "nmPdus": {
           "type": "NmPdu",
           "multiplicity": "*",
           "kind": "reference",
@@ -245,7 +245,7 @@
           "note": "This attribute is used to identify the actual DMx message,"
         },
         "MessageType": {
-          "type": "e.g",
+          "type": "any (e.g)",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
@@ -374,7 +374,7 @@
           "is_ref": false,
           "note": "The used length (in bytes) of the referencing frame."
         },
-        "pduToFrame": {
+        "pduToFrames": {
           "type": "PduToFrameMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -441,14 +441,14 @@
           "is_ref": false,
           "note": "One frame can be triggered several times, e.g. on"
         },
-        "framePort": {
+        "framePorts": {
           "type": "FramePort",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "References to the FramePort on every ECU of the system and/or receives the frame. both the sender and the receiver side included when the system is completely defined."
         },
-        "pduTriggering": {
+        "pduTriggerings": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -543,7 +543,7 @@
         }
       ],
       "attributes": {
-        "iSignalToIPdu": {
+        "iSignalToIPdus": {
           "type": "ISignalToIPduMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -688,14 +688,14 @@
           "is_ref": false,
           "note": "Reference to the Pdu for which the PduTriggering is"
         },
-        "iPduPort": {
+        "iPduPorts": {
           "type": "IPduPort",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "References to the IPduPort on every ECU of the system and/or receives the I-PDU. both the sender and the receiver side included when the system is completely defined."
         },
-        "iSignal": {
+        "iSignals": {
           "type": "ISignalTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -703,14 +703,14 @@
           "note": "This reference provides the relationship to the ISignal that are implemented by the PduTriggering. is optional since no ISignalTriggering can for DCM and Multiplexed Pdus. atpVariation 318 Document ID 87: AUTOSAR_CP_TPS_ECUConfiguration ECU Configuration R23-11"
         },
         "secOcCryptoService": {
-          "type": "SecOcCryptoService",
+          "type": "SecOcCryptoServiceMapping",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the crypto profile applicable to the usage (send, receive) of the also referenced Secured reference is only applicable if the references a SecuredIPdu in the role i"
         },
-        "triggerIPduSend": {
-          "type": "TriggerIPduSend",
+        "triggerIPduSends": {
+          "type": "TriggerIPduSendCondition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
@@ -817,7 +817,7 @@
           "is_ref": false,
           "note": "Optional reference to a DataTransformation which the transformer chain that is used to transform data that shall be placed inside this ISignalGroup the COMBasedTransformer approach. atpVariation"
         },
-        "iSignal": {
+        "iSignals": {
           "type": "ISignal",
           "multiplicity": "*",
           "kind": "reference",
@@ -831,8 +831,8 @@
           "is_ref": true,
           "note": "Reference to the SystemSignalGroup that is defined on level and that is supposed to be transmitted in the"
         },
-        "transformationISignal": {
-          "type": "TransformationISignal",
+        "transformationISignals": {
+          "type": "any (TransformationISignal)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -890,7 +890,7 @@
           "is_ref": false,
           "note": "Timing specification for Com IPdus (Transmission"
         },
-        "iSignalToPdu": {
+        "iSignalToPdus": {
           "type": "ISignalToIPduMapping",
           "multiplicity": "*",
           "kind": "attribute",
@@ -968,7 +968,7 @@
       ],
       "attributes": {
         "iPduSignal": {
-          "type": "IPduSignalProcessing",
+          "type": "IPduSignalProcessingEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1092,7 +1092,7 @@
       ],
       "attributes": {
         "handleOutOfRange": {
-          "type": "HandleOutOfRange",
+          "type": "any (HandleOutOfRange)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1132,7 +1132,7 @@
         }
       ],
       "attributes": {
-        "systemSignal": {
+        "systemSignals": {
           "type": "SystemSignal",
           "multiplicity": "*",
           "kind": "reference",
@@ -1271,7 +1271,7 @@
           "is_ref": true,
           "note": "This reference shall be used if an ISignalGroup is the PhysicalChannel. This reference XOR relationship with the ISignal"
         },
-        "iSignalPort": {
+        "iSignalPorts": {
           "type": "ISignalPort",
           "multiplicity": "*",
           "kind": "reference",
@@ -1618,7 +1618,7 @@
           "note": "Minimum Delay in seconds between successive this I-PDU, independent of the"
         },
         "transmission": {
-          "type": "TransmissionMode",
+          "type": "any (TransmissionMode)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1665,7 +1665,7 @@
           "is_ref": false,
           "note": "This attribute defines the use-case for this PduRIPdu"
         },
-        "iPdu": {
+        "iPdus": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -1711,14 +1711,14 @@
         }
       ],
       "attributes": {
-        "containedIPduProps": {
+        "containedIPduPropses": {
           "type": "ContainedIPduProps",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines properties for an IPdu that is part of the"
         },
-        "containedPdu": {
+        "containedPdus": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -1733,14 +1733,14 @@
           "note": "When this timeout expires the ContainerIPdu is sent out. respective timer is started when the first Ipdu is put ContainerIPdu. This attribute is ignored on"
         },
         "containerTrigger": {
-          "type": "ContainerIPduTrigger",
+          "type": "ContainerIPduTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
           "note": "Defines if the transmission of the ContainerIPdu shall be right after the first ContainedIPdu was put into attribute shall be ignored on receiver side."
         },
         "headerType": {
-          "type": "ContainerIPduHeader",
+          "type": "ContainerIPduHeaderTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1761,7 +1761,7 @@
           "note": "This attribute defines the minimum queue size for containers."
         },
         "rxAccept": {
-          "type": "RxAcceptContainedI",
+          "type": "RxAcceptContainedIPduEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1811,7 +1811,7 @@
       ],
       "attributes": {
         "collection": {
-          "type": "ContainedIPdu",
+          "type": "any (ContainedIPdu)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1860,7 +1860,7 @@
           "note": "Defines a IPdu specific sender timeout which can reduce timer when this containedIPdu is put ContainerIPdu. This attribute is ignored on"
         },
         "trigger": {
-          "type": "PduCollectionTrigger",
+          "type": "PduCollectionTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -1913,7 +1913,7 @@
       ],
       "attributes": {
         "authentication": {
-          "type": "SecureCommunication",
+          "type": "any (SecureCommunication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1927,7 +1927,7 @@
           "note": "Defines whether the length information for handling this"
         },
         "freshnessProps": {
-          "type": "SecureCommunication",
+          "type": "any (SecureCommunication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1941,7 +1941,7 @@
           "note": "Reference to a Pdu that will be protected against"
         },
         "secure": {
-          "type": "SecureCommunication",
+          "type": "any (SecureCommunication)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1955,7 +1955,7 @@
           "note": "If this attribute is set to true the SecuredIPdu contains the"
         },
         "useSecuredPdu": {
-          "type": "SecuredPduHeader",
+          "type": "SecuredPduHeaderEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -2072,15 +2072,15 @@
         }
       ],
       "attributes": {
-        "authentication": {
-          "type": "SecureCommunication",
+        "authentications": {
+          "type": "any (SecureCommunication)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Authentication properties used to configure Secured IPdus."
         },
-        "freshnessProps": {
-          "type": "SecureCommunication",
+        "freshnessPropses": {
+          "type": "any (SecureCommunication)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -2301,7 +2301,7 @@
         }
       ],
       "attributes": {
-        "dynamicPart": {
+        "dynamicParts": {
           "type": "DynamicPartAlternative",
           "multiplicity": "*",
           "kind": "attribute",
@@ -2389,7 +2389,7 @@
         }
       ],
       "attributes": {
-        "segmentPosition": {
+        "segmentPositions": {
           "type": "SegmentPosition",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json
@@ -27,15 +27,15 @@
         }
       ],
       "attributes": {
-        "modeDriven": {
-          "type": "ModeDriven",
+        "modeDrivens": {
+          "type": "ModeDrivenTransmissionModeCondition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the trigger for the Com_SwitchIpduTxMode"
         },
         "transmission": {
-          "type": "TransmissionMode",
+          "type": "any (TransmissionMode)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -112,7 +112,7 @@
         }
       ],
       "attributes": {
-        "mode": {
+        "modes": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "reference",
@@ -392,7 +392,7 @@
         }
       ],
       "attributes": {
-        "mode": {
+        "modes": {
           "type": "ModeDeclaration",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreTopology.classes.json
@@ -55,7 +55,7 @@
           "is_ref": false,
           "note": "Channels speed in bits/s."
         },
-        "physicalChannel": {
+        "physicalChannels": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "attribute",
@@ -128,21 +128,21 @@
         }
       ],
       "attributes": {
-        "associatedCom": {
+        "associatedComs": {
           "type": "ISignalIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": true,
           "note": "With this reference it is possible to identify which ISignal are applicable for which Communication level ISignalIPduGroups shall be referenced by If an ISignalIPduGroup contains other these contained ISignalIPdu not be referenced by the EcuInstance. are associated to an Ecu the top level ISignalIPduGroup. 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "associated": {
-          "type": "ConsumedProvided",
+        "associateds": {
+          "type": "ConsumedProvidedServiceInstanceGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "With this reference it is possible to identify which ConsumedProvidedServiceInstanceGroups are for which ECUInstance. atpSplitable; atpVariation Group Tags:"
         },
-        "associatedPdur": {
+        "associatedPdurs": {
           "type": "PdurIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -177,15 +177,15 @@
           "is_ref": false,
           "note": "Enables for the Com module of this EcuInstance the"
         },
-        "commController": {
-          "type": "Communication",
+        "commControllers": {
+          "type": "any (Communication)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "CommunicationControllers of the ECU."
         },
-        "connector": {
-          "type": "Communication",
+        "connectors": {
+          "type": "any (Communication)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -205,7 +205,7 @@
           "is_ref": false,
           "note": "DoIp configuration on this EcuInstance."
         },
-        "ecuTaskProxy": {
+        "ecuTaskProxies": {
           "type": "OsTaskProxy",
           "multiplicity": "*",
           "kind": "reference",
@@ -219,14 +219,14 @@
           "is_ref": false,
           "note": "Defines whether the derivation of SwitchPortGroups"
         },
-        "firewallRule": {
+        "firewallRules": {
           "type": "StateDependentFirewall",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Firewall rules defined in the context of an EcuInstance."
         },
-        "partition": {
+        "partitions": {
           "type": "EcuPartition",
           "multiplicity": "*",
           "kind": "attribute",
@@ -283,7 +283,7 @@
           "note": "EcuInstance specific TcpIp Stack attributes."
         },
         "v2xSupported": {
-          "type": "V2xSupportEnum",
+          "type": "any (V2xSupportEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -350,35 +350,35 @@
         }
       ],
       "attributes": {
-        "commConnector": {
+        "commConnectors": {
           "type": "CommunicationConnector",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference to the ECUInstance via a Communication assignment of Physical Channels to is expressed with atpVariation"
         },
-        "frameTriggering": {
+        "frameTriggerings": {
           "type": "FrameTriggering",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "One frame triggering is defined for exactly one channel. have assigned an arbitrary number of signals/PDUs/frames are variable, the shall be variable, too. atpVariation"
         },
-        "iSignal": {
+        "iSignals": {
           "type": "ISignalTriggering",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "One ISignalTriggering is defined for exactly one channel. may have assigned an arbitrary number of signals/PDUs/frames are variable, the shall be variable, too. atpVariation 719 Document ID 673: AUTOSAR_CP_TPS_DiagnosticExtractTemplate Template R23-11"
         },
-        "managed": {
+        "manageds": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "Reference between a channel with role managing and a channel with role managed channel."
         },
-        "pduTriggering": {
+        "pduTriggerings": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "attribute",
@@ -523,7 +523,7 @@
       ],
       "attributes": {
         "commController": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -543,14 +543,14 @@
           "is_ref": false,
           "note": "Defines if this EcuInstance shall implement the dynamic"
         },
-        "ecuCommPort": {
+        "ecuCommPorts": {
           "type": "CommConnectorPort",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "An ECUs reception or send ports. If signals/PDUs/frames are variable, the shall be variable, too. atpVariation"
         },
-        "pncFilterArray": {
+        "pncFilterArrays": {
           "type": "PositiveInteger",
           "multiplicity": "*",
           "kind": "attribute",
@@ -604,7 +604,7 @@
       ],
       "attributes": {
         "communication": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GeneralPurposeConnection.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GeneralPurposeConnection.classes.json
@@ -33,7 +33,7 @@
         }
       ],
       "attributes": {
-        "pduTriggering": {
+        "pduTriggerings": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime.classes.json
@@ -56,7 +56,7 @@
           "is_ref": false,
           "note": "This represents the ID of the GlobalTimeDomain used in messages sent on behalf of global time"
         },
-        "gateway": {
+        "gateways": {
           "type": "GlobalTimeGateway",
           "multiplicity": "*",
           "kind": "attribute",
@@ -64,7 +64,7 @@
           "note": "A GlobalTimeGateway may exist in the context of a actively update the global time it is routed from one GlobalTimeDomain to atpVariation"
         },
         "globalTime": {
-          "type": "AbstractGlobalTime",
+          "type": "AbstractGlobalTimeDomainProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -77,7 +77,7 @@
           "is_ref": false,
           "note": "This represents the single master of a GlobalTime A GlobalTimeDomain may have no GlobalTime when it gets its time from a GPS atpVariation"
         },
-        "globalTimeSub": {
+        "globalTimeSubs": {
           "type": "GlobalTimeDomain",
           "multiplicity": "*",
           "kind": "reference",
@@ -85,7 +85,7 @@
           "note": "By this means it is possible to create a hierarchy of sub where one global time domain can declare one other global time domains as its subDomains. atpVariation"
         },
         "network": {
-          "type": "NetworkSegment",
+          "type": "NetworkSegmentIdentification",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -105,7 +105,7 @@
           "is_ref": true,
           "note": "This PduTriggering will be taken to transmit the global"
         },
-        "slave": {
+        "slaves": {
           "type": "GlobalTimeSlave",
           "multiplicity": "*",
           "kind": "attribute",
@@ -238,7 +238,7 @@
           "note": "The GlobalTimeMaster is bound to the Communication"
         },
         "icvSecured": {
-          "type": "GlobalTimeIcvSupport",
+          "type": "GlobalTimeIcvSupportEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -322,7 +322,7 @@
           "note": "Rx timeout for the follow-up message."
         },
         "icvVerification": {
-          "type": "GlobalTimeIcv",
+          "type": "any (GlobalTimeIcv)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_CAN.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_CAN.classes.json
@@ -32,7 +32,7 @@
       ],
       "attributes": {
         "crcSecured": {
-          "type": "GlobalTimeCrcSupport",
+          "type": "GlobalTimeCrcSupportEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -78,7 +78,7 @@
       ],
       "attributes": {
         "crcValidated": {
-          "type": "GlobalTimeCrc",
+          "type": "any (GlobalTimeCrc)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_ETH.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_ETH.classes.json
@@ -32,7 +32,7 @@
       ],
       "attributes": {
         "crcSecured": {
-          "type": "GlobalTimeCrcSupport",
+          "type": "GlobalTimeCrcSupportEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -141,7 +141,7 @@
       ],
       "attributes": {
         "crcValidated": {
-          "type": "GlobalTimeCrc",
+          "type": "any (GlobalTimeCrc)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -197,15 +197,15 @@
           "is_ref": false,
           "note": ""
         },
-        "managed": {
-          "type": "EthGlobalTime",
+        "manageds": {
+          "type": "any (EthGlobalTime)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of CouplingPorts which are managed in the"
         },
         "message": {
-          "type": "EthGlobalTimeMessage",
+          "type": "EthGlobalTimeMessageFormatEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -324,7 +324,7 @@
           "note": "Defines which CouplingPort is managed by this EthGlobal"
         },
         "globalTimePortRole": {
-          "type": "GlobalTimePortRole",
+          "type": "GlobalTimePortRoleEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_FR.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_GlobalTime_FR.classes.json
@@ -32,7 +32,7 @@
       ],
       "attributes": {
         "crcSecured": {
-          "type": "GlobalTimeCrcSupport",
+          "type": "GlobalTimeCrcSupportEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -71,7 +71,7 @@
       ],
       "attributes": {
         "crcValidated": {
-          "type": "GlobalTimeCrc",
+          "type": "any (GlobalTimeCrc)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_InstanceRefs.classes.json
@@ -43,14 +43,14 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Tags: xml.sequenceOffset=20"
         },
         "target": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "1",
           "kind": "reference",
           "is_ref": false,
@@ -97,7 +97,7 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -162,7 +162,7 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -221,7 +221,7 @@
           "note": "This represents that base of the InstanceRef"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -280,7 +280,7 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "RootSwComposition",
+          "type": "RootSwCompositionPrototype",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_NetworkManagement.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_NetworkManagement.classes.json
@@ -38,7 +38,7 @@
       ],
       "attributes": {
         "address": {
-          "type": "J1939NmAddress",
+          "type": "J1939NmAddressConfigurationCapabilityEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -88,21 +88,21 @@
         }
       ],
       "attributes": {
-        "nmCluster": {
+        "nmClusters": {
           "type": "NmCluster",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of NM Clusters"
         },
-        "nmClusterCoupling": {
+        "nmClusterCouplings": {
           "type": "NmClusterCoupling",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of NmClusterCouplings Derived, because NmCluster can vary. atpVariation"
         },
-        "nmIfEcu": {
+        "nmIfEcus": {
           "type": "NmEcu",
           "multiplicity": "*",
           "kind": "attribute",
@@ -237,7 +237,7 @@
         }
       ],
       "attributes": {
-        "busDependentNmEcu": {
+        "busDependentNmEcus": {
           "type": "BusspecificNmEcu",
           "multiplicity": "*",
           "kind": "attribute",
@@ -252,7 +252,7 @@
           "note": "Association to an ECUInstance in the topology"
         },
         "nmBusSynchronization": {
-          "type": "BooleanEnabled",
+          "type": "any (BooleanEnabled)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -280,14 +280,14 @@
           "note": "The period between successive calls to the Main Function the NM Interface in seconds."
         },
         "nmPduRxIndication": {
-          "type": "BooleanEnabled",
+          "type": "any (BooleanEnabled)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Switch for enabling the PDU Rx Indication."
         },
         "nmRemoteSleepInd": {
-          "type": "BooleanEnabled",
+          "type": "any (BooleanEnabled)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -393,7 +393,7 @@
           "is_ref": false,
           "note": "This attribute defines the maximum shutdown time (in of a connected and coordinated NM-Cluster."
         },
-        "nmNode": {
+        "nmNodes": {
           "type": "NmNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -442,7 +442,7 @@
       ],
       "attributes": {
         "controller": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -456,7 +456,7 @@
           "note": "NmCoordinationCluster identification number."
         },
         "nmCoordinatorRole": {
-          "type": "NmCoordinatorRole",
+          "type": "NmCoordinatorRoleEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -483,14 +483,14 @@
           "is_ref": false,
           "note": "Enables support of the Passive Mode. The passive mode"
         },
-        "rxNmPdu": {
+        "rxNmPdus": {
           "type": "NmPdu",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "receive NM Pdu."
         },
-        "txNmPdu": {
+        "txNmPdus": {
           "type": "NmPdu",
           "multiplicity": "*",
           "kind": "reference",
@@ -685,7 +685,7 @@
         }
       ],
       "attributes": {
-        "coupledCluster": {
+        "coupledClusters": {
           "type": "FlexrayNmCluster",
           "multiplicity": "*",
           "kind": "reference",
@@ -693,7 +693,7 @@
           "note": "Reference to coupled FlexRay Clusters."
         },
         "nmSchedule": {
-          "type": "FlexrayNmSchedule",
+          "type": "FlexrayNmScheduleVariant",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -903,7 +903,7 @@
         }
       ],
       "attributes": {
-        "coupledCluster": {
+        "coupledClusters": {
           "type": "CanNmCluster",
           "multiplicity": "*",
           "kind": "reference",
@@ -911,7 +911,7 @@
           "note": "Reference to coupled CAN Clusters."
         },
         "nmBusloadReduction": {
-          "type": "BooleanEnabled",
+          "type": "any (BooleanEnabled)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1080,7 +1080,7 @@
           "note": "Timeout for bus calm down phase in seconds. It denotes time how long the CanNm shall stay in the Prepare before transition into Bus-Sleep Mode place."
         },
         "vlan": {
-          "type": "EthernetPhysical",
+          "type": "any (EthernetPhysical)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1143,7 +1143,7 @@
         }
       ],
       "attributes": {
-        "coupledCluster": {
+        "coupledClusters": {
           "type": "UdpNmCluster",
           "multiplicity": "*",
           "kind": "reference",
@@ -1278,7 +1278,7 @@
       ],
       "attributes": {
         "arbitraryAddress": {
-          "type": "BooleanCapable",
+          "type": "any (BooleanCapable)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_PncMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_PncMapping.classes.json
@@ -28,7 +28,7 @@
         }
       ],
       "attributes": {
-        "dynamicPnc": {
+        "dynamicPncs": {
           "type": "ISignalIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -42,21 +42,21 @@
           "is_ref": true,
           "note": "This adds the ability to become referrable to PncMapping."
         },
-        "physicalChannel": {
+        "physicalChannels": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference maps the partial network to a channel."
         },
-        "pncConsumed": {
-          "type": "ConsumedProvided",
+        "pncConsumeds": {
+          "type": "ConsumedProvidedServiceInstanceGroup",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "ConsumedProvidedServiceInstanceGroup used in a Partial Network Cluster. This reference is optional, since could be used for starting and stopping Consumed according the requested but is not necessarily needed. atpVariation"
         },
-        "pncGroup": {
+        "pncGroups": {
           "type": "ISignalIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -70,7 +70,7 @@
           "is_ref": false,
           "note": "Identifer of the Partial Network Cluster. This number absolute bit position of this Partial Network the NM Pdu."
         },
-        "pncPdurGroup": {
+        "pncPdurGroups": {
           "type": "PdurIPduGroup",
           "multiplicity": "*",
           "kind": "reference",
@@ -84,7 +84,7 @@
           "is_ref": false,
           "note": "If this parameter is available and set to true then this PNC"
         },
-        "relevantFor": {
+        "relevantFors": {
           "type": "EcuInstance",
           "multiplicity": "*",
           "kind": "reference",
@@ -98,14 +98,14 @@
           "is_ref": false,
           "note": "This attribute specifies an identifying shortName for the"
         },
-        "vfc": {
+        "vfcs": {
           "type": "PortGroup",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": true,
           "note": "This reference is optional in case that Description doesn’t use a complete Software (VFB View). This supports the legacy systems. by: PortGroupInSystem"
         },
-        "wakeupFrame": {
+        "wakeupFrames": {
           "type": "FrameTriggering",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_RteEventToOsTaskMapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_RteEventToOsTaskMapping.classes.json
@@ -41,7 +41,7 @@
           "note": "This attribute specifies the period in seconds of this task of a cyclically activated task. Please note that this informative and not directly relevant for the But the attribute value can be mapped OS configuration to support configuration work a fixed set of OsTasks."
         },
         "preemptability": {
-          "type": "OsTaskPreemptability",
+          "type": "OsTaskPreemptabilityEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -189,7 +189,7 @@
         }
       ],
       "attributes": {
-        "rteEventInstanceRef": {
+        "rteEventInstanceRefs": {
           "type": "RTEEvent",
           "multiplicity": "*",
           "kind": "attribute",
@@ -279,7 +279,7 @@
         }
       ],
       "attributes": {
-        "rteEventInstanceRef": {
+        "rteEventInstanceRefs": {
           "type": "RTEEvent",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SWmapping.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SWmapping.classes.json
@@ -30,8 +30,8 @@
         }
       ],
       "attributes": {
-        "component": {
-          "type": "SwComponent",
+        "components": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -207,7 +207,7 @@
         }
       ],
       "attributes": {
-        "application": {
+        "applications": {
           "type": "ApplicationPartition",
           "multiplicity": "*",
           "kind": "reference",
@@ -329,8 +329,8 @@
         }
       ],
       "attributes": {
-        "clustered": {
-          "type": "SwComponent",
+        "clustereds": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -408,7 +408,7 @@
       ],
       "attributes": {
         "j1939Controller": {
-          "type": "J1939Controller",
+          "type": "any (J1939Controller)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -525,7 +525,7 @@
           "is_ref": false,
           "note": "Estimation for the resource consumption of the run time"
         },
-        "swCompToEcu": {
+        "swCompToEcus": {
           "type": "SwcToEcuMapping",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SecureCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SecureCommunication.classes.json
@@ -42,14 +42,14 @@
       ],
       "attributes": {
         "algorithmFamily": {
-          "type": "CryptoCertificate",
+          "type": "any (CryptoCertificate)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute represents a description of the family of algorithm used to generate public key and the cryptographic certificate."
         },
         "format": {
-          "type": "CryptoCertificateFormat",
+          "type": "CryptoCertificateFormatEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -63,7 +63,7 @@
           "note": "This attribute represents the ability to define the length of the certificate in bytes."
         },
         "nextHigher": {
-          "type": "CryptoService",
+          "type": "any (CryptoService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -168,7 +168,7 @@
           "note": "This attribute defines the destination MAC Address that is to calculate the ICV (Integrity Check Value)."
         },
         "globalKayProps": {
-          "type": "MacSecGlobalKay",
+          "type": "MacSecGlobalKayProps",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -181,7 +181,7 @@
           "is_ref": false,
           "note": "This attribute defines the key-server priority. atp.Status=candidate"
         },
-        "mkaParticipant": {
+        "mkaParticipants": {
           "type": "MacSecKayParticipant",
           "multiplicity": "*",
           "kind": "reference",
@@ -295,7 +295,7 @@
           "is_ref": false,
           "note": "Reference to the EthernetCluster (Link) on which the KaY located"
         },
-        "mkaParticipant": {
+        "mkaParticipants": {
           "type": "MacSecKayParticipant",
           "multiplicity": "*",
           "kind": "attribute",
@@ -341,7 +341,7 @@
           "note": "Reference to the key where the ckn (Connectivity is stored."
         },
         "cryptoAlgo": {
-          "type": "MacSecCryptoAlgo",
+          "type": "MacSecCryptoAlgoConfig",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -390,14 +390,14 @@
           "note": "This attribute defines the MACsec capability."
         },
         "cipherSuite": {
-          "type": "MacSecCipherSuite",
+          "type": "MacSecCipherSuiteConfig",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Tags: atp.Status=candidate"
         },
         "confidentiality": {
-          "type": "MacSecConfidentiality",
+          "type": "MacSecConfidentialityOffsetEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -747,14 +747,14 @@
         }
       ],
       "attributes": {
-        "keyExchange": {
+        "keyExchanges": {
           "type": "CryptoServicePrimitive",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the shared(i.e. applicable for the aggregated cipher suites) crypto service the execution of key exchange during the"
         },
-        "tlsCipherSuite": {
+        "tlsCipherSuites": {
           "type": "TlsCryptoCipherSuite",
           "multiplicity": "*",
           "kind": "attribute",
@@ -815,7 +815,7 @@
           "note": "This reference identifies the crypto service primitive for and verification of MACs."
         },
         "certificate": {
-          "type": "CryptoService",
+          "type": "any (CryptoService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -835,8 +835,8 @@
           "is_ref": false,
           "note": "Name of the CipherSuite according to the IANA"
         },
-        "ellipticCurve": {
-          "type": "CryptoEllipticCurve",
+        "ellipticCurves": {
+          "type": "CryptoEllipticCurveProps",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -849,7 +849,7 @@
           "is_ref": false,
           "note": "This reference identifies the crypto service primitive for of encryption."
         },
-        "keyExchange": {
+        "keyExchanges": {
           "type": "CryptoServicePrimitive",
           "multiplicity": "*",
           "kind": "reference",
@@ -878,14 +878,14 @@
           "note": "Pre-shared key identity shared during the handshake"
         },
         "remote": {
-          "type": "CryptoService",
+          "type": "any (CryptoService)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the applicable remote certificate."
         },
-        "signature": {
-          "type": "CryptoSignature",
+        "signatures": {
+          "type": "CryptoSignatureScheme",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -1102,7 +1102,7 @@
           "is_ref": false,
           "note": "Global IPsec configuration settings that are valid for all that are defined on the NetworkEndpoint."
         },
-        "ipSecRule": {
+        "ipSecRules": {
           "type": "IPSecRule",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1141,7 +1141,7 @@
       ],
       "attributes": {
         "direction": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1161,8 +1161,8 @@
           "is_ref": false,
           "note": "This attribute defines the relevant IP protocol used in the Database (SPD) entry."
         },
-        "localCertificate": {
-          "type": "CryptoService",
+        "localCertificates": {
+          "type": "any (CryptoService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -1210,8 +1210,8 @@
           "is_ref": false,
           "note": "This attribute defines the priority of the IPSecRule (SPD processing of entries is based on priority, the highest priority \"0\"."
         },
-        "remote": {
-          "type": "CryptoService",
+        "remotes": {
+          "type": "any (CryptoService)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -1224,7 +1224,7 @@
           "is_ref": false,
           "note": "This attribute defines how the remote participant should"
         },
-        "remoteIp": {
+        "remoteIps": {
           "type": "NetworkEndpoint",
           "multiplicity": "*",
           "kind": "reference",
@@ -1274,7 +1274,7 @@
         }
       ],
       "attributes": {
-        "ahCipherSuite": {
+        "ahCipherSuites": {
           "type": "String",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1295,7 +1295,7 @@
           "is_ref": false,
           "note": "This attribute describes the interval to check the liveness peer actively using IKEv2 INFORMATIONAL DPD checking is only enforced if no ESP/AH packet has been received for the delay. configured the value \"5 minutes\" shall be assumed."
         },
-        "espCipherSuite": {
+        "espCipherSuites": {
           "type": "String",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SignalPaths.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SignalPaths.classes.json
@@ -28,14 +28,14 @@
         }
       ],
       "attributes": {
-        "operation": {
-          "type": "SwcToSwcOperation",
+        "operations": {
+          "type": "any (SwcToSwcOperation)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The arguments sent in one direction (either from client to or server to client) of the operations that shall take signal path."
         },
-        "signal": {
+        "signals": {
           "type": "SwcToSwcSignal",
           "multiplicity": "*",
           "kind": "attribute",
@@ -73,7 +73,7 @@
         }
       ],
       "attributes": {
-        "dataElement": {
+        "dataElements": {
           "type": "VariableDataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -111,13 +111,13 @@
       ],
       "attributes": {
         "direction": {
-          "type": "SwcToSwcOperation",
+          "type": "any (SwcToSwcOperation)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Direction addressed by this SwcToSwcClientServer element."
         },
-        "operation": {
+        "operations": {
           "type": "ClientServerOperation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -153,21 +153,21 @@
         }
       ],
       "attributes": {
-        "operation": {
-          "type": "SwcToSwcOperation",
+        "operations": {
+          "type": "any (SwcToSwcOperation)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Reference to the operation arguments of one operation shall not take the predefined way in the topology."
         },
-        "physicalChannel": {
+        "physicalChannels": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The SwcToSwcSignal shall not be transmitted on one of physical channels."
         },
-        "signal": {
+        "signals": {
           "type": "SwcToSwcSignal",
           "multiplicity": "*",
           "kind": "attribute",
@@ -203,21 +203,21 @@
         }
       ],
       "attributes": {
-        "operation": {
-          "type": "SwcToSwcOperation",
+        "operations": {
+          "type": "any (SwcToSwcOperation)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The arguments of an operation that can take the way in the topology."
         },
-        "physicalChannel": {
+        "physicalChannels": {
           "type": "PhysicalChannel",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "The SwcToSwcSignal can be transmitted on one of these channels."
         },
-        "signal": {
+        "signals": {
           "type": "SwcToSwcSignal",
           "multiplicity": "*",
           "kind": "attribute",
@@ -253,14 +253,14 @@
         }
       ],
       "attributes": {
-        "operation": {
-          "type": "SwcToSwcOperation",
+        "operations": {
+          "type": "any (SwcToSwcOperation)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "The SwcToSwcOperationArguments that shall not take same way (Signal Path) in the topology."
         },
-        "signal": {
+        "signals": {
           "type": "SwcToSwcSignal",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SoftwareCluster.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SoftwareCluster.classes.json
@@ -42,8 +42,8 @@
         }
       ],
       "attributes": {
-        "dependent": {
-          "type": "RoleBasedResource",
+        "dependents": {
+          "type": "RoleBasedResourceDependency",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -164,14 +164,14 @@
           "is_ref": false,
           "note": "This attribute represents the value of the id of the CP software cluster."
         },
-        "swComponent": {
-          "type": "SwComponent",
+        "swComponents": {
+          "type": "any (SwComponent)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This is the collection of SwComponentPrototype"
         },
-        "swCompositionComponentType": {
+        "swCompositionComponentTypes": {
           "type": "CompositionSwComponentType",
           "multiplicity": "*",
           "kind": "reference",
@@ -223,7 +223,7 @@
           "is_ref": false,
           "note": "Unique number of the (virtual or physical) machine to Software Cluster is mapped."
         },
-        "swCluster": {
+        "swClusters": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "reference",
@@ -310,29 +310,29 @@
         }
       ],
       "attributes": {
-        "portElementTo": {
-          "type": "PortElementTo",
+        "portElementTos": {
+          "type": "PortElementToCommunicationResourceMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "maps a communication resource to CP Software Clusters"
         },
-        "resourceTo": {
+        "resourceTos": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Maps a Software Cluster resource to an Application Partition to restrict the usage. Stereotypes: atpSplitable; atpVariation Mapping Tags:"
         },
-        "softwareCluster": {
-          "type": "CpSoftwareClusterTo",
+        "softwareClusters": {
+          "type": "any (CpSoftwareClusterTo)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "maps a service resource to CP Software Clusters Stereotypes: atpSplitable; atpVariation Mapping Tags:"
         },
-        "swcTo": {
-          "type": "SwcToApplication",
+        "swcTos": {
+          "type": "SwcToApplicationPartitionMapping",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -370,7 +370,7 @@
         }
       ],
       "attributes": {
-        "application": {
+        "applications": {
           "type": "ApplicationPartition",
           "multiplicity": "*",
           "kind": "reference",
@@ -503,7 +503,7 @@
       ],
       "attributes": {
         "swComponent": {
-          "type": "SwComponent",
+          "type": "any (SwComponent)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -543,14 +543,14 @@
         }
       ],
       "attributes": {
-        "ecuScope": {
+        "ecuScopes": {
           "type": "EcuInstance",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
           "note": "This reference identifies the EcuInstance in which the is defined."
         },
-        "resource": {
+        "resources": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "attribute",
@@ -659,7 +659,7 @@
       ],
       "attributes": {
         "data": {
-          "type": "DataConsistencyPolicy",
+          "type": "DataConsistencyPolicyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -740,7 +740,7 @@
         }
       ],
       "attributes": {
-        "resourceNeeds": {
+        "resourceNeedses": {
           "type": "EcucContainerValue",
           "multiplicity": "*",
           "kind": "reference",
@@ -786,7 +786,7 @@
           "is_ref": false,
           "note": "CP Software Cluster providing the resource"
         },
-        "requester": {
+        "requesters": {
           "type": "CpSoftwareCluster",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SoftwareCluster_BinaryManifest.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_SoftwareCluster_BinaryManifest.classes.json
@@ -40,29 +40,29 @@
           "is_ref": false,
           "note": "This reference identifies the CpSoftwareCluster to which enclosing CpSoftwareClusterBinaryManifest is an integration phase while the referenced Cp a design element. Therefore, sense to use a reference rather than an the relation of the two meta-classes."
         },
-        "metaDataField": {
-          "type": "BinaryManifestMeta",
+        "metaDataFields": {
+          "type": "BinaryManifestMetaDataField",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation identifies the collection of meta-data in the enclosing binary manifest."
         },
-        "provide": {
-          "type": "BinaryManifestProvide",
+        "provides": {
+          "type": "BinaryManifestProvideResource",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the collection of provided resources in the enclosing binary manifest."
         },
-        "require": {
-          "type": "BinaryManifestRequire",
+        "requires": {
+          "type": "BinaryManifestRequireResource",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This aggregation represents the collection of required resources in the enclosing binary manifest."
         },
-        "resource": {
-          "type": "BinaryManifest",
+        "resources": {
+          "type": "any (BinaryManifest)",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
@@ -164,7 +164,7 @@
           "note": "A unique identifiers per resource used for the connection The identifier is required to be unique in the a single machine. If software clusters are be reused on multiple machines the applies for all the intended BinaryManifestItem * aggr This aggregation represents the collection of binary owned by the enclosing binary manifest"
         },
         "resource": {
-          "type": "BinaryManifest",
+          "type": "any (BinaryManifest)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -247,7 +247,7 @@
         }
       ],
       "attributes": {
-        "itemDefinition": {
+        "itemDefinitions": {
           "type": "BinaryManifestItem",
           "multiplicity": "*",
           "kind": "attribute",
@@ -287,7 +287,7 @@
         }
       ],
       "attributes": {
-        "auxiliaryField": {
+        "auxiliaryFields": {
           "type": "BinaryManifestItem",
           "multiplicity": "*",
           "kind": "attribute",
@@ -347,7 +347,7 @@
         }
       ],
       "attributes": {
-        "auxiliaryField": {
+        "auxiliaryFields": {
           "type": "BinaryManifestItem",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Transformer.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Transformer.classes.json
@@ -37,7 +37,7 @@
       ],
       "attributes": {
         "data": {
-          "type": "DataTransformationKind",
+          "type": "DataTransformationKindEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -50,8 +50,8 @@
           "is_ref": false,
           "note": "Specifies whether the transformer chain is executed even"
         },
-        "transformer": {
-          "type": "Transformation",
+        "transformers": {
+          "type": "any (Transformation)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -285,7 +285,7 @@
           "note": "Disables the E2EStateMachine (only E2E check"
         },
         "e2eProfile": {
-          "type": "E2EProfileCompatibility",
+          "type": "E2EProfileCompatibilityProps",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -468,7 +468,7 @@
           "note": "Offset of the Data ID nibble in the Data[] array in bits. 1228 Document ID 62: AUTOSAR_CP_TPS_SoftwareComponentTemplate Template R23-11"
         },
         "e2eProfile": {
-          "type": "E2EProfileCompatibility",
+          "type": "E2EProfileCompatibilityProps",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -517,7 +517,7 @@
           "note": "Offset of the E2E header in the Data[] array in bits."
         },
         "profileBehaviorBehaviorEnum": {
-          "type": "EndToEndProfile",
+          "type": "EndToEndProfileBehaviorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -592,14 +592,14 @@
         }
       ],
       "attributes": {
-        "data": {
+        "datas": {
           "type": "DataTransformation",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "This container consists of all transformer chains which be used for transformation of data communication. atpVariation"
         },
-        "transformationTechnology": {
+        "transformationTechnologies": {
           "type": "TransformationTechnology",
           "multiplicity": "*",
           "kind": "attribute",
@@ -670,13 +670,13 @@
       ],
       "attributes": {
         "csErrorReaction": {
-          "type": "CSTransformerError",
+          "type": "CSTransformerErrorReactionEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines whether the transformer chain of client/server coordinates an autonomous error reaction the RTE or whether any error reaction is the the application."
         },
-        "dataPrototype": {
+        "dataPrototypes": {
           "type": "DataPrototype",
           "multiplicity": "*",
           "kind": "attribute",
@@ -684,7 +684,7 @@
           "note": "Fine granular modeling of TransfromationProps on the level of DataPrototypes. This atpSplitable property has no atp.Splitkey due (PropertySetPattern)."
         },
         "transformer": {
-          "type": "Transformation",
+          "type": "any (Transformation)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -794,7 +794,7 @@
           "note": "This attribute shall be used to determine the wire type in"
         },
         "messageType": {
-          "type": "SOMEIPMessageType",
+          "type": "SOMEIPMessageTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -828,7 +828,7 @@
           "is_ref": false,
           "note": "The size of all length fields (in Bytes) of unions in the message. This attribute is valid for all available Unions in the SOME/IP message. For a granular modeling on the level of Data DataPrototypeTransformationProps shall"
         },
-        "tlvDataId": {
+        "tlvDataIds": {
           "type": "TlvDataIdDefinitionSet",
           "multiplicity": "*",
           "kind": "reference",
@@ -871,7 +871,7 @@
         }
       ],
       "attributes": {
-        "transformationPropsProps": {
+        "transformationPropsPropses": {
           "type": "TransformationProps",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1265,7 +1265,7 @@
         }
       ],
       "attributes": {
-        "tlvDataId": {
+        "tlvDataIds": {
           "type": "TlvDataIdDefinition",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1322,7 +1322,7 @@
           "note": "This reference associates the definition of a TLV data id with a given AbstractImplementationDataTypeElement."
         },
         "tlvRecord": {
-          "type": "ApplicationRecord",
+          "type": "any (ApplicationRecord)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Transformer_InstanceRef.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Transformer_InstanceRef.classes.json
@@ -31,14 +31,14 @@
       ],
       "attributes": {
         "baseInterface": {
-          "type": "SenderReceiver",
+          "type": "any (SenderReceiver)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
           "note": "Stereotypes: atpDerived"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -97,8 +97,8 @@
           "is_ref": false,
           "note": "Stereotypes: atpDerived"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -148,8 +148,8 @@
         }
       ],
       "attributes": {
-        "context": {
-          "type": "AbstractImplementation",
+        "contexts": {
+          "type": "any (AbstractImplementation)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -210,8 +210,8 @@
           "is_ref": false,
           "note": "Stereotypes: atpAbstract"
         },
-        "contextData": {
-          "type": "ApplicationComposite",
+        "contextDatas": {
+          "type": "any (ApplicationComposite)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols.classes.json
@@ -34,14 +34,14 @@
         }
       ],
       "attributes": {
-        "doIpLogicAddressAddress": {
+        "doIpLogicAddressAddresses": {
           "type": "DoIpLogicAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of logical DoIP Addresses."
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "DoIpTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -88,7 +88,7 @@
           "note": "The logical DoIP address."
         },
         "doIpLogic": {
-          "type": "AbstractDoIpLogic",
+          "type": "AbstractDoIpLogicAddressProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -231,35 +231,35 @@
         }
       ],
       "attributes": {
-        "pduPool": {
+        "pduPools": {
           "type": "FlexrayTpPduPool",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of FlexRay TP Pdu Pools. atpVariation"
         },
-        "tpAddress": {
+        "tpAddresses": {
           "type": "TpAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TpAddresses."
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "FlexrayTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of FlexRay TP Connection Controls. Stereotypes: atpSplitable; atpVariation"
         },
-        "tpEcu": {
+        "tpEcus": {
           "type": "FlexrayTpEcu",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TP Ecus"
         },
-        "tpNode": {
+        "tpNodes": {
           "type": "FlexrayTpNode",
           "multiplicity": "*",
           "kind": "attribute",
@@ -298,7 +298,7 @@
       ],
       "attributes": {
         "ackType": {
-          "type": "TpAckType",
+          "type": "FrArTpAckType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -431,7 +431,7 @@
           "is_ref": false,
           "note": "TP address for 1:n connections."
         },
-        "receiver": {
+        "receivers": {
           "type": "FlexrayTpNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -504,7 +504,7 @@
         }
       ],
       "attributes": {
-        "nPdu": {
+        "nPdus": {
           "type": "NPdu",
           "multiplicity": "*",
           "kind": "reference",
@@ -542,8 +542,8 @@
         }
       ],
       "attributes": {
-        "connector": {
-          "type": "Communication",
+        "connectors": {
+          "type": "any (Communication)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -647,21 +647,21 @@
         }
       ],
       "attributes": {
-        "tpAddress": {
+        "tpAddresses": {
           "type": "TpAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TpAddresses."
         },
-        "tpChannel": {
+        "tpChannels": {
           "type": "FlexrayArTpChannel",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of FlexRay Autosar Transport Protocol atpVariation"
         },
-        "tpNode": {
+        "tpNodes": {
           "type": "FlexrayArTpNode",
           "multiplicity": "*",
           "kind": "attribute",
@@ -746,7 +746,7 @@
           "note": "This attribute defines the maximal number of wait frames sent for a pending connection. Range is 0..255."
         },
         "maximumMessage": {
-          "type": "MaximumMessage",
+          "type": "MaximumMessageLengthType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -773,7 +773,7 @@
           "is_ref": false,
           "note": "This attribute defines whether segmentation within a 1:n"
         },
-        "nPdu": {
+        "nPdus": {
           "type": "NPdu",
           "multiplicity": "*",
           "kind": "reference",
@@ -822,7 +822,7 @@
           "is_ref": false,
           "note": "This attribute defines the timeout value in seconds for a CF or FF-x (in case of retry) after receiving CF or after sending an FC or AF on the receiver"
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "FlexrayArTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -860,8 +860,8 @@
         }
       ],
       "attributes": {
-        "connector": {
-          "type": "FlexrayCommunication",
+        "connectors": {
+          "type": "any (FlexrayCommunication)",
           "multiplicity": "*",
           "kind": "reference",
           "is_ref": false,
@@ -938,7 +938,7 @@
           "is_ref": false,
           "note": "The source of the TP connection."
         },
-        "target": {
+        "targets": {
           "type": "FlexrayArTpNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -980,35 +980,35 @@
         }
       ],
       "attributes": {
-        "tpAddress": {
+        "tpAddresses": {
           "type": "CanTpAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TP Addresses."
         },
-        "tpChannel": {
+        "tpChannels": {
           "type": "CanTpChannel",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of CAN TP channels. atpVariation"
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "CanTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Senders and receivers of CAN TP messages. because TpNode can vary. atpVariation"
         },
-        "tpEcu": {
+        "tpEcus": {
           "type": "CanTpEcu",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TP Ecus"
         },
-        "tpNode": {
+        "tpNodes": {
           "type": "CanTpNode",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1083,7 +1083,7 @@
       ],
       "attributes": {
         "addressing": {
-          "type": "CanTpAddressing",
+          "type": "CanTpAddressingFormatType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1138,7 +1138,7 @@
           "is_ref": false,
           "note": "This specifies whether or not Sfs, FCs and the last CF"
         },
-        "receiver": {
+        "receivers": {
           "type": "CanTpNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -1146,7 +1146,7 @@
           "note": "The target of the TP connection."
         },
         "taTypeType": {
-          "type": "NetworkTargetAddress",
+          "type": "NetworkTargetAddressType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -1306,7 +1306,7 @@
       ],
       "attributes": {
         "connector": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1382,21 +1382,21 @@
         }
       ],
       "attributes": {
-        "tpAddress": {
+        "tpAddresses": {
           "type": "TpAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TpAddresses."
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "LinTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of LIN TP channels. because TpNode can vary. atpVariation"
         },
-        "tpNode": {
+        "tpNodes": {
           "type": "LinTpNode",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1435,7 +1435,7 @@
       ],
       "attributes": {
         "connector": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -1533,7 +1533,7 @@
           "is_ref": false,
           "note": "TP address for 1:n connections."
         },
-        "receiver": {
+        "receivers": {
           "type": "LinTpNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -1603,7 +1603,7 @@
         }
       ],
       "attributes": {
-        "tpConnection": {
+        "tpConnections": {
           "type": "EthTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1639,7 +1639,7 @@
         }
       ],
       "attributes": {
-        "tpSdu": {
+        "tpSdus": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -1681,14 +1681,14 @@
         }
       ],
       "attributes": {
-        "tpChannel": {
+        "tpChannels": {
           "type": "SomeipTpChannel",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of SomeipTpChannels that are collecting that are valid for a collection of"
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "SomeipTpConnection",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1831,21 +1831,21 @@
         }
       ],
       "attributes": {
-        "tpAddress": {
+        "tpAddresses": {
           "type": "TpAddress",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Collection of TP Adresses."
         },
-        "tpConnection": {
+        "tpConnections": {
           "type": "J1939TpConnection",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Configuration of J1939 TP connections. because TpNode can vary. atpVariation 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "tpNode": {
+        "tpNodes": {
           "type": "J1939TpNode",
           "multiplicity": "*",
           "kind": "attribute",
@@ -1937,7 +1937,7 @@
           "is_ref": false,
           "note": "Set maximum for expected block size (maximum number in TP.CM_RTS)."
         },
-        "receiver": {
+        "receivers": {
           "type": "J1939TpNode",
           "multiplicity": "*",
           "kind": "reference",
@@ -1951,7 +1951,7 @@
           "is_ref": false,
           "note": "Enable support for protocol retry."
         },
-        "tpPg": {
+        "tpPgs": {
           "type": "J1939TpPg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -2014,7 +2014,7 @@
           "is_ref": false,
           "note": "Parameter Group can be triggered by the J1939 request"
         },
-        "sdu": {
+        "sdus": {
           "type": "IPdu",
           "multiplicity": "*",
           "kind": "reference",
@@ -2053,7 +2053,7 @@
       ],
       "attributes": {
         "connector": {
-          "type": "Communication",
+          "type": "any (Communication)",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp.classes.json
@@ -34,7 +34,7 @@
         }
       ],
       "attributes": {
-        "tpConnection": {
+        "tpConnections": {
           "type": "IEEE1722TpConnection",
           "multiplicity": "*",
           "kind": "reference",
@@ -175,7 +175,7 @@
           "is_ref": false,
           "note": "Defines the time offset that is added to the current time at in order to get the \"presentation time\" (in content shall be presented at the"
         },
-        "sdu": {
+        "sdus": {
           "type": "PduTriggering",
           "multiplicity": "*",
           "kind": "reference",
@@ -217,7 +217,7 @@
         }
       ],
       "attributes": {
-        "acfTransported": {
+        "acfTransporteds": {
           "type": "IEEE1722TpAcfBus",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp_IEEE1722TpAcf.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp_IEEE1722TpAcf.classes.json
@@ -36,7 +36,7 @@
         }
       ],
       "attributes": {
-        "acfPart": {
+        "acfParts": {
           "type": "IEEE1722TpAcfBusPart",
           "multiplicity": "*",
           "kind": "attribute",
@@ -88,7 +88,7 @@
       ],
       "attributes": {
         "collectionTrigger": {
-          "type": "PduCollectionTrigger",
+          "type": "PduCollectionTriggerEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": true,
@@ -166,7 +166,7 @@
       ],
       "attributes": {
         "canAddressing": {
-          "type": "CanAddressingMode",
+          "type": "CanAddressingModeType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -180,7 +180,7 @@
           "note": "Defines whether the bit rate switch bit shall be set."
         },
         "canFrameTxBehavior": {
-          "type": "CanFrameTxBehavior",
+          "type": "CanFrameTxBehaviorEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp_IEEE1722TpAv.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_TransportProtocols_IEEE1722Tp_IEEE1722TpAv.classes.json
@@ -43,14 +43,14 @@
           "note": "CRF base frequency in Hz."
         },
         "crfPullEnum": {
-          "type": "IEEE1722TpCrfPull",
+          "type": "IEEE1722TpCrfPullEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of the CRF stream pull value."
         },
         "crfTypeEnum": {
-          "type": "IEEE1722TpCrfType",
+          "type": "IEEE1722TpCrfTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -107,21 +107,21 @@
       ],
       "attributes": {
         "aafAes3Data": {
-          "type": "IEEE1722TpAafAes3",
+          "type": "IEEE1722TpAafAes3DataTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of the AAF AES3 stream aes3_data_type reference."
         },
         "aafFormatEnum": {
-          "type": "IEEE1722TpAafFormat",
+          "type": "IEEE1722TpAafFormatEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of the AAF stream format."
         },
         "aafNominalRate": {
-          "type": "IEEE1722TpAaf",
+          "type": "any (IEEE1722TpAaf)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -312,7 +312,7 @@
           "note": "Definition of the RVF stream active_pixels."
         },
         "rvfColorSpace": {
-          "type": "IEEE1722TpRvfColor",
+          "type": "IEEE1722TpRvfColorSpaceEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -326,7 +326,7 @@
           "note": "Definition of the RVF stream event (evt) default value."
         },
         "rvfFrameRate": {
-          "type": "IEEE1722TpRvfFrame",
+          "type": "IEEE1722TpRvfFrameRateEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -340,14 +340,14 @@
           "note": "Defines the RVF stream interlaced (i)."
         },
         "rvfPixelDepth": {
-          "type": "IEEE1722TpRvfPixel",
+          "type": "any (IEEE1722TpRvfPixel)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Definition of the RVF stream pixel_depth. atp.Status=candidate"
         },
         "rvfPixelFormat": {
-          "type": "IEEE1722TpRvfPixel",
+          "type": "any (IEEE1722TpRvfPixel)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_AdminData.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_AdminData.classes.json
@@ -53,7 +53,7 @@
         }
       ],
       "attributes": {
-        "docRevision": {
+        "docRevisions": {
           "type": "DocRevision",
           "multiplicity": "*",
           "kind": "attribute",
@@ -115,7 +115,7 @@
           "is_ref": false,
           "note": "This is the name of an individual or an organization who"
         },
-        "modification": {
+        "modifications": {
           "type": "Modification",
           "multiplicity": "*",
           "kind": "attribute",
@@ -179,14 +179,14 @@
       ],
       "attributes": {
         "change": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This property denotes the one particular change which performed on the object."
         },
         "reason": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_BaseTypes.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_BaseTypes.classes.json
@@ -171,7 +171,7 @@
       ],
       "attributes": {
         "baseTypeEncoding": {
-          "type": "BaseTypeEncoding",
+          "type": "BaseTypeEncodingString",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json
@@ -272,7 +272,7 @@
           "note": "This represents the computation details of the scale."
         },
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -342,7 +342,7 @@
         }
       ],
       "attributes": {
-        "compuScale": {
+        "compuScales": {
           "type": "CompuScale",
           "multiplicity": "*",
           "kind": "attribute",
@@ -496,7 +496,7 @@
           "note": "This is the denominator of the expression."
         },
         "compu": {
-          "type": "CompuNominator",
+          "type": "CompuNominatorDenominator",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_Constraints_GlobalConstraints.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_Constraints_GlobalConstraints.classes.json
@@ -54,7 +54,7 @@
         }
       ],
       "attributes": {
-        "dataConstrRule": {
+        "dataConstrRules": {
           "type": "DataConstrRule",
           "multiplicity": "*",
           "kind": "attribute",
@@ -178,7 +178,7 @@
           "is_ref": false,
           "note": "This specifies the monotony constraints on the data"
         },
-        "scaleConstr": {
+        "scaleConstrs": {
           "type": "ScaleConstr",
           "multiplicity": "*",
           "kind": "attribute",
@@ -255,7 +255,7 @@
           "is_ref": false,
           "note": "This element specifies the monotony characteristics of"
         },
-        "scaleConstr": {
+        "scaleConstrs": {
           "type": "ScaleConstr",
           "multiplicity": "*",
           "kind": "attribute",
@@ -299,7 +299,7 @@
       ],
       "attributes": {
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -327,7 +327,7 @@
           "note": "This specifies the upper limit of a the scale."
         },
         "validity": {
-          "type": "ScaleConstrValidity",
+          "type": "any (ScaleConstrValidity)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
@@ -167,7 +167,7 @@
       ],
       "attributes": {
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -216,7 +216,7 @@
           "note": "This is the value of the special data."
         },
         "xmlSpace": {
-          "type": "XmlSpaceEnum",
+          "type": "any (XmlSpaceEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_AsamHdo_Units.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_Units.classes.json
@@ -52,7 +52,7 @@
       ],
       "attributes": {
         "displayName": {
-          "type": "SingleLanguageUnit",
+          "type": "SingleLanguageUnitNames",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -119,7 +119,7 @@
         }
       ],
       "attributes": {
-        "unit": {
+        "units": {
           "type": "Unit",
           "multiplicity": "*",
           "kind": "reference",
@@ -285,7 +285,7 @@
         }
       ],
       "attributes": {
-        "physical": {
+        "physicals": {
           "type": "PhysicalDimension",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_MSR_CalibrationData_CalibrationValue.classes.json
+++ b/docs/json/packages/M2_MSR_CalibrationData_CalibrationValue.classes.json
@@ -49,7 +49,7 @@
           "note": "This represents the physical unit of the provided values."
         },
         "unitDisplay": {
-          "type": "SingleLanguageUnit",
+          "type": "SingleLanguageUnitNames",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -84,7 +84,7 @@
       ],
       "attributes": {
         "category": {
-          "type": "CalprmAxisCategory",
+          "type": "CalprmAxisCategoryEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -119,7 +119,7 @@
           "note": "This represents the physical unit of the provided values."
         },
         "unitDisplay": {
-          "type": "SingleLanguageUnit",
+          "type": "SingleLanguageUnitNames",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -219,7 +219,7 @@
       ],
       "attributes": {
         "label": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_AuxillaryObjects.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_AuxillaryObjects.classes.json
@@ -49,13 +49,13 @@
       ],
       "attributes": {
         "memory": {
-          "type": "MemoryAllocation",
+          "type": "MemoryAllocationKeywordPolicyType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Enumeration to specify the name pattern of the Memory Allocation Keyword. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
-        "option": {
+        "options": {
           "type": "Identifier",
           "multiplicity": "*",
           "kind": "attribute",
@@ -63,7 +63,7 @@
           "note": "This attribute introduces the ability to specify further"
         },
         "section": {
-          "type": "SectionInitialization",
+          "type": "SectionInitializationPolicyType",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_Axis.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_Axis.classes.json
@@ -43,7 +43,7 @@
           "note": "Refers to constraints, e.g. for plausibility checks."
         },
         "inputVariable": {
-          "type": "ApplicationPrimitive",
+          "type": "ApplicationPrimitiveDataType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -70,7 +70,7 @@
           "is_ref": false,
           "note": "Minimum number of base points contained in the axis of a"
         },
-        "swVariableRefProxy": {
+        "swVariableRefProxies": {
           "type": "SwVariableRefProxy",
           "multiplicity": "*",
           "kind": "attribute",
@@ -119,7 +119,7 @@
           "is_ref": false,
           "note": "Associated axis calculation strategy."
         },
-        "swGenericAxisParam": {
+        "swGenericAxisParams": {
           "type": "SwGenericAxisParam",
           "multiplicity": "*",
           "kind": "attribute",
@@ -167,7 +167,7 @@
           "is_ref": false,
           "note": "Associated axis description in textual form. xml.sequenceOffset=20 1228 Document ID 62: AUTOSAR_CP_TPS_SoftwareComponentTemplate Template R23-11"
         },
-        "swGenericAxisParam": {
+        "swGenericAxisParams": {
           "type": "SwGenericAxisParam",
           "multiplicity": "*",
           "kind": "attribute",
@@ -277,7 +277,7 @@
       ],
       "attributes": {
         "sharedAxisType": {
-          "type": "ApplicationPrimitive",
+          "type": "ApplicationPrimitiveDataType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_CalibrationParameter.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_CalibrationParameter.classes.json
@@ -27,7 +27,7 @@
         }
       ],
       "attributes": {
-        "swCalprmAxis": {
+        "swCalprmAxises": {
           "type": "SwCalprmAxis",
           "multiplicity": "*",
           "kind": "attribute",
@@ -63,7 +63,7 @@
       ],
       "attributes": {
         "category": {
-          "type": "CalprmAxisCategory",
+          "type": "CalprmAxisCategoryEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -84,14 +84,14 @@
           "note": "This attribute specifies which axis is specified by the in a curve this is usually \"1\". In a map this is \"2\"."
         },
         "swCalibrationAccess": {
-          "type": "SwCalibrationAccess",
+          "type": "SwCalibrationAccessEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Describes the applicability of parameters and variables. Tags: xml.sequenceOffset=90"
         },
         "swCalprmAxis": {
-          "type": "SwCalprmAxisType",
+          "type": "SwCalprmAxisTypeProps",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.classes.json
@@ -169,7 +169,7 @@
           "is_ref": false,
           "note": "This attribute is used to declare native qualifiers of the language which can neither be deduced baseType (e.g. because the data object pointer) nor from other more abstract are qualifiers like \"volatile\", \"strict\" or the C-language. All such declarations have to into one string."
         },
-        "annotation": {
+        "annotations": {
           "type": "Annotation",
           "multiplicity": "*",
           "kind": "attribute",
@@ -205,7 +205,7 @@
           "note": "This property describes how a number is to be rendered documents or in a measurement and calibration"
         },
         "display": {
-          "type": "DisplayPresentation",
+          "type": "DisplayPresentationEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -254,7 +254,7 @@
           "note": "Description of the binary representation in case of a bit"
         },
         "swCalibrationAccess": {
-          "type": "SwCalibrationAccess",
+          "type": "SwCalibrationAccessEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -267,7 +267,7 @@
           "is_ref": true,
           "note": "This specifies the properties of the axes in case of a or map etc. This is mainly applicable to calibration"
         },
-        "swComparison": {
+        "swComparisons": {
           "type": "SwVariableRefProxy",
           "multiplicity": "*",
           "kind": "attribute",
@@ -344,7 +344,7 @@
           "is_ref": false,
           "note": "the specific properties if the data object is a text object."
         },
-        "swValueBlock": {
+        "swValueBlocks": {
           "type": "Numerical",
           "multiplicity": "*",
           "kind": "attribute",
@@ -359,7 +359,7 @@
           "note": "Physical unit associated with the semantics of this data"
         },
         "valueAxisData": {
-          "type": "ApplicationPrimitive",
+          "type": "ApplicationPrimitiveDataType",
           "multiplicity": "0..1",
           "kind": "reference",
           "is_ref": false,
@@ -412,7 +412,7 @@
       ],
       "attributes": {
         "arraySize": {
-          "type": "ArraySizeSemantics",
+          "type": "ArraySizeSemanticsEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_RecordLayout.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_RecordLayout.classes.json
@@ -82,7 +82,7 @@
           "note": "This association allows to refer to a base type in case a is intended. If no base type is referred, type referenced initially in the corresponding to be used."
         },
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -145,14 +145,14 @@
       ],
       "attributes": {
         "category": {
-          "type": "AsamRecordLayout",
+          "type": "AsamRecordLayoutSemantics",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute denotes the semantics in particular in terms the corresponding A2L-Keyword. This is to support the the more general record layouts in AUTOSAR/ the specific A2l keywords. possible to express the specific semantics of A2l in swRecordlayoutGroup but not versa. Therefore the mapping is provided in attribute."
         },
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -173,7 +173,7 @@
           "note": "This association allows to specify record layout groups to iterate over generic axis parameters. For example, if the parameter is an array, the record layout iterate over this array. axis referred to by swRecordLayoutGroup be a generic axis in which the referenced Sw aggregated."
         },
         "swRecord": {
-          "type": "RecordLayoutIterator",
+          "type": "RecordLayoutIteratorPoint",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_DataDictionary_ServiceProcessTask.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_ServiceProcessTask.classes.json
@@ -56,7 +56,7 @@
       ],
       "attributes": {
         "direction": {
-          "type": "ArgumentDirection",
+          "type": "ArgumentDirectionEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements.classes.json
@@ -132,7 +132,7 @@
           "note": "This represents a note in the text flow."
         },
         "p": {
-          "type": "MultiLanguage",
+          "type": "any (MultiLanguage)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -192,7 +192,7 @@
       ],
       "attributes": {
         "desc": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_Figure.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_Figure.classes.json
@@ -492,7 +492,7 @@
           "is_ref": false,
           "note": "This specifies an entry point in an online help system to"
         },
-        "lGraphic": {
+        "lGraphics": {
           "type": "LGraphic",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_Formula.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_Formula.classes.json
@@ -51,7 +51,7 @@
           "is_ref": false,
           "note": "this rpresents the semantic and mathematical are processed by a math-processor."
         },
-        "lGraphic": {
+        "lGraphics": {
           "type": "LGraphic",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_GerneralParameters.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_GerneralParameters.classes.json
@@ -30,14 +30,14 @@
       ],
       "attributes": {
         "label": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This represents the caption of the parameter table. xml.sequenceOffset=20 topic1 is given to remain compatible with [22] 535 Document ID 202: AUTOSAR_FO_TPS_GenericStructureTemplate Template R23-11"
         },
         "prm": {
-          "type": "GeneralParameter",
+          "type": "any (GeneralParameter)",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_ListElements.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_ListElements.classes.json
@@ -169,7 +169,7 @@
           "note": "This represents the actual content of the item. It is a DocumentationBlock. This way it is use simple paragraphs to nested lists, or notes."
         },
         "itemLabel": {
-          "type": "MultiLanguageOverview",
+          "type": "MultiLanguageOverviewParagraph",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_Note.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_Note.classes.json
@@ -30,7 +30,7 @@
       ],
       "attributes": {
         "label": {
-          "type": "MultilanguageLong",
+          "type": "MultilanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_OasisExchangeTable.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_OasisExchangeTable.classes.json
@@ -59,7 +59,7 @@
           "note": "This specifies an entry point in an online help system to"
         },
         "orient": {
-          "type": "OrientEnum",
+          "type": "any (OrientEnum)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -142,7 +142,7 @@
           "is_ref": false,
           "note": "Indicates if by default a line shall be drawn between the this table group."
         },
-        "colspec": {
+        "colspecs": {
           "type": "Colspec",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_RequirementsTracing.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_RequirementsTracing.classes.json
@@ -50,7 +50,7 @@
         }
       ],
       "attributes": {
-        "appliesTo": {
+        "appliesTos": {
           "type": "StandardNameEnum",
           "multiplicity": "*",
           "kind": "attribute",
@@ -120,7 +120,7 @@
           "is_ref": false,
           "note": "This represents an informal specification of the material."
         },
-        "testedItem": {
+        "testedItems": {
           "type": "Traceable",
           "multiplicity": "*",
           "kind": "reference",
@@ -234,7 +234,7 @@
         }
       ],
       "attributes": {
-        "trace": {
+        "traces": {
           "type": "Traceable",
           "multiplicity": "*",
           "kind": "reference",

--- a/docs/json/packages/M2_MSR_Documentation_Chapters.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_Chapters.classes.json
@@ -154,7 +154,7 @@
           "note": "This is a parameter table within a chapter."
         },
         "topicContentOrMsr": {
-          "type": "TopicContentOrMsr",
+          "type": "TopicContentOrMsrQuery",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -237,7 +237,7 @@
           "note": "This specifies an entry point in an online help system to"
         },
         "topicContentOrMsr": {
-          "type": "TopicContentOrMsr",
+          "type": "TopicContentOrMsrQuery",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -414,7 +414,7 @@
           "note": "This represents a table within a topic. atpVariation"
         },
         "traceableTable": {
-          "type": "TraceableTable",
+          "type": "any (TraceableTable)",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_MsrQuery.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_MsrQuery.classes.json
@@ -169,7 +169,7 @@
           "is_ref": false,
           "note": "This element contains a commentary in text form."
         },
-        "msrQueryArg": {
+        "msrQueryArgs": {
           "type": "MsrQueryArg",
           "multiplicity": "*",
           "kind": "attribute",
@@ -253,7 +253,7 @@
         }
       ],
       "attributes": {
-        "chapter": {
+        "chapters": {
           "type": "Chapter",
           "multiplicity": "*",
           "kind": "attribute",

--- a/docs/json/packages/M2_MSR_Documentation_TextModel_InlineTextElements.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_TextModel_InlineTextElements.classes.json
@@ -203,7 +203,7 @@
           "note": "This represents the subtitle of the standard."
         },
         "url": {
-          "type": "Url",
+          "type": "any (Url)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -328,7 +328,7 @@
           "note": "This represents version and state of the external"
         },
         "url": {
-          "type": "Url",
+          "type": "any (Url)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -379,7 +379,7 @@
           "note": "This element describes the tool version which was used"
         },
         "url": {
-          "type": "Url",
+          "type": "any (Url)",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -416,7 +416,7 @@
       ],
       "attributes": {
         "label1": {
-          "type": "SingleLanguageLong",
+          "type": "SingleLanguageLongName",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -444,42 +444,42 @@
           "note": "Indicates if the content of the xref element shall be default is \"NO-SHOW-CONTENT\"."
         },
         "showResourceAlias": {
-          "type": "ShowResourceAlias",
+          "type": "ShowResourceAliasNameEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This indicates if the alias names of the referenced objects shall be rendered. This means this is some kind of look whether there is an alias for the if yes, print it. is more than one AliasNameSet, Xref might of those. alias is found and showResourceShortName is set to the shortName of the reference be displayed. By this showResourceAlias similar to showResourceShortName but shows instead of the shortName. NO-SHOW-ALIAS-NAME."
         },
         "showResource": {
-          "type": "ShowResourceType",
+          "type": "ShowResourceTypeEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates if the type of the referenced Resource shall be shown. Default is \"SHOW-TYPE\""
         },
         "showResourceLong": {
-          "type": "ShowResourceLong",
+          "type": "ShowResourceLongNameEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates if the longName of the referenced resource shall be rendered. Default is \"SHOW-LONG-NAME\"."
         },
         "showResourceNumber": {
-          "type": "ShowResourceNumber",
+          "type": "ShowResourceNumberEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates if the Number of the referenced resource shall be shown. Default is \"SHOW–NUMBER\""
         },
         "showResourcePage": {
-          "type": "ShowResourcePage",
+          "type": "ShowResourcePageEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Indicates if the page number of the referenced resource shall be shown. Default is \"SHOW-PAGE\""
         },
         "showResourceShort": {
-          "type": "ShowResourceShort",
+          "type": "ShowResourceShortNameEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_MSR_Documentation_TextModel_LanguageDataModel.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_TextModel_LanguageDataModel.classes.json
@@ -72,7 +72,7 @@
       ],
       "attributes": {
         "xmlSpace": {
-          "type": "XmlSpaceEnum",
+          "type": "any (XmlSpaceEnum)",
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,


### PR DESCRIPTION
- Correct singular attribute names to plural form for consistency
- Changes include: attribute->attributes, command->commands, indication->indications, etc.
- Affects 195 JSON documentation files in docs/json/packages/
- Ensures naming convention matches AUTOSAR model structure