### PR TITLE
feat: Add multi-level nesting support for @xml_element_name decorator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,6 +587,40 @@ class LanguageSpecific(ARObject):
 
 Generated XML: `<L-LONG-NAME L="EN">Long Name</L-LONG-NAME>`
 
+**xml_element_name Decorator:**
+The `@xml_element_name()` decorator marks an attribute to use custom XML element names. This is used when the XML element name differs from the auto-generated name or when multi-level nesting is required.
+
+```python
+class ExecutableEntity(ARObject):
+    _can_enter_refs: list[ARRef] = []
+    
+    @property
+    @xml_element_name("CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA/CAN-ENTER-EXCLUSIVE-AREA-REF")
+    def can_enter_refs(self) -> list[ARRef]:
+        """Get can_enter_refs with custom XML element name."""
+        return self._can_enter_refs
+```
+
+The decorator supports:
+- **Single parameter**: Override the container tag name
+  - Example: `@xml_element_name("PROVIDED-ENTRYS")` → `<PROVIDED-ENTRYS>...</PROVIDED-ENTRYS>`
+- **Multi-level path**: Specify nested container structure using `/` separator
+  - Example: `@xml_element_name("TAG1/TAG2/TAG3")` → `<TAG1><TAG2><TAG3>...</TAG3></TAG2></TAG1>`
+
+Generated XML for multi-level nesting:
+```xml
+<CAN-ENTER-EXCLUSIVE-AREA-REFS>
+  <CAN-ENTER-EXCLUSIVE-AREA>
+    <CAN-ENTER-EXCLUSIVE-AREA-REF DEST="EXCLUSIVE-AREA">/path/to/area</CAN-ENTER-EXCLUSIVE-AREA-REF>
+  </CAN-ENTER-EXCLUSIVE-AREA>
+</CAN-ENTER-EXCLUSIVE-AREA-REFS>
+```
+
+The serialization framework automatically:
+- Creates nested wrapper elements for each level in the path during serialization
+- Navigates through nested containers during deserialization
+- Uses the last level tag for individual child elements
+
 ### Serialization Behavior
 
 **How serialize() works:**

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_InternalBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_InternalBehavior.classes.json
@@ -177,7 +177,7 @@
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
-          "decorator": "xml_element_name:CAN-ENTER-EXCLUSIVE-AREA-REFS,CAN-ENTER-EXCLUSIVE-AREA-REF",
+          "decorator": "xml_element_name:CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA-REF",
           "note": "This means that the executable entity can enter/leave the"
         },
         "exclusiveAreaNestingOrders": {

--- a/docs/json/packages/M2_MSR_DataDictionary_RecordLayout.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_RecordLayout.classes.json
@@ -39,11 +39,11 @@
         }
       ],
       "attributes": {
-        "swRecord": {
+        "swRecordLayoutGroup": {
           "type": "SwRecordLayoutGroup",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "This is the top level record layout group."
         }
       }
@@ -165,20 +165,63 @@
           "is_ref": false,
           "note": "This attribute specifies a name which can be used e.g."
         },
-        "swGenericAxisParam": {
-          "type": "SwGenericAxisParam",
+        "swGenericAxisParamType": {
+          "type": "SwGenericAxisParamType",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
           "note": "This association allows to specify record layout groups to iterate over generic axis parameters. For example, if the parameter is an array, the record layout iterate over this array. axis referred to by swRecordLayoutGroup be a generic axis in which the referenced Sw aggregated."
         },
-        "swRecord": {
+        "swRecordLayoutComponent": {
+          "type": "Identifier",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupAxis": {
+          "type": "AxisIndexType ",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupContentType": {
+          "type": "swRecordLayoutGroupContent",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupIndex": {
+          "type": "NameToken",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupStep": {
+          "type": "Integer",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupFrom": {
+          "type": "RecordLayoutIteratorPoint",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
+        },
+        "swRecordLayoutGroupTo": {
           "type": "RecordLayoutIteratorPoint",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "This attribute specifies the end point for the iteration. Negative values are also possible, i.e. the value -4 counts the fourth value from the end. If this property is not iteration ends at \"-1\" which is the last element."
         }
+        
       }
     },
     {

--- a/src/armodel/models/M2/AUTOSARTemplates/AbstractPlatform/application_interface.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/AbstractPlatform/application_interface.py
@@ -150,8 +150,8 @@ class ApplicationInterface(PortInterface):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/firewall_rule_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/firewall_rule_props.py
@@ -138,8 +138,8 @@ class FirewallRuleProps(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -154,8 +154,8 @@ class FirewallRuleProps(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/state_dependent_firewall.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/Firewall/state_dependent_firewall.py
@@ -147,8 +147,8 @@ class StateDependentFirewall(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/IntrusionDetectionSystem/ids_platform_instantiation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/AdaptivePlatform/PlatformModuleDeployment/IntrusionDetectionSystem/ids_platform_instantiation.py
@@ -117,8 +117,8 @@ class IdsPlatformInstantiation(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_event.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_event.py
@@ -136,8 +136,8 @@ class BswEvent(AbstractEvent, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_call_point.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_call_point.py
@@ -101,8 +101,8 @@ class BswModuleCallPoint(Referrable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_entity.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_entity.py
@@ -249,8 +249,8 @@ class BswModuleEntity(ExecutableEntity, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -265,8 +265,8 @@ class BswModuleEntity(ExecutableEntity, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -317,8 +317,8 @@ class BswModuleEntity(ExecutableEntity, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -333,8 +333,8 @@ class BswModuleEntity(ExecutableEntity, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_variable_access.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_variable_access.py
@@ -125,8 +125,8 @@ class BswVariableAccess(Referrable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswImplementation/bsw_implementation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswImplementation/bsw_implementation.py
@@ -215,8 +215,8 @@ class BswImplementation(Implementation):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -231,8 +231,8 @@ class BswImplementation(Implementation):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -253,8 +253,8 @@ class BswImplementation(Implementation):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
@@ -364,8 +364,8 @@ class BswModuleDescription(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -380,8 +380,8 @@ class BswModuleDescription(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/code.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/code.py
@@ -126,8 +126,8 @@ class Code(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/dependency_on_artifact.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/dependency_on_artifact.py
@@ -126,8 +126,8 @@ class DependencyOnArtifact(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/implementation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Implementation/implementation.py
@@ -372,8 +372,8 @@ class Implementation(ARElement, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/exclusive_area_nesting_order.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/exclusive_area_nesting_order.py
@@ -101,8 +101,8 @@ class ExclusiveAreaNestingOrder(Referrable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/executable_entity.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/executable_entity.py
@@ -70,7 +70,7 @@ class ExecutableEntity(Identifiable, ABC):
         self.runs_inside_refs: list[ARRef] = []
         self.sw_addr_method_ref: Optional[ARRef] = None
     @property
-    @xml_element_name("CAN-ENTER-EXCLUSIVE-AREA-REFS,CAN-ENTER-EXCLUSIVE-AREA-REF")
+    @xml_element_name("CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA-REF")
     def can_enter_refs(self) -> list[ARRef]:
         """Get can_enter_refs with custom XML element name."""
         return self._can_enter_refs
@@ -239,8 +239,8 @@ class ExecutableEntity(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child matches expected reference tag "CAN-ENTER-EXCLUSIVE-AREA-REF"
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag == "CAN-ENTER-EXCLUSIVE-AREA-REF":
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag == "CAN-ENTER-EXCLUSIVE-AREA-REF":
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -255,8 +255,8 @@ class ExecutableEntity(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -283,8 +283,8 @@ class ExecutableEntity(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/internal_behavior.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/internal_behavior.py
@@ -210,8 +210,8 @@ class InternalBehavior(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -226,8 +226,8 @@ class InternalBehavior(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups/mc_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups/mc_group.py
@@ -155,8 +155,8 @@ class McGroup(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -183,8 +183,8 @@ class McGroup(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups/mc_group_data_ref_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/McGroups/mc_group_data_ref_set.py
@@ -160,11 +160,19 @@ class McGroupDataRefSet(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("FlatInstanceDescriptor", package_data):
                     child_value = child.text
                 elif is_enum_type("FlatInstanceDescriptor", package_data):
@@ -180,11 +188,19 @@ class McGroupDataRefSet(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("McDataInstance", package_data):
                     child_value = child.text
                 elif is_enum_type("McDataInstance", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/mc_function_data_ref_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/mc_function_data_ref_set.py
@@ -160,11 +160,19 @@ class McFunctionDataRefSet(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("FlatInstanceDescriptor", package_data):
                     child_value = child.text
                 elif is_enum_type("FlatInstanceDescriptor", package_data):
@@ -180,11 +188,19 @@ class McFunctionDataRefSet(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("McDataInstance", package_data):
                     child_value = child.text
                 elif is_enum_type("McDataInstance", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/rpt_executable_entity_event.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/RptSupport/rpt_executable_entity_event.py
@@ -194,8 +194,8 @@ class RptExecutableEntityEvent(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -238,8 +238,8 @@ class RptExecutableEntityEvent(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_function.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_function.py
@@ -210,8 +210,8 @@ class McFunction(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_support_data.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_support_data.py
@@ -189,8 +189,8 @@ class McSupportData(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/role_based_mc_data_assignment.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/role_based_mc_data_assignment.py
@@ -141,8 +141,8 @@ class RoleBasedMcDataAssignment(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -157,8 +157,8 @@ class RoleBasedMcDataAssignment(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/ExecutionTime/execution_time.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/ExecutionTime/execution_time.py
@@ -248,8 +248,8 @@ class ExecutionTime(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/MemorySectionUsage/memory_section.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/MemorySectionUsage/memory_section.py
@@ -230,8 +230,8 @@ class MemorySection(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/resource_consumption.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ResourceConsumption/resource_consumption.py
@@ -177,8 +177,8 @@ class ResourceConsumption(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds/diagnostic_event_needs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds/diagnostic_event_needs.py
@@ -188,8 +188,8 @@ class DiagnosticEventNeeds(DiagnosticCapabilityElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -216,8 +216,8 @@ class DiagnosticEventNeeds(DiagnosticCapabilityElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds/supervised_entity_needs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/ServiceNeeds/supervised_entity_needs.py
@@ -205,8 +205,8 @@ class SupervisedEntityNeeds(ServiceNeeds):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/signal_service_translation_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/SignalServiceTranslation/signal_service_translation_props.py
@@ -174,8 +174,8 @@ class SignalServiceTranslationProps(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -190,8 +190,8 @@ class SignalServiceTranslationProps(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -206,8 +206,8 @@ class SignalServiceTranslationProps(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintDedicated/Port/port_prototype_blueprint.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintDedicated/Port/port_prototype_blueprint.py
@@ -148,8 +148,8 @@ class PortPrototypeBlueprint(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintMapping/blueprint_mapping_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/BlueprintMapping/blueprint_mapping_set.py
@@ -101,8 +101,8 @@ class BlueprintMappingSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/DataExchange/document_element_scope.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/DataExchange/document_element_scope.py
@@ -119,8 +119,8 @@ class DocumentElementScope(SpecElementReference):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/DataExchangePoint/baseline.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/StandardizationTemplate/DataExchangePoint/baseline.py
@@ -141,8 +141,8 @@ class Baseline(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -157,8 +157,8 @@ class Baseline(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/mode_in_swc_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCondition/mode_in_swc_instance_ref.py
@@ -176,8 +176,8 @@ class ModeInSwcInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_event_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_event_ref.py
@@ -169,8 +169,8 @@ class EOCEventRef(EOCExecutableEntityRefAbstract):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref.py
@@ -169,8 +169,8 @@ class EOCExecutableEntityRef(EOCExecutableEntityRefAbstract):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref_abstract.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref_abstract.py
@@ -98,8 +98,8 @@ class EOCExecutableEntityRefAbstract(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/ExecutionOrderConstraint/eoc_executable_entity_ref_group.py
@@ -247,8 +247,8 @@ class EOCExecutableEntityRefGroup(EOCExecutableEntityRefAbstract):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -287,8 +287,8 @@ class EOCExecutableEntityRefGroup(EOCExecutableEntityRefAbstract):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -303,8 +303,8 @@ class EOCExecutableEntityRefGroup(EOCExecutableEntityRefAbstract):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/SynchronizationPointConstraint/synchronization_point_constraint.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/SynchronizationPointConstraint/synchronization_point_constraint.py
@@ -157,8 +157,8 @@ class SynchronizationPointConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -173,8 +173,8 @@ class SynchronizationPointConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -189,8 +189,8 @@ class SynchronizationPointConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -205,8 +205,8 @@ class SynchronizationPointConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/SynchronizationTiming/synchronization_timing_constraint.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingConstraint/SynchronizationTiming/synchronization_timing_constraint.py
@@ -180,8 +180,8 @@ class SynchronizationTimingConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -196,8 +196,8 @@ class SynchronizationTimingConstraint(TimingConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCpSoftwareCluster/td_cp_software_cluster_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingCpSoftwareCluster/td_cp_software_cluster_mapping.py
@@ -141,8 +141,8 @@ class TDCpSoftwareClusterMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingDescription/TimingDescription/td_event_frame_ethernet.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingDescription/TimingDescription/td_event_frame_ethernet.py
@@ -172,8 +172,8 @@ class TDEventFrameEthernet(TDEventCom):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingDescription/timing_description_event_chain.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingDescription/timing_description_event_chain.py
@@ -163,8 +163,8 @@ class TimingDescriptionEventChain(TimingDescription):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingExtensions/bsw_composition_timing.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/CommonStructure/Timing/TimingExtensions/bsw_composition_timing.py
@@ -100,8 +100,8 @@ class BswCompositionTiming(TimingExtension):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/CommunicationControl/diagnostic_com_control_class.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/CommunicationControl/diagnostic_com_control_class.py
@@ -146,8 +146,8 @@ class DiagnosticComControlClass(DiagnosticServiceClass):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -162,8 +162,8 @@ class DiagnosticComControlClass(DiagnosticServiceClass):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/IOControl/diagnostic_control_enable_mask_bit.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/IOControl/diagnostic_control_enable_mask_bit.py
@@ -122,8 +122,8 @@ class DiagnosticControlEnableMaskBit(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/MemoryByAddress/diagnostic_memory_addressable_range_access.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/DiagnosticService/MemoryByAddress/diagnostic_memory_addressable_range_access.py
@@ -98,8 +98,8 @@ class DiagnosticMemoryAddressableRangeAccess(DiagnosticMemoryByAddress, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/ObdService/Mode_0x02_RequestPowertrainFreeze/diagnostic_powertrain_freeze_frame.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/ObdService/Mode_0x02_RequestPowertrainFreeze/diagnostic_powertrain_freeze_frame.py
@@ -100,8 +100,8 @@ class DiagnosticPowertrainFreezeFrame(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/ObdService/Mode_0x06_RequestOnBoard/diagnostic_request_on_board_monitoring_test_results.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/ObdService/Mode_0x06_RequestOnBoard/diagnostic_request_on_board_monitoring_test_results.py
@@ -116,8 +116,8 @@ class DiagnosticRequestOnBoardMonitoringTestResults(DiagnosticServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/diagnostic_access_permission.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/diagnostic_access_permission.py
@@ -163,8 +163,8 @@ class DiagnosticAccessPermission(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -185,8 +185,8 @@ class DiagnosticAccessPermission(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/diagnostic_auth_role_proxy.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dcm/diagnostic_auth_role_proxy.py
@@ -97,8 +97,8 @@ class DiagnosticAuthRoleProxy(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticConditionGroup/diagnostic_enable_condition_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticConditionGroup/diagnostic_enable_condition_group.py
@@ -97,8 +97,8 @@ class DiagnosticEnableConditionGroup(DiagnosticConditionGroup):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticConditionGroup/diagnostic_storage_condition_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticConditionGroup/diagnostic_storage_condition_group.py
@@ -97,8 +97,8 @@ class DiagnosticStorageConditionGroup(DiagnosticConditionGroup):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticEvent/diagnostic_iumpr_denominator_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticEvent/diagnostic_iumpr_denominator_group.py
@@ -100,8 +100,8 @@ class DiagnosticIumprDenominatorGroup(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticEvent/diagnostic_iumpr_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticEvent/diagnostic_iumpr_group.py
@@ -116,8 +116,8 @@ class DiagnosticIumprGroup(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticMemoryDestination/diagnostic_memory_destination_user_defined.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticMemoryDestination/diagnostic_memory_destination_user_defined.py
@@ -119,8 +119,8 @@ class DiagnosticMemoryDestinationUserDefined(DiagnosticMemoryDestination):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_data_identifier_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_data_identifier_set.py
@@ -100,8 +100,8 @@ class DiagnosticDataIdentifierSet(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_trouble_code_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_trouble_code_group.py
@@ -119,8 +119,8 @@ class DiagnosticTroubleCodeGroup(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_trouble_code_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Dem/DiagnosticTroubleCode/diagnostic_trouble_code_props.py
@@ -275,8 +275,8 @@ class DiagnosticTroubleCodeProps(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -291,8 +291,8 @@ class DiagnosticTroubleCodeProps(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticCommonProps/diagnostic_common_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticCommonProps/diagnostic_common_props.py
@@ -285,11 +285,19 @@ class DiagnosticCommonProps(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("any (DiagnosticDebounce)", package_data):
                     child_value = child.text
                 elif is_enum_type("any (DiagnosticDebounce)", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_contribution_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_contribution_set.py
@@ -141,8 +141,8 @@ class DiagnosticContributionSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -157,8 +157,8 @@ class DiagnosticContributionSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_ecu_instance_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_ecu_instance_props.py
@@ -119,8 +119,8 @@ class DiagnosticEcuInstanceProps(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_protocol.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_protocol.py
@@ -172,8 +172,8 @@ class DiagnosticProtocol(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_service_table.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticContribution/diagnostic_service_table.py
@@ -157,8 +157,8 @@ class DiagnosticServiceTable(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -185,8 +185,8 @@ class DiagnosticServiceTable(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/DiagnosticJ1939Mapping/diagnostic_j1939_spn_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/DiagnosticJ1939Mapping/diagnostic_j1939_spn_mapping.py
@@ -138,8 +138,8 @@ class DiagnosticJ1939SpnMapping(DiagnosticMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/ServiceMapping/diagnostic_parameter_element_access.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/ServiceMapping/diagnostic_parameter_element_access.py
@@ -113,8 +113,8 @@ class DiagnosticParameterElementAccess(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/diagnostic_auth_transmit_certificate_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/diagnostic_auth_transmit_certificate_mapping.py
@@ -113,8 +113,8 @@ class DiagnosticAuthTransmitCertificateMapping(DiagnosticMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/diagnostic_secure_coding_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/DiagnosticMapping/diagnostic_secure_coding_mapping.py
@@ -116,8 +116,8 @@ class DiagnosticSecureCodingMapping(DiagnosticMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Fim/diagnostic_fim_alias_event_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Fim/diagnostic_fim_alias_event_group.py
@@ -97,8 +97,8 @@ class DiagnosticFimAliasEventGroup(DiagnosticAbstractAliasEvent):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Fim/diagnostic_fim_event_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/Fim/diagnostic_fim_event_group.py
@@ -100,8 +100,8 @@ class DiagnosticFimEventGroup(DiagnosticCommonElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/InstanceRefs/data_prototype_in_system_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/InstanceRefs/data_prototype_in_system_instance_ref.py
@@ -214,8 +214,8 @@ class DataPrototypeInSystemInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -230,8 +230,8 @@ class DataPrototypeInSystemInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/InstanceRefs/swc_service_dependency_in_system_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/DiagnosticExtract/InstanceRefs/swc_service_dependency_in_system_instance_ref.py
@@ -135,8 +135,8 @@ class SwcServiceDependencyInSystemInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/ecuc_container_value.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/ecuc_container_value.py
@@ -162,8 +162,8 @@ class EcucContainerValue(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/ecuc_value_collection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCDescriptionTemplate/ecuc_value_collection.py
@@ -118,8 +118,8 @@ class EcucValueCollection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_choice_reference_def.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_choice_reference_def.py
@@ -101,8 +101,8 @@ class EcucChoiceReferenceDef(EcucAbstractInternalReferenceDef):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_container_def.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_container_def.py
@@ -182,8 +182,8 @@ class EcucContainerDef(EcucDefinitionElement, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_definition_collection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_definition_collection.py
@@ -101,8 +101,8 @@ class EcucDefinitionCollection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_destination_uri_policy.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_destination_uri_policy.py
@@ -166,8 +166,8 @@ class EcucDestinationUriPolicy(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_param_conf_container_def.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/ECUCParameterDefTemplate/ecuc_param_conf_container_def.py
@@ -134,8 +134,8 @@ class EcucParamConfContainerDef(EcucContainerDef):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_description_entity.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_description_entity.py
@@ -163,8 +163,8 @@ class HwDescriptionEntity(Referrable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_element.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_element.py
@@ -150,8 +150,8 @@ class HwElement(HwDescriptionEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -166,8 +166,8 @@ class HwElement(HwDescriptionEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_element_connector.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_element_connector.py
@@ -140,8 +140,8 @@ class HwElementConnector(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -166,8 +166,8 @@ class HwElementConnector(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_connector.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_connector.py
@@ -100,8 +100,8 @@ class HwPinConnector(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_group_connector.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_group_connector.py
@@ -125,8 +125,8 @@ class HwPinGroupConnector(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_decomposition.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_decomposition.py
@@ -155,8 +155,8 @@ class FMFeatureDecomposition(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_map_element.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_map_element.py
@@ -169,8 +169,8 @@ class FMFeatureMapElement(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -185,8 +185,8 @@ class FMFeatureMapElement(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_model.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_model.py
@@ -117,8 +117,8 @@ class FMFeatureModel(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_relation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_relation.py
@@ -119,8 +119,8 @@ class FMFeatureRelation(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_selection_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/FeatureModelTemplate/fm_feature_selection_set.py
@@ -134,8 +134,8 @@ class FMFeatureSelectionSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -150,8 +150,8 @@ class FMFeatureSelectionSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure/atp_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/AbstractStructure/atp_instance_ref.py
@@ -146,8 +146,8 @@ class AtpInstanceRef(ARObject, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/BuildActionManifest/build_action.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/BuildActionManifest/build_action.py
@@ -185,8 +185,8 @@ class BuildAction(BuildActionEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -221,8 +221,8 @@ class BuildAction(BuildActionEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/BuildActionManifest/build_action_manifest.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/BuildActionManifest/build_action_manifest.py
@@ -165,8 +165,8 @@ class BuildActionManifest(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -181,8 +181,8 @@ class BuildActionManifest(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -197,8 +197,8 @@ class BuildActionManifest(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/FormulaLanguage/formula_expression.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/FormulaLanguage/formula_expression.py
@@ -119,8 +119,8 @@ class FormulaExpression(ARObject, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -135,8 +135,8 @@ class FormulaExpression(ARObject, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage/reference_base.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ARPackage/reference_base.py
@@ -234,8 +234,8 @@ class ReferenceBase(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -250,8 +250,8 @@ class ReferenceBase(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/AnyInstanceRef/any_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/AnyInstanceRef/any_instance_ref.py
@@ -141,8 +141,8 @@ class AnyInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection/collection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ElementCollection/collection.py
@@ -231,8 +231,8 @@ class Collection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -247,8 +247,8 @@ class Collection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/SpecialDataDef/sdg_class.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/SpecialDataDef/sdg_class.py
@@ -174,8 +174,8 @@ class SdgClass(SdgElementWithGid):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles/life_cycle_info.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles/life_cycle_info.py
@@ -217,8 +217,8 @@ class LifeCycleInfo(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_object_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_object_set.py
@@ -176,8 +176,8 @@ class AclObjectSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -204,8 +204,8 @@ class AclObjectSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_operation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_operation.py
@@ -98,8 +98,8 @@ class AclOperation(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_permission.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/RolesAndRights/acl_permission.py
@@ -196,8 +196,8 @@ class AclPermission(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -212,8 +212,8 @@ class AclPermission(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -228,8 +228,8 @@ class AclPermission(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/AttributeValueVariationPoints/enumeration_mapping_table.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/AttributeValueVariationPoints/enumeration_mapping_table.py
@@ -109,8 +109,8 @@ class EnumerationMappingTable(PackageableElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/evaluated_variant_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/evaluated_variant_set.py
@@ -125,8 +125,8 @@ class EvaluatedVariantSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/predefined_variant.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/VariantHandling/predefined_variant.py
@@ -140,8 +140,8 @@ class PredefinedVariant(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -156,8 +156,8 @@ class PredefinedVariant(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -172,8 +172,8 @@ class PredefinedVariant(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/LogAndTraceExtract/dlt_application.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/LogAndTraceExtract/dlt_application.py
@@ -148,8 +148,8 @@ class DltApplication(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/LogAndTraceExtract/dlt_context.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/LogAndTraceExtract/dlt_context.py
@@ -148,8 +148,8 @@ class DltContext(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/inner_port_group_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/inner_port_group_in_composition_instance_ref.py
@@ -138,8 +138,8 @@ class InnerPortGroupInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/complex_device_driver_sw_component_type.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/complex_device_driver_sw_component_type.py
@@ -103,8 +103,8 @@ class ComplexDeviceDriverSwComponentType(AtomicSwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/ecu_abstraction_sw_component_type.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/ecu_abstraction_sw_component_type.py
@@ -103,8 +103,8 @@ class EcuAbstractionSwComponentType(AtomicSwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/parameter_sw_component_type.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/parameter_sw_component_type.py
@@ -138,8 +138,8 @@ class ParameterSwComponentType(SwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -154,8 +154,8 @@ class ParameterSwComponentType(SwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/port_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/port_group.py
@@ -120,8 +120,8 @@ class PortGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -136,8 +136,8 @@ class PortGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/port_prototype.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/port_prototype.py
@@ -291,8 +291,8 @@ class PortPrototype(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/sw_component_type.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/sw_component_type.py
@@ -220,8 +220,8 @@ class SwComponentType(ARElement, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -242,8 +242,8 @@ class SwComponentType(ARElement, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs/component_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs/component_in_composition_instance_ref.py
@@ -136,8 +136,8 @@ class ComponentInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs/instance_event_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/InstanceRefs/instance_event_in_composition_instance_ref.py
@@ -138,8 +138,8 @@ class InstanceEventInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/composition_sw_component_type.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/Composition/composition_sw_component_type.py
@@ -212,8 +212,8 @@ class CompositionSwComponentType(SwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -228,8 +228,8 @@ class CompositionSwComponentType(SwComponentType):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection/end_to_end_protection_variable_prototype.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/EndToEndProtection/end_to_end_protection_variable_prototype.py
@@ -133,8 +133,8 @@ class EndToEndProtectionVariablePrototype(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/inner_data_prototype_group_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/inner_data_prototype_group_in_composition_instance_ref.py
@@ -138,8 +138,8 @@ class InnerDataPrototypeGroupInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/inner_runnable_entity_group_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/inner_runnable_entity_group_in_composition_instance_ref.py
@@ -138,8 +138,8 @@ class InnerRunnableEntityGroupInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/runnable_entity_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/runnable_entity_in_composition_instance_ref.py
@@ -138,8 +138,8 @@ class RunnableEntityInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/variable_data_prototype_in_composition_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/InstanceRef/variable_data_prototype_in_composition_instance_ref.py
@@ -163,8 +163,8 @@ class VariableDataPrototypeInCompositionInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/consistency_needs.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/consistency_needs.py
@@ -161,8 +161,8 @@ class ConsistencyNeeds(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -177,8 +177,8 @@ class ConsistencyNeeds(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -193,8 +193,8 @@ class ConsistencyNeeds(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -209,8 +209,8 @@ class ConsistencyNeeds(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/data_prototype_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/data_prototype_group.py
@@ -120,8 +120,8 @@ class DataPrototypeGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -136,8 +136,8 @@ class DataPrototypeGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/runnable_entity_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/ImplicitCommunicationBehavior/runnable_entity_group.py
@@ -135,8 +135,8 @@ class RunnableEntityGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/NvBlockComponent/bulk_nv_data_descriptor.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/NvBlockComponent/bulk_nv_data_descriptor.py
@@ -125,8 +125,8 @@ class BulkNvDataDescriptor(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/NvBlockComponent/nv_block_descriptor.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/NvBlockComponent/nv_block_descriptor.py
@@ -315,8 +315,8 @@ class NvBlockDescriptor(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -331,8 +331,8 @@ class NvBlockDescriptor(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -367,8 +367,8 @@ class NvBlockDescriptor(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/InstanceRefs/application_composite_element_in_port_interface_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/InstanceRefs/application_composite_element_in_port_interface_instance_ref.py
@@ -154,8 +154,8 @@ class ApplicationCompositeElementInPortInterfaceInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/client_server_operation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/client_server_operation.py
@@ -160,8 +160,8 @@ class ClientServerOperation(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/client_server_operation_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/client_server_operation_mapping.py
@@ -151,8 +151,8 @@ class ClientServerOperationMapping(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/data_prototype_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/data_prototype_mapping.py
@@ -211,8 +211,8 @@ class DataPrototypeMapping(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/meta_data_item_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/meta_data_item_set.py
@@ -113,8 +113,8 @@ class MetaDataItemSet(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/mode_declaration_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/mode_declaration_mapping.py
@@ -116,8 +116,8 @@ class ModeDeclarationMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/nv_data_interface.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/nv_data_interface.py
@@ -103,8 +103,8 @@ class NvDataInterface(DataInterface):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/parameter_interface.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/parameter_interface.py
@@ -101,8 +101,8 @@ class ParameterInterface(DataInterface):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/port_interface_mapping_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/port_interface_mapping_set.py
@@ -101,8 +101,8 @@ class PortInterfaceMappingSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/trigger_interface.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/trigger_interface.py
@@ -101,8 +101,8 @@ class TriggerInterface(PortInterface):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/trigger_interface_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/trigger_interface_mapping.py
@@ -100,8 +100,8 @@ class TriggerInterfaceMapping(PortInterfaceMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/variable_and_parameter_interface_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/PortInterface/variable_and_parameter_interface_mapping.py
@@ -101,8 +101,8 @@ class VariableAndParameterInterfaceMapping(PortInterfaceMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/RPTScenario/rpt_container.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/RPTScenario/rpt_container.py
@@ -213,8 +213,8 @@ class RptContainer(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/parameter_in_atomic_swc_type_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/parameter_in_atomic_swc_type_instance_ref.py
@@ -173,8 +173,8 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/variable_in_atomic_swc_type_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/variable_in_atomic_swc_type_instance_ref.py
@@ -176,8 +176,8 @@ class VariableInAtomicSWCTypeInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_parameter_in_implementation_data_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_parameter_in_implementation_data_instance_ref.py
@@ -148,8 +148,8 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_variable_in_implementation_data_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_variable_in_implementation_data_instance_ref.py
@@ -148,8 +148,8 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes/included_data_type_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/IncludedDataTypes/included_data_type_set.py
@@ -116,8 +116,8 @@ class IncludedDataTypeSet(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ModeDeclarationGroup/included_mode_declaration_group_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ModeDeclarationGroup/included_mode_declaration_group_set.py
@@ -116,8 +116,8 @@ class IncludedModeDeclarationGroupSet(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
@@ -406,8 +406,8 @@ class RunnableEntity(ExecutableEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -422,8 +422,8 @@ class RunnableEntity(ExecutableEntity):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/swc_internal_behavior.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/swc_internal_behavior.py
@@ -366,8 +366,8 @@ class SwcInternalBehavior(InternalBehavior):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -402,8 +402,8 @@ class SwcInternalBehavior(InternalBehavior):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -418,8 +418,8 @@ class SwcInternalBehavior(InternalBehavior):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -434,8 +434,8 @@ class SwcInternalBehavior(InternalBehavior):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/ids_design.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/ids_design.py
@@ -100,8 +100,8 @@ class IdsDesign(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/security_event_context_mapping_comm_connector.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/security_event_context_mapping_comm_connector.py
@@ -100,8 +100,8 @@ class SecurityEventContextMappingCommConnector(SecurityEventContextMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/security_event_state_filter.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SecurityExtractTemplate/security_event_state_filter.py
@@ -100,8 +100,8 @@ class SecurityEventStateFilter(AbstractSecurityEventFilter):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/BusMirror/bus_mirror_channel_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/BusMirror/bus_mirror_channel_mapping.py
@@ -173,8 +173,8 @@ class BusMirrorChannelMapping(FibexElement, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection/diagnostic_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DiagnosticConnection/diagnostic_connection.py
@@ -171,8 +171,8 @@ class DiagnosticConnection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -187,8 +187,8 @@ class DiagnosticConnection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Dlt/dlt_log_channel.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Dlt/dlt_log_channel.py
@@ -245,8 +245,8 @@ class DltLogChannel(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -267,8 +267,8 @@ class DltLogChannel(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_interface.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_interface.py
@@ -317,8 +317,8 @@ class DoIpInterface(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -373,8 +373,8 @@ class DoIpInterface(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_logic_tester_address_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_logic_tester_address_props.py
@@ -100,8 +100,8 @@ class DoIpLogicTesterAddressProps(AbstractDoIpLogicAddressProps):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_routing_activation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/DoIP/do_ip_routing_activation.py
@@ -100,8 +100,8 @@ class DoIpRoutingActivation(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/Dds/dds_cp_provided_service_instance.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/Dds/dds_cp_provided_service_instance.py
@@ -169,8 +169,8 @@ class DdsCpProvidedServiceInstance(DdsCpServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_element.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_element.py
@@ -222,8 +222,8 @@ class CouplingElement(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port.py
@@ -354,8 +354,8 @@ class CouplingPort(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -392,8 +392,8 @@ class CouplingPort(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_connection.py
@@ -170,8 +170,8 @@ class CouplingPortConnection(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_rate_policy.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_rate_policy.py
@@ -186,8 +186,8 @@ class CouplingPortRatePolicy(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_scheduler.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/coupling_port_scheduler.py
@@ -122,8 +122,8 @@ class CouplingPortScheduler(CouplingPortStructuralElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/ethernet_cluster.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/ethernet_cluster.py
@@ -143,11 +143,19 @@ class EthernetCluster(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("MacMulticastGroup", package_data):
                     child_value = child.text
                 elif is_enum_type("MacMulticastGroup", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/ethernet_communication_controller.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/ethernet_communication_controller.py
@@ -224,11 +224,19 @@ class EthernetCommunicationController(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("CouplingPort", package_data):
                     child_value = child.text
                 elif is_enum_type("CouplingPort", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/switch_stream_filter_action_dest_port_modification.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/switch_stream_filter_action_dest_port_modification.py
@@ -116,8 +116,8 @@ class SwitchStreamFilterActionDestPortModification(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/switch_stream_identification.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/EthernetTopology/switch_stream_identification.py
@@ -206,8 +206,8 @@ class SwitchStreamIdentification(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -246,8 +246,8 @@ class SwitchStreamIdentification(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/IPv6HeaderFilterList/i_pv6_ext_header_filter_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/IPv6HeaderFilterList/i_pv6_ext_header_filter_set.py
@@ -100,8 +100,8 @@ class IPv6ExtHeaderFilterSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/abstract_service_instance.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/abstract_service_instance.py
@@ -188,8 +188,8 @@ class AbstractServiceInstance(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_event_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_event_group.py
@@ -259,8 +259,8 @@ class ConsumedEventGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -291,8 +291,8 @@ class ConsumedEventGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_provided_service_instance_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_provided_service_instance_group.py
@@ -116,8 +116,8 @@ class ConsumedProvidedServiceInstanceGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -132,8 +132,8 @@ class ConsumedProvidedServiceInstanceGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_service_instance.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/consumed_service_instance.py
@@ -326,8 +326,8 @@ class ConsumedServiceInstance(AbstractServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -358,8 +358,8 @@ class ConsumedServiceInstance(AbstractServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/event_handler.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/event_handler.py
@@ -226,8 +226,8 @@ class EventHandler(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -270,8 +270,8 @@ class EventHandler(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/pdu_activation_routing_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/pdu_activation_routing_group.py
@@ -125,8 +125,8 @@ class PduActivationRoutingGroup(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/provided_service_instance.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/provided_service_instance.py
@@ -305,8 +305,8 @@ class ProvidedServiceInstance(AbstractServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -367,8 +367,8 @@ class ProvidedServiceInstance(AbstractServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -383,8 +383,8 @@ class ProvidedServiceInstance(AbstractServiceInstance):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/socket_address.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/socket_address.py
@@ -312,8 +312,8 @@ class SocketAddress(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/static_socket_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/ServiceInstances/static_socket_connection.py
@@ -160,8 +160,8 @@ class StaticSocketConnection(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/TcpOptionFilterSet/tcp_option_filter_set.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Ethernet/TcpOptionFilterSet/tcp_option_filter_set.py
@@ -100,8 +100,8 @@ class TcpOptionFilterSet(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology/flexray_communication_controller.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Flexray/FlexrayTopology/flexray_communication_controller.py
@@ -587,11 +587,19 @@ class FlexrayCommunicationController(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("any (FlexrayFifo)", package_data):
                     child_value = child.text
                 elif is_enum_type("any (FlexrayFifo)", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication/lin_event_triggered_frame.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication/lin_event_triggered_frame.py
@@ -125,8 +125,8 @@ class LinEventTriggeredFrame(LinFrame):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication/lin_sporadic_frame.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinCommunication/lin_sporadic_frame.py
@@ -100,8 +100,8 @@ class LinSporadicFrame(LinFrame):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinTopology/lin_master.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Lin/LinTopology/lin_master.py
@@ -151,11 +151,19 @@ class LinMaster(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("LinSlaveConfig", package_data):
                     child_value = child.text
                 elif is_enum_type("LinSlaveConfig", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Multiplatform/gateway.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Multiplatform/gateway.py
@@ -169,8 +169,8 @@ class Gateway(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -185,8 +185,8 @@ class Gateway(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -201,8 +201,8 @@ class Gateway(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/mode_driven_transmission_mode_condition.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/mode_driven_transmission_mode_condition.py
@@ -97,8 +97,8 @@ class ModeDrivenTransmissionModeCondition(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/trigger_i_pdu_send_condition.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/trigger_i_pdu_send_condition.py
@@ -97,8 +97,8 @@ class TriggerIPduSendCondition(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/container_i_pdu.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/container_i_pdu.py
@@ -262,8 +262,8 @@ class ContainerIPdu(IPdu):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/frame_triggering.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/frame_triggering.py
@@ -150,8 +150,8 @@ class FrameTriggering(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -166,8 +166,8 @@ class FrameTriggering(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_group.py
@@ -157,8 +157,8 @@ class ISignalGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_i_pdu.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_i_pdu.py
@@ -145,8 +145,8 @@ class ISignalIPdu(IPdu):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_i_pdu_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_i_pdu_group.py
@@ -167,8 +167,8 @@ class ISignalIPduGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -183,8 +183,8 @@ class ISignalIPduGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -199,8 +199,8 @@ class ISignalIPduGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_triggering.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_triggering.py
@@ -151,8 +151,8 @@ class ISignalTriggering(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/nm_pdu.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/nm_pdu.py
@@ -153,8 +153,8 @@ class NmPdu(Pdu):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdu_triggering.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdu_triggering.py
@@ -190,8 +190,8 @@ class PduTriggering(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -206,8 +206,8 @@ class PduTriggering(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -228,8 +228,8 @@ class PduTriggering(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdur_i_pdu_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdur_i_pdu_group.py
@@ -125,8 +125,8 @@ class PdurIPduGroup(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/system_signal_group.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/system_signal_group.py
@@ -116,8 +116,8 @@ class SystemSignalGroup(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/communication_cluster.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/communication_cluster.py
@@ -173,11 +173,19 @@ class CommunicationCluster(ARObject, ABC):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("PhysicalChannel", package_data):
                     child_value = child.text
                 elif is_enum_type("PhysicalChannel", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/ecu_instance.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/ecu_instance.py
@@ -517,8 +517,8 @@ class EcuInstance(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -533,8 +533,8 @@ class EcuInstance(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -549,8 +549,8 @@ class EcuInstance(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -621,8 +621,8 @@ class EcuInstance(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -643,8 +643,8 @@ class EcuInstance(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/physical_channel.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/physical_channel.py
@@ -188,8 +188,8 @@ class PhysicalChannel(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -204,8 +204,8 @@ class PhysicalChannel(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -220,8 +220,8 @@ class PhysicalChannel(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -236,8 +236,8 @@ class PhysicalChannel(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -252,8 +252,8 @@ class PhysicalChannel(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/GeneralPurposeConnection/general_purpose_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/GeneralPurposeConnection/general_purpose_connection.py
@@ -100,8 +100,8 @@ class GeneralPurposeConnection(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/GlobalTime/global_time_domain.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/GlobalTime/global_time_domain.py
@@ -306,8 +306,8 @@ class GlobalTimeDomain(FibexElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/can_nm_cluster_coupling.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/can_nm_cluster_coupling.py
@@ -135,8 +135,8 @@ class CanNmClusterCoupling(NmClusterCoupling):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/flexray_nm_cluster_coupling.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/flexray_nm_cluster_coupling.py
@@ -119,8 +119,8 @@ class FlexrayNmClusterCoupling(NmClusterCoupling):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/nm_coordinator.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/nm_coordinator.py
@@ -171,8 +171,8 @@ class NmCoordinator(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/nm_node.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/nm_node.py
@@ -268,8 +268,8 @@ class NmNode(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -284,8 +284,8 @@ class NmNode(Identifiable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/udp_nm_cluster_coupling.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/NetworkManagement/udp_nm_cluster_coupling.py
@@ -119,8 +119,8 @@ class UdpNmClusterCoupling(NmClusterCoupling):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/PncMapping/pnc_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/PncMapping/pnc_mapping.py
@@ -323,8 +323,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -345,8 +345,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -361,8 +361,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -377,8 +377,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -399,8 +399,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -421,8 +421,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -443,8 +443,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -459,8 +459,8 @@ class PncMapping(Describable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SWmapping/application_partition_to_ecu_partition_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SWmapping/application_partition_to_ecu_partition_mapping.py
@@ -119,8 +119,8 @@ class ApplicationPartitionToEcuPartitionMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SWmapping/ecu_resource_estimation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SWmapping/ecu_resource_estimation.py
@@ -194,8 +194,8 @@ class EcuResourceEstimation(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/ip_sec_rule.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/ip_sec_rule.py
@@ -348,8 +348,8 @@ class IPSecRule(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -400,8 +400,8 @@ class IPSecRule(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -422,8 +422,8 @@ class IPSecRule(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/mac_sec_local_kay_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/mac_sec_local_kay_props.py
@@ -205,8 +205,8 @@ class MacSecLocalKayProps(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/tls_crypto_cipher_suite.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/tls_crypto_cipher_suite.py
@@ -338,8 +338,8 @@ class TlsCryptoCipherSuite(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -360,8 +360,8 @@ class TlsCryptoCipherSuite(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -400,8 +400,8 @@ class TlsCryptoCipherSuite(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/tls_crypto_service_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SecureCommunication/tls_crypto_service_mapping.py
@@ -150,8 +150,8 @@ class TlsCryptoServiceMapping(CryptoServiceMapping):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/forbidden_signal_path.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/forbidden_signal_path.py
@@ -137,8 +137,8 @@ class ForbiddenSignalPath(SignalPathConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/permissible_signal_path.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/permissible_signal_path.py
@@ -137,8 +137,8 @@ class PermissibleSignalPath(SignalPathConstraint):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/swc_to_swc_signal.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SignalPaths/swc_to_swc_signal.py
@@ -97,8 +97,8 @@ class SwcToSwcSignal(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster.py
@@ -149,8 +149,8 @@ class CpSoftwareCluster(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_resource_pool.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_resource_pool.py
@@ -115,8 +115,8 @@ class CpSoftwareClusterResourcePool(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_service_resource.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_service_resource.py
@@ -100,8 +100,8 @@ class CpSoftwareClusterServiceResource(CpSoftwareClusterResource):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_application_partition_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_application_partition_mapping.py
@@ -119,8 +119,8 @@ class CpSoftwareClusterToApplicationPartitionMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_ecu_instance_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_ecu_instance_mapping.py
@@ -150,8 +150,8 @@ class CpSoftwareClusterToEcuInstanceMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_resource_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/SoftwareCluster/cp_software_cluster_to_resource_mapping.py
@@ -138,8 +138,8 @@ class CpSoftwareClusterToResourceMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_client_server_interface_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_client_server_interface_instance_ref.py
@@ -160,8 +160,8 @@ class DataPrototypeInClientServerInterfaceInstanceRef(DataPrototypeInPortInterfa
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_port_interface_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_port_interface_instance_ref.py
@@ -158,8 +158,8 @@ class DataPrototypeInPortInterfaceInstanceRef(ARObject, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_sender_receiver_interface_instance_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/data_prototype_in_sender_receiver_interface_instance_ref.py
@@ -157,8 +157,8 @@ class DataPrototypeInSenderReceiverInterfaceInstanceRef(DataPrototypeInPortInter
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/implementation_data_type_element_in_port_interface_ref.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/InstanceRef/implementation_data_type_element_in_port_interface_ref.py
@@ -138,8 +138,8 @@ class ImplementationDataTypeElementInPortInterfaceRef(DataPrototypeReference):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/data_transformation.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/data_transformation.py
@@ -148,8 +148,8 @@ class DataTransformation(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/someip_transformation_i_signal_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/someip_transformation_i_signal_props.py
@@ -294,11 +294,19 @@ class SOMEIPTransformationISignalProps(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("TlvDataIdDefinitionSet", package_data):
                     child_value = child.text
                 elif is_enum_type("TlvDataIdDefinitionSet", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/transformation_i_signal_props.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Transformer/transformation_i_signal_props.py
@@ -157,11 +157,19 @@ class TransformationISignalProps(ARObject, ABC):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("DataPrototype", package_data):
                     child_value = child.text
                 elif is_enum_type("DataPrototype", package_data):

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/IEEE1722Tp/ieee1722_tp_av_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/IEEE1722Tp/ieee1722_tp_av_connection.py
@@ -126,8 +126,8 @@ class IEEE1722TpAvConnection(IEEE1722TpConnection, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/IEEE1722Tp/ieee1722_tp_config.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/IEEE1722Tp/ieee1722_tp_config.py
@@ -100,8 +100,8 @@ class IEEE1722TpConfig(TpConfig):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/can_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/can_tp_connection.py
@@ -409,8 +409,8 @@ class CanTpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/eth_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/eth_tp_connection.py
@@ -100,8 +100,8 @@ class EthTpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_channel.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_channel.py
@@ -460,8 +460,8 @@ class FlexrayArTpChannel(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_connection.py
@@ -219,8 +219,8 @@ class FlexrayArTpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_node.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_ar_tp_node.py
@@ -116,8 +116,8 @@ class FlexrayArTpNode(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_connection.py
@@ -258,8 +258,8 @@ class FlexrayTpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_node.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_node.py
@@ -116,8 +116,8 @@ class FlexrayTpNode(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_pdu_pool.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/flexray_tp_pdu_pool.py
@@ -100,8 +100,8 @@ class FlexrayTpPduPool(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/j1939_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/j1939_tp_connection.py
@@ -330,8 +330,8 @@ class J1939TpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/j1939_tp_pg.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/j1939_tp_pg.py
@@ -170,8 +170,8 @@ class J1939TpPg(ARObject):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/lin_tp_connection.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/TransportProtocols/lin_tp_connection.py
@@ -264,8 +264,8 @@ class LinTpConnection(TpConnection):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/com_management_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/com_management_mapping.py
@@ -122,8 +122,8 @@ class ComManagementMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -138,8 +138,8 @@ class ComManagementMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/j1939_shared_address_cluster.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/j1939_shared_address_cluster.py
@@ -100,8 +100,8 @@ class J1939SharedAddressCluster(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/root_sw_composition_prototype.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/root_sw_composition_prototype.py
@@ -138,8 +138,8 @@ class RootSwCompositionPrototype(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/system.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/system.py
@@ -323,8 +323,8 @@ class System(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -351,8 +351,8 @@ class System(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -367,8 +367,8 @@ class System(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -421,8 +421,8 @@ class System(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/system_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/system_mapping.py
@@ -497,8 +497,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -513,8 +513,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -539,8 +539,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -565,8 +565,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -581,8 +581,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -687,8 +687,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -703,8 +703,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:
@@ -719,8 +719,8 @@ class SystemMapping(Identifiable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/MSR/AsamHdo/Units/unit_group.py
+++ b/src/armodel/models/M2/MSR/AsamHdo/Units/unit_group.py
@@ -101,8 +101,8 @@ class UnitGroup(ARElement):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/MSR/DataDictionary/Axis/sw_axis_individual.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/Axis/sw_axis_individual.py
@@ -281,8 +281,8 @@ class SwAxisIndividual(SwCalprmAxisTypeProps):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_def_props.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_def_props.py
@@ -653,11 +653,19 @@ class SwDataDefProps(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("Annotation", package_data):
                     child_value = child.text
                 elif is_enum_type("Annotation", package_data):
@@ -751,11 +759,19 @@ class SwDataDefProps(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("SwVariableRefProxy", package_data):
                     child_value = child.text
                 elif is_enum_type("SwVariableRefProxy", package_data):
@@ -837,11 +853,19 @@ class SwDataDefProps(ARObject):
         if container is not None:
             for child in container:
                 if is_ref:
-                    child_tag = SerializationHelper.strip_namespace(child.tag)
-                    if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
-                        child_value = ARRef.deserialize(child)
+                    # Use the child_tag from decorator if specified to match specific child tag
+                    if child_tag:
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag == "None":
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                     else:
-                        child_value = SerializationHelper.deserialize_by_tag(child, None)
+                        child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                        if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
+                            child_value = ARRef.deserialize(child)
+                        else:
+                            child_value = SerializationHelper.deserialize_by_tag(child, None)
                 elif is_primitive_type("Numerical", package_data):
                     child_value = child.text
                 elif is_enum_type("Numerical", package_data):

--- a/src/armodel/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout.py
@@ -15,7 +15,6 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
-from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel.models.M2.MSR.DataDictionary.RecordLayout.sw_record_layout_group import (
     SwRecordLayoutGroup,
 )
@@ -33,11 +32,11 @@ class SwRecordLayout(ARElement):
         """
         return False
 
-    sw_record_ref: Optional[ARRef]
+    sw_record_layout_group: Optional[SwRecordLayoutGroup]
     def __init__(self) -> None:
         """Initialize SwRecordLayout."""
         super().__init__()
-        self.sw_record_ref: Optional[ARRef] = None
+        self.sw_record_layout_group: Optional[SwRecordLayoutGroup] = None
 
     def serialize(self) -> ET.Element:
         """Serialize SwRecordLayout to XML element.
@@ -63,12 +62,12 @@ class SwRecordLayout(ARElement):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize sw_record_ref
-        if self.sw_record_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_record_ref, "SwRecordLayoutGroup")
+        # Serialize sw_record_layout_group
+        if self.sw_record_layout_group is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group, "SwRecordLayoutGroup")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("SW-RECORD-REF")
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -92,11 +91,11 @@ class SwRecordLayout(ARElement):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(SwRecordLayout, cls).deserialize(element)
 
-        # Parse sw_record_ref
-        child = SerializationHelper.find_child_element(element, "SW-RECORD-REF")
+        # Parse sw_record_layout_group
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP")
         if child is not None:
-            sw_record_ref_value = ARRef.deserialize(child)
-            obj.sw_record_ref = sw_record_ref_value
+            sw_record_layout_group_value = SerializationHelper.deserialize_by_tag(child, "SwRecordLayoutGroup")
+            obj.sw_record_layout_group = sw_record_layout_group_value
 
         return obj
 
@@ -233,8 +232,8 @@ class SwRecordLayoutBuilder:
         self._obj.uuid = value
         return self
 
-    def with_sw_record(self, value: Optional[SwRecordLayoutGroup]) -> "SwRecordLayoutBuilder":
-        """Set sw_record attribute.
+    def with_sw_record_layout_group(self, value: Optional[SwRecordLayoutGroup]) -> "SwRecordLayoutBuilder":
+        """Set sw_record_layout_group attribute.
 
         Args:
             value: Value to set
@@ -244,7 +243,7 @@ class SwRecordLayoutBuilder:
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.sw_record = value
+        self._obj.sw_record_layout_group = value
         return self
 
 

--- a/src/armodel/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout_group.py
+++ b/src/armodel/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout_group.py
@@ -15,6 +15,8 @@ from armodel.serialization import SerializationHelper
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Identifier,
+    Integer,
+    NameToken,
 )
 from armodel.models.M2.MSR.DataDictionary.RecordLayout import (
     AsamRecordLayoutSemantics,
@@ -23,8 +25,8 @@ from armodel.models.M2.MSR.DataDictionary.RecordLayout import (
 from armodel.models.M2.MSR.Documentation.TextModel.MultilanguageData.multi_language_overview_paragraph import (
     MultiLanguageOverviewParagraph,
 )
-from armodel.models.M2.MSR.DataDictionary.Axis.sw_generic_axis_param import (
-    SwGenericAxisParam,
+from armodel.models.M2.MSR.DataDictionary.Axis.sw_generic_axis_param_type import (
+    SwGenericAxisParamType,
 )
 
 
@@ -43,16 +45,28 @@ class SwRecordLayoutGroup(ARObject):
     category: Optional[AsamRecordLayoutSemantics]
     desc: Optional[MultiLanguageOverviewParagraph]
     short_label: Optional[Identifier]
-    sw_generic_axis_param_ref: Optional[ARRef]
-    sw_record: Optional[RecordLayoutIteratorPoint]
+    sw_generic_axis_param_type_ref: Optional[ARRef]
+    sw_record_layout_component: Optional[Identifier]
+    sw_record_layout_group_axis: Optional[AxisIndexType ]
+    sw_record_layout_group_content_type: Optional[swRecordLayoutGroupContent]
+    sw_record_layout_group_index: Optional[NameToken]
+    sw_record_layout_group_step: Optional[Integer]
+    sw_record_layout_group_from: Optional[RecordLayoutIteratorPoint]
+    sw_record_layout_group_to: Optional[RecordLayoutIteratorPoint]
     def __init__(self) -> None:
         """Initialize SwRecordLayoutGroup."""
         super().__init__()
         self.category: Optional[AsamRecordLayoutSemantics] = None
         self.desc: Optional[MultiLanguageOverviewParagraph] = None
         self.short_label: Optional[Identifier] = None
-        self.sw_generic_axis_param_ref: Optional[ARRef] = None
-        self.sw_record: Optional[RecordLayoutIteratorPoint] = None
+        self.sw_generic_axis_param_type_ref: Optional[ARRef] = None
+        self.sw_record_layout_component: Optional[Identifier] = None
+        self.sw_record_layout_group_axis: Optional[AxisIndexType ] = None
+        self.sw_record_layout_group_content_type: Optional[swRecordLayoutGroupContent] = None
+        self.sw_record_layout_group_index: Optional[NameToken] = None
+        self.sw_record_layout_group_step: Optional[Integer] = None
+        self.sw_record_layout_group_from: Optional[RecordLayoutIteratorPoint] = None
+        self.sw_record_layout_group_to: Optional[RecordLayoutIteratorPoint] = None
 
     def serialize(self) -> ET.Element:
         """Serialize SwRecordLayoutGroup to XML element.
@@ -120,12 +134,12 @@ class SwRecordLayoutGroup(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sw_generic_axis_param_ref
-        if self.sw_generic_axis_param_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_generic_axis_param_ref, "SwGenericAxisParam")
+        # Serialize sw_generic_axis_param_type_ref
+        if self.sw_generic_axis_param_type_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_generic_axis_param_type_ref, "SwGenericAxisParamType")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("SW-GENERIC-AXIS-PARAM-REF")
+                wrapped = ET.Element("SW-GENERIC-AXIS-PARAM-TYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -134,12 +148,96 @@ class SwRecordLayoutGroup(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sw_record
-        if self.sw_record is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_record, "RecordLayoutIteratorPoint")
+        # Serialize sw_record_layout_component
+        if self.sw_record_layout_component is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_component, "Identifier")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("SW-RECORD")
+                wrapped = ET.Element("SW-RECORD-LAYOUT-COMPONENT")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_axis
+        if self.sw_record_layout_group_axis is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_axis, "AxisIndexType ")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-AXIS")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_content_type
+        if self.sw_record_layout_group_content_type is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_content_type, "swRecordLayoutGroupContent")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-CONTENT-TYPE")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_index
+        if self.sw_record_layout_group_index is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_index, "NameToken")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-INDEX")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_step
+        if self.sw_record_layout_group_step is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_step, "Integer")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-STEP")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_from
+        if self.sw_record_layout_group_from is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_from, "RecordLayoutIteratorPoint")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-FROM")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_record_layout_group_to
+        if self.sw_record_layout_group_to is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_to, "RecordLayoutIteratorPoint")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-RECORD-LAYOUT-GROUP-TO")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -181,17 +279,53 @@ class SwRecordLayoutGroup(ARObject):
             short_label_value = SerializationHelper.deserialize_by_tag(child, "Identifier")
             obj.short_label = short_label_value
 
-        # Parse sw_generic_axis_param_ref
-        child = SerializationHelper.find_child_element(element, "SW-GENERIC-AXIS-PARAM-REF")
+        # Parse sw_generic_axis_param_type_ref
+        child = SerializationHelper.find_child_element(element, "SW-GENERIC-AXIS-PARAM-TYPE-REF")
         if child is not None:
-            sw_generic_axis_param_ref_value = ARRef.deserialize(child)
-            obj.sw_generic_axis_param_ref = sw_generic_axis_param_ref_value
+            sw_generic_axis_param_type_ref_value = ARRef.deserialize(child)
+            obj.sw_generic_axis_param_type_ref = sw_generic_axis_param_type_ref_value
 
-        # Parse sw_record
-        child = SerializationHelper.find_child_element(element, "SW-RECORD")
+        # Parse sw_record_layout_component
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-COMPONENT")
         if child is not None:
-            sw_record_value = child.text
-            obj.sw_record = sw_record_value
+            sw_record_layout_component_value = SerializationHelper.deserialize_by_tag(child, "Identifier")
+            obj.sw_record_layout_component = sw_record_layout_component_value
+
+        # Parse sw_record_layout_group_axis
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-AXIS")
+        if child is not None:
+            sw_record_layout_group_axis_value = SerializationHelper.deserialize_by_tag(child, "AxisIndexType ")
+            obj.sw_record_layout_group_axis = sw_record_layout_group_axis_value
+
+        # Parse sw_record_layout_group_content_type
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-CONTENT-TYPE")
+        if child is not None:
+            sw_record_layout_group_content_type_value = SerializationHelper.deserialize_by_tag(child, "swRecordLayoutGroupContent")
+            obj.sw_record_layout_group_content_type = sw_record_layout_group_content_type_value
+
+        # Parse sw_record_layout_group_index
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-INDEX")
+        if child is not None:
+            sw_record_layout_group_index_value = child.text
+            obj.sw_record_layout_group_index = sw_record_layout_group_index_value
+
+        # Parse sw_record_layout_group_step
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-STEP")
+        if child is not None:
+            sw_record_layout_group_step_value = child.text
+            obj.sw_record_layout_group_step = sw_record_layout_group_step_value
+
+        # Parse sw_record_layout_group_from
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-FROM")
+        if child is not None:
+            sw_record_layout_group_from_value = child.text
+            obj.sw_record_layout_group_from = sw_record_layout_group_from_value
+
+        # Parse sw_record_layout_group_to
+        child = SerializationHelper.find_child_element(element, "SW-RECORD-LAYOUT-GROUP-TO")
+        if child is not None:
+            sw_record_layout_group_to_value = child.text
+            obj.sw_record_layout_group_to = sw_record_layout_group_to_value
 
         return obj
 
@@ -248,8 +382,8 @@ class SwRecordLayoutGroupBuilder:
         self._obj.short_label = value
         return self
 
-    def with_sw_generic_axis_param(self, value: Optional[SwGenericAxisParam]) -> "SwRecordLayoutGroupBuilder":
-        """Set sw_generic_axis_param attribute.
+    def with_sw_generic_axis_param_type(self, value: Optional[SwGenericAxisParamType]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_generic_axis_param_type attribute.
 
         Args:
             value: Value to set
@@ -259,11 +393,11 @@ class SwRecordLayoutGroupBuilder:
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.sw_generic_axis_param = value
+        self._obj.sw_generic_axis_param_type = value
         return self
 
-    def with_sw_record(self, value: Optional[RecordLayoutIteratorPoint]) -> "SwRecordLayoutGroupBuilder":
-        """Set sw_record attribute.
+    def with_sw_record_layout_component(self, value: Optional[Identifier]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_component attribute.
 
         Args:
             value: Value to set
@@ -273,7 +407,91 @@ class SwRecordLayoutGroupBuilder:
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.sw_record = value
+        self._obj.sw_record_layout_component = value
+        return self
+
+    def with_sw_record_layout_group_axis(self, value: Optional[AxisIndexType ]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_axis attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_axis = value
+        return self
+
+    def with_sw_record_layout_group_content_type(self, value: Optional[swRecordLayoutGroupContent]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_content_type attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_content_type = value
+        return self
+
+    def with_sw_record_layout_group_index(self, value: Optional[NameToken]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_index attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_index = value
+        return self
+
+    def with_sw_record_layout_group_step(self, value: Optional[Integer]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_step attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_step = value
+        return self
+
+    def with_sw_record_layout_group_from(self, value: Optional[RecordLayoutIteratorPoint]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_from attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_from = value
+        return self
+
+    def with_sw_record_layout_group_to(self, value: Optional[RecordLayoutIteratorPoint]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_to attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.sw_record_layout_group_to = value
         return self
 
 

--- a/src/armodel/models/M2/MSR/Documentation/BlockElements/RequirementsTracing/structured_req.py
+++ b/src/armodel/models/M2/MSR/Documentation/BlockElements/RequirementsTracing/structured_req.py
@@ -375,8 +375,8 @@ class StructuredReq(Paginateable):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:

--- a/src/armodel/models/M2/MSR/Documentation/BlockElements/RequirementsTracing/traceable.py
+++ b/src/armodel/models/M2/MSR/Documentation/BlockElements/RequirementsTracing/traceable.py
@@ -99,8 +99,8 @@ class Traceable(MultilanguageReferrable, ABC):
         if container is not None:
             for child in container:
                 # Check if child is a reference element (ends with -REF or -TREF)
-                child_tag = SerializationHelper.strip_namespace(child.tag)
-                if child_tag.endswith("-REF") or child_tag.endswith("-TREF"):
+                child_element_tag = SerializationHelper.strip_namespace(child.tag)
+                if child_element_tag.endswith("-REF") or child_element_tag.endswith("-TREF"):
                     # Use ARRef.deserialize() for reference elements
                     child_value = ARRef.deserialize(child)
                 else:


### PR DESCRIPTION
## Summary

This PR enhances the `@xml_element_name` decorator to support multi-level nested XML element structures using forward-slash-separated paths (e.g., `"TAG1/TAG2/TAG3"`).

## Problem

Previously, the `@xml_element_name` decorator only supported single-level custom tag names. When AUTOSAR schemas required nested wrapper elements (e.g., `<CAN-ENTER-EXCLUSIVE-AREA-REFS><CAN-ENTER-EXCLUSIVE-AREA><CAN-ENTER-EXCLUSIVE-AREA-REF>`), there was no clean way to handle this in the code generator.

## Solution

The code generator now:
1. **Splits the tag path** by `/` into outer_tags (intermediate levels) and inner_tag (leaf level)
2. **Creates nested wrappers** during serialization (reverse order: innermost to outermost)
3. **Navigates through nested levels** during deserialization to find actual child elements
4. **Uses forward slash separator** instead of comma for better clarity

## Changes

### Code Generator (`tools/generate_models/generators.py`)

- **serialize() method**: Added nested wrapper creation logic
- **deserialize() method**: Added nested container navigation logic
- **atp_variant handling**: Applied same multi-level logic to `@atp_variant` classes

### Generated Models

Regenerated 250+ model classes to use new forward-slash separator:
- `ExecutableEntity.can_enter_refs`
- `BswModuleDescription.required_client_server_entries`
- And 250+ other attributes with multi-level nesting

### Variable Naming

Fixed consistency in deserialize() methods:
- Changed `child_tag` → `child_element_tag` for clarity

### Documentation

- `docs/designs/decorators.md`: Added multi-level nesting documentation
- `AGENTS.md`: Added `@xml_element_name` decorator examples

## Example

**Python code**:
```python
class ExecutableEntity(ARObject):
    @property
    @xml_element_name("CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA/CAN-ENTER-EXCLUSIVE-AREA-REF")
    def can_enter_refs(self) -> list[ARRef]:
        return self._can_enter_refs
```

**Generated XML**:
```xml
<CAN-ENTER-EXCLUSIVE-AREA-REFS>
  <CAN-ENTER-EXCLUSIVE-AREA>
    <CAN-ENTER-EXCLUSIVE-AREA-REF DEST="EXCLUSIVE-AREA">/path/to/area</CAN-ENTER-EXCLUSIVE-AREA-REF>
  </CAN-ENTER-EXCLUSIVE-AREA>
</CAN-ENTER-EXCLUSIVE-AREA-REFS>
```

## Test Coverage

✅ **All quality checks passed**:
- **Ruff**: No linting errors (1 auto-fixed)
- **MyPy**: No type errors (2252 source files)
- **Pytest**: 259 passed, 3 xfailed, 1 xpassed

## Breaking Changes

⚠️ **Separator change**: Comma (`,`) → Forward slash (`/`)

Any manually maintained classes (in `tools/skip_classes.yaml`) that use comma-separated `@xml_element_name` decorators must be updated to use the new forward-slash format.

## Files Modified

- `tools/generate_models/generators.py` (~150 lines changed)
- 250+ generated model files (regenerated)
- `docs/designs/decorators.md` (documentation)
- `AGENTS.md` (documentation)

Closes #112