### PR TITLE
refactor: Rename @l_prefix to @lang_prefix and enhance @xml_attribute

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ArObject.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ArObject.classes.json
@@ -393,7 +393,7 @@
         "BlueprintMapping"
       ],
       "subclasses": [
-        "–all concrete metaclasses–"
+        "\u2013all concrete metaclasses\u2013"
       ],
       "aggregated_by": [],
       "implements": [],
@@ -413,14 +413,15 @@
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
-          "note": "Checksum calculated by the user’s tool environment for"
+          "note": "Checksum calculated by the user\u2019s tool environment for"
         },
         "timestamp": {
           "type": "DateTime",
           "multiplicity": "0..1",
-          "kind": "xml_attribute",
+          "kind": "aggr",
+          "decorator": "xml_attribute:T",
           "is_ref": false,
-          "note": "Timestamp calculated by the user’s tool environment for"
+          "note": "Timestamp calculated by the user\u2019s tool environment for"
         }
       }
     }

--- a/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
@@ -204,9 +204,10 @@
         "gid": {
           "type": "NameToken",
           "multiplicity": "1",
-          "kind": "xml_attribute",
+          "kind": "aggr",
           "is_ref": false,
-          "note": "This attributes specifies an identifier. Gid comes from the SGML/XML-Term \"Generic Identifier\" which is the element name in XML. The role of this attribute is the same as the name of an XML - element."
+          "note": "This attributes specifies an identifier. Gid comes from the SGML/XML-Term \"Generic Identifier\" which is the element name in XML. The role of this attribute is the same as the name of an XML - element.",
+          "decorator": "xml_attribute"
         },
         "value": {
           "type": "VerbatimStringPlain",

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_Figure.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_Figure.classes.json
@@ -241,9 +241,10 @@
         "filename": {
           "type": "String",
           "multiplicity": "0..1",
-          "kind": "xml_attribute",
+          "kind": "aggr",
           "is_ref": false,
-          "note": "Name of the file that should be displayed. This attribute is"
+          "note": "Name of the file that should be displayed. This attribute is",
+          "decorator": "xml_attribute"
         },
         "fit": {
           "type": "GraphicFitEnum",
@@ -495,9 +496,10 @@
         "lGraphic": {
           "type": "LGraphic",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": "Container of the graphic (or diagram) and optional map of"
+          "note": "Container of the graphic (or diagram) and optional map of",
+          "decorator": "lang_prefix:L-GRAPHIC"
         },
         "pgwide": {
           "type": "PgwideEnum",

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_ListElements.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_ListElements.classes.json
@@ -39,9 +39,10 @@
         "type": {
           "type": "ListEnum",
           "multiplicity": "0..1",
-          "kind": "xml_attribute",
+          "kind": "aggr",
           "is_ref": false,
-          "note": "The type of the list. Default is \"UNNUMBER\""
+          "note": "The type of the list. Default is \"UNNUMBER\"",
+          "decorator": "xml_attribute"
         }
       }
     },

--- a/docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData.classes.json
@@ -59,9 +59,10 @@
         "l2": {
           "type": "LOverviewParagraph",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": ""
+          "note": "",
+          "decorator": "lang_prefix:L-2"
         }
       }
     },
@@ -111,9 +112,10 @@
         "l4": {
           "type": "LLongName",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": ""
+          "note": "",
+          "decorator": "lang_prefix:L-4"
         }
       }
     },
@@ -155,9 +157,10 @@
         "l1": {
           "type": "LParagraph",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": ""
+          "note": "",
+          "decorator": "lang_prefix:L-1"
         }
       }
     },
@@ -216,9 +219,10 @@
         "l5": {
           "type": "LVerbatim",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": ""
+          "note": "",
+          "decorator": "lang_prefix:L-5"
         },
         "pgwide": {
           "type": "PgwideEnum",
@@ -260,9 +264,10 @@
         "l10": {
           "type": "LPlainText",
           "multiplicity": "*",
-          "kind": "l_prefix",
+          "kind": "aggr",
           "is_ref": false,
-          "note": ""
+          "note": "",
+          "decorator": "lang_prefix:L-10"
         }
       }
     }

--- a/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject/ar_object.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/GenericStructure/GeneralTemplateClasses/ArObject/ar_object.py
@@ -50,7 +50,7 @@ class ARObject:
         self._checksum = value
 
     @property
-    @xml_attribute
+    @xml_attribute("T")
     def timestamp(self) -> Optional["DateTime"]:
         """Timestamp attribute serialized as XML attribute 'T'."""
         return self._timestamp

--- a/src/armodel/models/M2/MSR/Documentation/BlockElements/Figure/ml_figure.py
+++ b/src/armodel/models/M2/MSR/Documentation/BlockElements/Figure/ml_figure.py
@@ -8,7 +8,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_BlockElements_Figure.classe
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.MSR.Documentation.BlockElements.PaginationAndView.paginateable import (
     Paginateable,
@@ -61,7 +61,7 @@ class MlFigure(Paginateable):
         self.pgwide: Optional[PgwideEnum] = None
         self.verbatim: Optional[MultiLanguageVerbatim] = None
     @property
-    @l_prefix("L-GRAPHIC")
+    @lang_prefix("L-GRAPHIC")
     def l_graphic(self) -> list[LGraphic]:
         """Get l_graphic with language-specific wrapper."""
         return self._l_graphic
@@ -138,11 +138,11 @@ class MlFigure(Paginateable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize l_graphic (list with l_prefix "L-GRAPHIC")
+        # Serialize l_graphic (list with lang_prefix "L-GRAPHIC")
         for item in self.l_graphic:
             serialized = SerializationHelper.serialize_item(item, "LGraphic")
             if serialized is not None:
-                # For l_prefix lists, wrap each item in the l_prefix tag
+                # For lang_prefix lists, wrap each item in the lang_prefix tag
                 wrapped = ET.Element("L-GRAPHIC")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
@@ -213,7 +213,7 @@ class MlFigure(Paginateable):
             help_entry_value = child.text
             obj.help_entry = help_entry_value
 
-        # Parse l_graphic (list with l_prefix "L-GRAPHIC")
+        # Parse l_graphic (list with lang_prefix "L-GRAPHIC")
         obj.l_graphic = []
         for child in SerializationHelper.find_all_child_elements(element, "L-GRAPHIC"):
             l_graphic_value = SerializationHelper.deserialize_by_tag(child, "LGraphic")

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/LanguageDataModel/l_paragraph.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/LanguageDataModel/l_paragraph.py
@@ -14,7 +14,7 @@ from armodel.models.M2.MSR.Documentation.TextModel.LanguageDataModel.language_sp
 )
 from armodel.serialization import SerializationHelper
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 
 class LParagraph(LanguageSpecific):
@@ -37,7 +37,7 @@ class LParagraph(LanguageSpecific):
         self._l3: list[LParagraph] = []
 
     @property
-    @l_prefix("L-1")
+    @lang_prefix("L-1")
     def l1(self) -> list[LParagraph]:
         """Get l1 with language-specific wrapper."""
         return self._l1
@@ -48,7 +48,7 @@ class LParagraph(LanguageSpecific):
         self._l1 = value
 
     @property
-    @l_prefix("L-2")
+    @lang_prefix("L-2")
     def l2(self) -> list[LParagraph]:
         """Get l2 with language-specific wrapper."""
         return self._l2
@@ -59,7 +59,7 @@ class LParagraph(LanguageSpecific):
         self._l2 = value
 
     @property
-    @l_prefix("L-3")
+    @lang_prefix("L-3")
     def l3(self) -> list[LParagraph]:
         """Get l3 with language-specific wrapper."""
         return self._l3

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_overview_paragraph.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_overview_paragraph.py
@@ -11,7 +11,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -38,7 +38,7 @@ class MultiLanguageOverviewParagraph(ARObject):
         super().__init__()
         self._l2: list[LOverviewParagraph] = []
     @property
-    @l_prefix("L-2")
+    @lang_prefix("L-2")
     def l2(self) -> list[LOverviewParagraph]:
         """Get l2 with language-specific wrapper."""
         return self._l2
@@ -73,11 +73,11 @@ class MultiLanguageOverviewParagraph(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize l2 (list with l_prefix "L-2")
+        # Serialize l2 (list with lang_prefix "L-2")
         for item in self.l2:
             serialized = SerializationHelper.serialize_item(item, "LOverviewParagraph")
             if serialized is not None:
-                # For l_prefix lists, wrap each item in the l_prefix tag
+                # For lang_prefix lists, wrap each item in the lang_prefix tag
                 wrapped = ET.Element("L-2")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
@@ -102,7 +102,7 @@ class MultiLanguageOverviewParagraph(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(MultiLanguageOverviewParagraph, cls).deserialize(element)
 
-        # Parse l2 (list with l_prefix "L-2")
+        # Parse l2 (list with lang_prefix "L-2")
         obj.l2 = []
         for child in SerializationHelper.find_all_child_elements(element, "L-2"):
             l2_value = SerializationHelper.deserialize_by_tag(child, "LOverviewParagraph")

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_paragraph.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_paragraph.py
@@ -8,7 +8,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.MSR.Documentation.BlockElements.PaginationAndView.paginateable import (
     Paginateable,
@@ -43,7 +43,7 @@ class MultiLanguageParagraph(Paginateable):
         self.help_entry: Optional[String] = None
         self._l1: list[LParagraph] = []
     @property
-    @l_prefix("L-1")
+    @lang_prefix("L-1")
     def l1(self) -> list[LParagraph]:
         """Get l1 with language-specific wrapper."""
         return self._l1

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_plain_text.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_plain_text.py
@@ -8,7 +8,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -35,7 +35,7 @@ class MultiLanguagePlainText(ARObject):
         super().__init__()
         self._l10: list[LPlainText] = []
     @property
-    @l_prefix("L-10")
+    @lang_prefix("L-10")
     def l10(self) -> list[LPlainText]:
         """Get l10 with language-specific wrapper."""
         return self._l10

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_verbatim.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multi_language_verbatim.py
@@ -8,7 +8,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.MSR.Documentation.BlockElements.PaginationAndView.paginateable import (
     Paginateable,
@@ -54,7 +54,7 @@ class MultiLanguageVerbatim(Paginateable):
         self._l5: list[LVerbatim] = []
         self.pgwide: Optional[PgwideEnum] = None
     @property
-    @l_prefix("L-5")
+    @lang_prefix("L-5")
     def l5(self) -> list[LVerbatim]:
         """Get l5 with language-specific wrapper."""
         return self._l5

--- a/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multilanguage_long_name.py
+++ b/src/armodel/models/M2/MSR/Documentation/TextModel/MultilanguageData/multilanguage_long_name.py
@@ -10,7 +10,7 @@ JSON Source: docs/json/packages/M2_MSR_Documentation_TextModel_MultilanguageData
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel.serialization.decorators import l_prefix
+from armodel.serialization.decorators import lang_prefix
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -37,7 +37,7 @@ class MultilanguageLongName(ARObject):
         super().__init__()
         self._l4: list[LLongName] = []
     @property
-    @l_prefix("L-4")
+    @lang_prefix("L-4")
     def l4(self) -> list[LLongName]:
         """Get l4 with language-specific wrapper."""
         return self._l4

--- a/tests/integration/test_binary_comparison.py
+++ b/tests/integration/test_binary_comparison.py
@@ -515,7 +515,6 @@ class TestIndividualFiles:
             tmp_path
         )
 
-    @pytest.mark.xfail
     def test_bswm_bswmd_binary_comparison(
         self,
         reader: ARXMLReader,


### PR DESCRIPTION
## Summary

This PR refactors the `@l_prefix` decorator to `@lang_prefix` for better clarity and enhances the `@xml_attribute` decorator to support custom XML attribute names. These changes improve the decorator system's consistency and expressiveness while maintaining backward compatibility.

## Changes

### 🔄 Decorator Renaming: `@l_prefix` → `@lang_prefix`

**Rationale**: The new name `@lang_prefix` more clearly indicates that the decorator handles **language-specific** prefixes for multilanguage text elements.

**Updated Files**:
- `src/armodel/serialization/decorators.py` - Renamed decorator function and marker attributes
- All MultiLanguage* classes regenerated with new decorator
- JSON mapping files updated with new format
- Documentation updated throughout

**Marker Attributes**:
```python
# Old
_l_prefix, _l_prefix_tag

# New
_lang_prefix, _lang_prefix_tag
```

### ✨ Enhanced `@xml_attribute` Decorator

**New Feature**: Accept optional parameter for custom XML attribute name

**Before** (auto-generated name):
```python
@xml_attribute
@property
def schema_version(self) -> str:
    return self._schema_version
# Result: <AUTOSAR SCHEMA-VERSION="4.5.0">
```

**After** (custom name supported):
```python
@xml_attribute("T")
@property
def timestamp(self) -> str:
    return self._timestamp
# Result: <AR-OBJECT T="2025-01-01T12:00:00">
```

**Backward Compatible**: Parameterless usage continues to work as before

### 🔧 Code Generator Updates

**File**: `tools/generate_models/generators.py`

- ✅ Updated to process `decorator: "lang_prefix:L-N"` format instead of `kind: "l_prefix"`
- ✅ Enhanced to handle `xml_attribute` with optional custom name parameter
- ✅ Parses decorator field with format `"decorator_name:params"` or just `"decorator_name"`

### 📝 Updated Classes

All MultiLanguage* classes regenerated with `@lang_prefix` decorator:

| Class | File |
|-------|------|
| `MultiLanguagePlainText` | `multi_language_plain_text.py` |
| `MultiLanguageParagraph` | `multi_language_paragraph.py` |
| `MultiLanguageOverviewParagraph` | `multi_language_overview_paragraph.py` |
| `MultiLanguageVerbatim` | `multi_language_verbatim.py` |
| `MultilanguageLongName` | `multilanguage_long_name.py` |
| `LParagraph` | `l_paragraph.py` |
| `MLFigure` | `ml_figure.py` |

### 📚 Documentation Updates

**File**: `docs/designs/decorators.md`

- ✅ Renamed section from `@l_prefix` to `@lang_prefix`
- ✅ Added `@xml_attribute` custom name examples
- ✅ Updated implementation details and marker tables
- ✅ Updated JSON configuration examples
- ✅ Updated usage guidelines and comparison tables

## Files Modified

| File | Changes |
|------|---------|
| `src/armodel/serialization/decorators.py` | Renamed decorator, enhanced xml_attribute |
| `src/armodel/models/M2/AUTOSARTemplates/.../ar_object.py` | Updated decorator usage |
| `src/armodel/models/M2/MSR/Documentation/.../multi_language_*.py` | Regenerated with new decorator (5 files) |
| `src/armodel/models/M2/MSR/Documentation/.../ml_figure.py` | Updated decorator usage |
| `src/armodel/models/M2/MSR/Documentation/.../l_paragraph.py` | Updated decorator usage |
| `tools/generate_models/generators.py` | Enhanced code generator |
| `docs/json/packages/*_*.classes.json` | Updated decorator configs (6 files) |
| `docs/designs/decorators.md` | Comprehensive documentation updates |
| `tests/integration/test_binary_comparison.py` | Minor cleanup |

**Total**: 17 files changed, 315 insertions(+), 146 deletions(-)

## Test Coverage

✅ **All tests pass**: 260 passed, 3 xfailed  
✅ **Linting passes**: No ruff errors  
✅ **Type checking passes**: No mypy errors  
✅ **Integration tests pass**: Binary comparison test confirms read/write cycle

## Breaking Changes

### ⚠️ Decorator Renamed: `@l_prefix` → `@lang_prefix`

**Affected Classes**: Manually maintained classes in `tools/skip_classes.yaml`

**Migration Guide**:
```python
# Old
from armodel.serialization.decorators import l_prefix

@l_prefix("L-10")
def l10(self):
    return self._l10

# New
from armodel.serialization.decorators import lang_prefix

@lang_prefix("L-10")
def l10(self):
    return self._l10
```

**Note**: Generated classes are automatically updated by this PR. Only manually maintained classes need manual updates.

### ✅ Backward Compatible: `@xml_attribute`

Parameterless usage continues to work:
```python
@xml_attribute  # Still works
@property
def schema_version(self):
    return self._schema_version
```

## Requirements Traceability

N/A - This is a refactoring PR that improves code clarity and adds flexibility without changing functionality.

## Related Issues

Closes #116