### PR TITLE
fix: Restore correct generators.py after merge conflict resolution

### DIFF
--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection/collection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection/collection.py
@@ -95,6 +95,8 @@ class Collection(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize collected_instance_irefs (list of instance references with wrapper "COLLECTED-INSTANCE-IREF")
+        if self.collected_instance_irefs:
             serialized = ARObject._serialize_item(self.collected_instance_irefs, "AnyInstanceRef")
             if serialized is not None:
                 # Wrap in IREF wrapper element
@@ -165,6 +167,8 @@ class Collection(ARElement):
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
+        # Serialize source_instance_irefs (list of instance references with wrapper "SOURCE-INSTANCES-IREF")
+        if self.source_instance_irefs:
             serialized = ARObject._serialize_item(self.source_instance_irefs, "AnyInstanceRef")
             if serialized is not None:
                 # Wrap in IREF wrapper element

--- a/tools/generate_models/generators.py
+++ b/tools/generate_models/generators.py
@@ -1752,16 +1752,26 @@ def _generate_serialize_method(
                 should_flatten = attr_type in flattened_iref_types
 
                 iref_wrapper_tag = f"{xml_tag}-IREF"
-                
-                # For list types (multiplicity "*"), check if list is not empty
-                # For single types (multiplicity "0..1" or "1"), check if not None
-                if multiplicity == "*":
-                    condition = f"self.{python_name} and len(self.{python_name}) > 0"
-                else:
-                    condition = f"self.{python_name} is not None"
-                
                 if should_flatten:
                     # Flattened type: flatten children directly into iref wrapper
+                    if multiplicity == "*":
+                        # List type - check if not empty
+                        code += f'''        # Serialize {python_name} (list of instance references with wrapper "{iref_wrapper_tag}")
+        if self.{python_name}:
+            serialized = ARObject._serialize_item(self.{python_name}, "{effective_type}")
+            if serialized is not None:
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("{iref_wrapper_tag}")
+                # Flatten: append children of serialized element directly to iref wrapper
+                for child in serialized:
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
+
+'''
+                    else:
+                        # Single item type
+                        code += f'''        # Serialize {python_name} (instance reference with wrapper "{iref_wrapper_tag}")
+        if self.{python_name} is not None:
             serialized = ARObject._serialize_item(self.{python_name}, "{effective_type}")
             if serialized is not None:
                 # Wrap in IREF wrapper element
@@ -1774,6 +1784,23 @@ def _generate_serialize_method(
 '''
                 else:
                     # Non-flattened type: wrap in its own element
+                    if multiplicity == "*":
+                        # List type - check if not empty
+                        code += f'''        # Serialize {python_name} (list of instance references with wrapper "{iref_wrapper_tag}")
+        if self.{python_name}:
+            serialized = ARObject._serialize_item(self.{python_name}, "{effective_type}")
+            if serialized is not None:
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("{iref_wrapper_tag}")
+                # Append the serialized element as a child (don't flatten it)
+                iref_wrapper.append(serialized)
+                elem.append(iref_wrapper)
+
+'''
+                    else:
+                        # Single item type
+                        code += f'''        # Serialize {python_name} (instance reference with wrapper "{iref_wrapper_tag}")
+        if self.{python_name} is not None:
             serialized = ARObject._serialize_item(self.{python_name}, "{effective_type}")
             if serialized is not None:
                 # Wrap in IREF wrapper element


### PR DESCRIPTION
## Summary

This PR fixes a critical issue introduced during the merge of PR #76, where the merge conflict resolution left `generators.py` with syntax errors.

## Problem

The merge commit `6111f36b` had incorrectly resolved merge conflicts in `generators.py`, resulting in:
- Syntax errors throughout the IREF wrapper serialization code
- 5 failing binary comparison tests
- Broken code generation logic

## Root Cause

During the merge of `main` into the feature branch, the conflict resolution corrupted the code structure, leaving malformed Python code with incorrect indentation and incomplete f-strings.

## Solution

This PR restores the correct version of `generators.py` from commit `a94cefbf` (before the problematic merge), ensuring:
- Proper IREF wrapper serialization for list types
- Correct Python syntax throughout
- All binary comparison tests passing

## Test Results

Before fix:
```
5 failed, 206 passed, 20 skipped, 1 xfailed
```

After fix:
```
211 passed, 20 skipped, 1 xfailed
```

## Files Modified

- `tools/generate_models/generators.py` - Restored correct version
- `src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection/collection.py` - Regenerated with fixed generator

**Impact**: 2 files changed, 39 insertions(+), 8 deletions(-)

## Related Issues

Fixes critical regression introduced in merge of #75