### PR TITLE
fix: Remove duplicate CI triggers on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop, feature/** ]
+    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
 


### PR DESCRIPTION
## Summary

- Remove `feature/**` from push trigger to avoid duplicate CI runs
- CI now runs on:
  - Push to `main`/`develop` branches (protects main/develop)
  - Pull requests to `main`/`develop` (pre-merge validation)

## Problem

Previously, the CI workflow triggered on both:
1. Push to `feature/**` branches
2. Pull requests to `main`/`develop`

This caused duplicate CI runs when:
1. Developer pushes to `feature/xyz` branch → CI runs (1st time)
2. Developer creates PR from `feature/xyz` → CI runs again (2nd time)

## Solution

Remove `feature/**` from the push trigger. Now:
- Feature branch code is only tested when creating a PR
- Direct commits to `main`/`develop` are still protected
- No more duplicate runs

## Test Plan

- [x] Workflow syntax is valid
- [x] Feature branch created and pushed
- [ ] CI passes on this PR
- [ ] After merge, verify CI runs on future PRs but not on feature branch pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)