### PR TITLE
feat: Add ref_conditional pattern support to @atp_variant decorator

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
@@ -322,6 +322,7 @@
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
+          "decorator": "atp_variant:ref_conditional",
           "note": "The underlying BswModuleEntry. xml.sequenceOffset=5"
         },
         "isReentrant": {

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py
@@ -8,6 +8,7 @@ JSON Source: docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfa
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
+from armodel.serialization.decorators import atp_variant
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.referrable import (
     Referrable,
@@ -44,6 +45,17 @@ class BswModuleClientServerEntry(Referrable):
         self.encapsulated_entry_ref: Optional[ARRef] = None
         self.is_reentrant: Optional[Boolean] = None
         self.is_synchronous: Optional[Boolean] = None
+    @property
+    @atp_variant("ref_conditional")
+    def encapsulated_entry_ref(self) -> Optional[ARRef]:
+        """Get encapsulated_entry_ref with atp_variant pattern (ref_conditional)."""
+        return self._encapsulated_entry_ref
+
+    @encapsulated_entry_ref.setter
+    def encapsulated_entry_ref(self, value: Optional[ARRef]) -> None:
+        """Set encapsulated_entry_ref with atp_variant pattern (ref_conditional)."""
+        self._encapsulated_entry_ref = value
+
 
     def serialize(self) -> ET.Element:
         """Serialize BswModuleClientServerEntry to XML element.
@@ -69,18 +81,13 @@ class BswModuleClientServerEntry(Referrable):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize encapsulated_entry_ref
+        # Serialize encapsulated_entry_ref with ref_conditional pattern
         if self.encapsulated_entry_ref is not None:
             serialized = SerializationHelper.serialize_item(self.encapsulated_entry_ref, "BswModuleEntry")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("ENCAPSULATED-ENTRY-REF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
+                # Wrap reference in REF-CONDITIONAL element
+                ref_tag = SerializationHelper.get_ref_tag_from_type("BswModuleEntry")
+                wrapped = SerializationHelper.serialize_ref_conditional(serialized, ref_tag)
                 elem.append(wrapped)
 
         # Serialize is_reentrant
@@ -126,9 +133,11 @@ class BswModuleClientServerEntry(Referrable):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(BswModuleClientServerEntry, cls).deserialize(element)
 
-        # Parse encapsulated_entry_ref
-        child = SerializationHelper.find_child_element(element, "ENCAPSULATED-ENTRY-REF")
-        if child is not None:
+        # Parse encapsulated_entry_ref from REF-CONDITIONAL wrapper
+        ref_elems = SerializationHelper.deserialize_ref_conditional(element, "BSW-MODULE-ENTRY-REF")
+        if ref_elems:
+            # Take the first reference (single value)
+            child = ref_elems[0]
             encapsulated_entry_ref_value = ARRef.deserialize(child)
             obj.encapsulated_entry_ref = encapsulated_entry_ref_value
 

--- a/src/armodel/serialization/decorators.py
+++ b/src/armodel/serialization/decorators.py
@@ -27,32 +27,38 @@ def xml_attribute(func: Any) -> Any:
     return func
 
 
-def atp_variant() -> Callable[[Any], Any]:
-    """Decorator to mark a class as using AUTOSAR atpVariation pattern.
+def atp_variant(variant_type: str = "default") -> Callable[[Any], Any]:
+    """Decorator to mark a class/attribute as using AUTOSAR atpVariation pattern.
 
-    Classes with atpVariation wrap all their attributes in nested XML elements.
-    The wrapper path is automatically derived from the class name using AUTOSAR convention:
-    - First level: <CLASS-TAG>-VARIANTS
-    - Second level: <CLASS-TAG>-CONDITIONAL
+    Classes with atpVariation wrap their content in nested XML elements.
+    The variant_type parameter determines the wrapper pattern:
+    - "default" (class-level): Two-level wrapper <CLASS-TAG>-VARIANTS/<CLASS-TAG>-CONDITIONAL
+    - "ref_conditional" (attribute-level): Single-level <REF-TAG>-CONDITIONAL for references
 
-    Usage:
+    Usage (class-level - default pattern):
         @atp_variant()
         class SwDataDefProps(ARObject):
             base_type_ref: Optional[ARRef] = None
             sw_calibration_access: Optional[SwCalibrationAccessEnum] = None
 
-    Generates wrapper path: "SW-DATA-DEF-PROPS-VARIANTS/SW-DATA-DEF-PROPS-CONDITIONAL"
+        Generates: <SW-DATA-DEF-PROPS-VARIANTS><SW-DATA-DEF-PROPS-CONDITIONAL>...attributes...</SW-DATA-DEF-PROPS-CONDITIONAL></SW-DATA-DEF-PROPS-VARIANTS>
 
-    The ARObject serialization framework automatically:
-    1. Creates the nested wrapper elements during serialization
-    2. Navigates through wrapper elements during deserialization
+    Usage (attribute-level - ref_conditional pattern):
+        @atp_variant("ref_conditional")
+        encapsulated_entry: Optional[ARRef] = None
+
+        Generates: <BSW-MODULE-ENTRY-REF-CONDITIONAL><BSW-MODULE-ENTRY-REF>...</BSW-MODULE-ENTRY-REF></BSW-MODULE-ENTRY-REF-CONDITIONAL>
+
+    Args:
+        variant_type: Pattern type - "default" (VARIANTS/CONDITIONAL) or "ref_conditional" (REF-CONDITIONAL)
 
     Returns:
-        Decorator that sets _atp_variant flag on the class
+        Decorator that sets _atp_variant flag and _atp_variant_type on the class/attribute
     """
-    def decorator(cls: Any) -> Any:
-        cls._atp_variant = True  # type: ignore[union-attr]
-        return cls
+    def decorator(obj: Any) -> Any:
+        obj._atp_variant = True  # type: ignore[union-attr]
+        obj._atp_variant_type = variant_type  # type: ignore[union-attr]
+        return obj
     return decorator
 
 

--- a/tools/generate_models/generators.py
+++ b/tools/generate_models/generators.py
@@ -206,6 +206,17 @@ def generate_class_code(
         if atp_type == "atpVariation":
             decorator_import += "from armodel.serialization.decorators import atp_variant\n"
         
+        # Check if this class has atp_variant decorated attributes
+        has_atp_variant_attr = False
+        if attribute_types:
+            for attr_name, attr_info in attribute_types.items():
+                decorator_name = attr_info.get("decorator_name")
+                if decorator_name == "atp_variant":
+                    has_atp_variant_attr = True
+                    break
+        if has_atp_variant_attr:
+            decorator_import += "from armodel.serialization.decorators import atp_variant\n"
+        
         # Check if this class has l_prefix attributes
         has_l_prefix = False
         if attribute_types:
@@ -617,6 +628,25 @@ class {class_name}(ABC):
         self.{private_name} = value
 
 '''
+            elif decorator_name == "atp_variant":
+                python_name = get_python_identifier_with_ref(attr_name, is_ref, multiplicity, kind)
+                private_name = f"_{python_name}"
+                params = attr_info.get("decorator_params", "default")
+                # Determine Python type for this attribute
+                python_type = get_python_type(attr_type, multiplicity, package_data, is_ref, kind)
+                # Generate property with atp_variant decorator
+                code += f'''    @property
+    @atp_variant("{params}")
+    def {python_name}(self) -> {python_type}:
+        """Get {python_name} with atp_variant pattern ({params})."""
+        return self.{private_name}
+
+    @{python_name}.setter
+    def {python_name}(self, value: {python_type}) -> None:
+        """Set {python_name} with atp_variant pattern ({params})."""
+        self.{private_name} = value
+
+'''
             elif kind == "l_prefix":
                 python_name = get_python_identifier_with_ref(attr_name, is_ref, multiplicity, kind)
                 private_name = f"_{python_name}"
@@ -918,7 +948,35 @@ def _generate_deserialize_method(
 '''
                     else:
                         # Regular non-container list
-                        code += f'''        # Parse {python_name} (list)
+                        # Get decorator_name before generating code
+                        attr_decorator_name = attr_info.get("decorator_name")
+                        if attr_decorator_name == "atp_variant":
+                            params = attr_info.get("decorator_params", "default")
+                            if params == "ref_conditional":
+                                # Derive ref_tag from target type and embed in generated code
+                                from armodel.serialization.name_converter import NameConverter
+                                type_tag = NameConverter.to_xml_tag(attr_type)
+                                ref_tag = f"{type_tag}-REF"
+                                code += f'''        # Parse {python_name} (list from REF-CONDITIONAL wrappers)
+        obj.{python_name} = []
+        ref_elems = SerializationHelper.deserialize_ref_conditional(element, "{ref_tag}")
+        for child in ref_elems:
+            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+            obj.{python_name}.append({python_name}_value)
+
+'''
+                            else:
+                                # Default atp_variant pattern (not implemented for attributes yet)
+                                code += f'''        # Parse {python_name} (list)
+        obj.{python_name} = []
+        for child in SerializationHelper.find_all_child_elements(element, "{xml_tag}"):
+            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+            obj.{python_name}.append({python_name}_value)
+
+'''
+                        else:
+                            # Normal list parsing
+                            code += f'''        # Parse {python_name} (list)
         obj.{python_name} = []
         for child in SerializationHelper.find_all_child_elements(element, "{xml_tag}"):
             {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
@@ -927,7 +985,36 @@ def _generate_deserialize_method(
 '''
             else:
                 # Single value type
-                code += f'''        # Parse {python_name}
+                # Get decorator_name before generating code
+                attr_decorator_name = attr_info.get("decorator_name")
+                if attr_decorator_name == "atp_variant":
+                    params = attr_info.get("decorator_params", "default")
+                    if params == "ref_conditional":
+                        # Derive ref_tag from target type and embed in generated code
+                        from armodel.serialization.name_converter import NameConverter
+                        type_tag = NameConverter.to_xml_tag(attr_type)
+                        ref_tag = f"{type_tag}-REF"
+                        code += f'''        # Parse {python_name} from REF-CONDITIONAL wrapper
+        ref_elems = SerializationHelper.deserialize_ref_conditional(element, "{ref_tag}")
+        if ref_elems:
+            # Take the first reference (single value)
+            child = ref_elems[0]
+            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+            obj.{python_name} = {python_name}_value
+
+'''
+                    else:
+                        # Default atp_variant pattern (not implemented for attributes yet)
+                        code += f'''        # Parse {python_name}
+        child = SerializationHelper.find_child_element(element, "{xml_tag}")
+        if child is not None:
+            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+            obj.{python_name} = {python_name}_value
+
+'''
+                else:
+                    # Normal single value type
+                    code += f'''        # Parse {python_name}
         child = SerializationHelper.find_child_element(element, "{xml_tag}")
         if child is not None:
             {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
@@ -2464,7 +2551,34 @@ def _generate_serialize_method(
 '''
             else:
                 # Single value type
-                code += f'''        # Serialize {python_name}
+                # Get decorator_name before generating code
+                attr_decorator_name = attr_info.get("decorator_name")
+                if attr_decorator_name == "atp_variant":
+                    params = attr_info.get("decorator_params", "default")
+                    if params == "ref_conditional":
+                        # Derive ref_tag from target type and embed in generated code
+                        code += f'''        # Serialize {python_name} with ref_conditional pattern
+        if self.{python_name} is not None:
+            serialized = SerializationHelper.serialize_item(self.{python_name}, "{effective_type}")
+            if serialized is not None:
+                # Wrap reference in REF-CONDITIONAL element
+                ref_tag = SerializationHelper.get_ref_tag_from_type("{attr_type}")
+                wrapped = SerializationHelper.serialize_ref_conditional(serialized, ref_tag)
+                elem.append(wrapped)
+
+'''
+                    else:
+                        # Default atp_variant pattern (not implemented for attributes yet)
+                        code += f'''        # Serialize {python_name}
+        if self.{python_name} is not None:
+            serialized = SerializationHelper.serialize_item(self.{python_name}, "{effective_type}")
+            if serialized is not None:
+                elem.append(serialized)
+
+'''
+                else:
+                    # Normal single value type
+                    code += f'''        # Serialize {python_name}
         if self.{python_name} is not None:
             serialized = SerializationHelper.serialize_item(self.{python_name}, "{effective_type}")
             if serialized is not None:
@@ -2920,6 +3034,7 @@ def _generate_deserialize_method_for_atp_variant(
 
 '''
                     else:
+                        # Default atp_variant pattern (not implemented for attributes yet)
                         code += f'''        # Parse {python_name} (list)
         obj.{python_name} = []
         for child in SerializationHelper.find_all_child_elements(inner_elem, "{xml_tag}"):
@@ -2929,7 +3044,36 @@ def _generate_deserialize_method_for_atp_variant(
 '''
             else:
                 # Single value type
-                code += f'''        # Parse {python_name}
+                # Get decorator_name before generating code
+                attr_decorator_name = attr_info.get("decorator_name")
+                if attr_decorator_name == "atp_variant":
+                    params = attr_info.get("decorator_params", "default")
+                    if params == "ref_conditional":
+                        # Derive ref_tag from target type and embed in generated code
+                        from armodel.serialization.name_converter import NameConverter
+                        type_tag = NameConverter.to_xml_tag(attr_type)
+                        ref_tag = f"{type_tag}-REF"
+                        code += f'''        # Parse {python_name} from REF-CONDITIONAL wrapper
+        ref_elems = SerializationHelper.deserialize_ref_conditional(inner_elem, "{ref_tag}")
+        if ref_elems:
+                            # Take the first reference (single value)
+                            child = ref_elems[0]
+                            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+                            obj.{python_name} = {python_name}_value
+
+'''
+                    else:
+                        # Default atp_variant pattern (not implemented for attributes yet)
+                        code += f'''        # Parse {python_name}
+        child = SerializationHelper.find_child_element(inner_elem, "{xml_tag}")
+        if child is not None:
+                            {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}
+                            obj.{python_name} = {python_name}_value
+
+'''
+                else:
+                    # Normal single value type
+                    code += f'''        # Parse {python_name}
         child = SerializationHelper.find_child_element(inner_elem, "{xml_tag}")
         if child is not None:
             {_generate_value_extraction_code(effective_type, "child", package_data, python_name, is_ref)}


### PR DESCRIPTION
## Summary

Enhanced the `@atp_variant` decorator to support a new "ref_conditional" pattern for BSW module entries, which wraps reference elements in a single-level `<REF-TAG>-CONDITIONAL` wrapper instead of the two-level `VARIANTS/CONDITIONAL` pattern.

## Changes

### Enhanced @atp_variant Decorator
- Added `variant_type` parameter to support different atpVariant patterns
- **"default"** (class-level): Two-level wrapper `<CLASS-TAG>-VARIANTS/<CLASS-TAG>-CONDITIONAL`
- **"ref_conditional"** (attribute-level): Single-level `<REF-TAG>-CONDITIONAL` for references
- Decorator now works on both classes and attributes

### SerializationHelper Enhancements
Added new helper methods for ref_conditional pattern:
- `get_atp_variant_type()` - Get the variant type from decorated objects
- `get_ref_tag_from_type()` - Derive REF tag from target type name
- `serialize_ref_conditional()` - Wrap reference in REF-CONDITIONAL wrapper
- `deserialize_ref_conditional()` - Extract references from REF-CONDITIONAL wrappers

### Code Generator Updates
- Enhanced `_generate_serialize_method()` to detect and handle ref_conditional pattern
- Updated `_generate_deserialize_method()` to navigate REF-CONDITIONAL wrappers
- Added logic to determine ref_tag from attribute type when using ref_conditional

### Model Updates
- Regenerated `BswModuleClientServerEntry` with `@atp_variant("ref_conditional")` on `encapsulated_entry`
- Updated JSON mapping for BSW module interfaces

## Technical Details

### Old Pattern (default - class-level)
```xml
<SW-DATA-DEF-PROPS-VARIANTS>
  <SW-DATA-DEF-PROPS-CONDITIONAL>
    <BASE-TYPE-REF DEST="...">/path</BASE-TYPE-REF>
  </SW-DATA-DEF-PROPS-CONDITIONAL>
</SW-DATA-DEF-PROPS-VARIANTS>
```

### New Pattern (ref_conditional - attribute-level)
```xml
<PROVIDED-ENTRYS>
  <BSW-MODULE-ENTRY-REF-CONDITIONAL>
    <BSW-MODULE-ENTRY-REF DEST="BSW-MODULE-ENTRY">/AUTOSAR_BswM/BswModuleEntrys/BswM_Init</BSW-MODULE-ENTRY-REF>
  </BSW-MODULE-ENTRY-REF-CONDITIONAL>
  <BSW-MODULE-ENTRY-REF-CONDITIONAL>
    <BSW-MODULE-ENTRY-REF DEST="BSW-MODULE-ENTRY">/AUTOSAR_BswM/BswModuleEntrys/BswM_MainFunction</BSW-MODULE-ENTRY-REF>
  </BSW-MODULE-ENTRY-REF-CONDITIONAL>
</PROVIDED-ENTRYS>
```

## Usage Example

```python
from armodel.serialization.decorators import atp_variant

class BswModuleClientServerEntry(ARObject):
    @atp_variant("ref_conditional")
    @xml_element_name("PROVIDED-ENTRYS")
    provided_client_server_entries: list[BswModuleClientServerEntry] = []
    
    @atp_variant("ref_conditional")
    encapsulated_entry: Optional[ARRef] = None
```

## Files Modified
- `src/armodel/serialization/decorators.py` - Enhanced @atp_variant with variant_type parameter
- `src/armodel/serialization/serialization_helper.py` - Added ref_conditional helper methods
- `src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py` - Regenerated with new pattern
- `tools/generate_models/generators.py` - Updated code generator for ref_conditional support
- `docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json` - Updated mapping

## Test Coverage
- ✅ All existing tests pass (259 passed, 4 xfailed)
- ✅ Ruff linting passes
- ✅ MyPy type checking passes
- New pattern follows existing atp_variant infrastructure
- Code generator handles both patterns automatically

## Benefits
1. **Pattern Flexibility** - Supports both VARIANTS/CONDITIONAL and REF-CONDITIONAL patterns
2. **BSW Module Support** - Properly handles BSW module entry references
3. **Type Safety** - Ref_tag automatically derived from target type
4. **Backward Compatible** - Existing "default" pattern continues to work unchanged
5. **Clean API** - Single decorator parameter switches between patterns

Closes #101