### PR TITLE
feat: Fix @ref_conditional decorator type tag derivation and update Fibex model inheritance

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate.classes.json
@@ -55,7 +55,7 @@
         "hwElementConnections": {
           "type": "HwElementConnector",
           "multiplicity": "*",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "This represents one particular connection between two elements. atpVariation"
         },
@@ -118,7 +118,7 @@
         "hwAttributeValues": {
           "type": "HwAttributeValue",
           "multiplicity": "*",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "This aggregation represents a particular hardware value. atpVariation"
         },

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanTopology.classes.json
@@ -239,7 +239,7 @@
       "is_abstract": false,
       "atp_type": "atpVariation",
       "decorator": "atp_variant",
-      "parent": null,
+      "parent": "AbstractCanCommunicationController",
       "bases": [
         "ARObject",
         "AbstractCanCommunicationController",
@@ -272,7 +272,7 @@
       "package": "M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Can::CanTopology",
       "is_abstract": true,
       "atp_type": "atpVariation",
-      "parent": null,
+      "parent": "CommunicationController",
       "bases": [
         "ARObject",
         "CommunicationController",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
@@ -1529,7 +1529,7 @@
       "package": "M2::AUTOSARTemplates::SystemTemplate::Fibex::FibexCore::CoreCommunication",
       "is_abstract": false,
       "atp_type": "atpPrototype",
-      "parent": null,
+      "parent": "Identifiable",
       "bases": [
         "ARObject",
         "Identifiable",
@@ -1553,7 +1553,7 @@
         }
       ],
       "attributes": {
-        "packingByte": {
+        "packingByteOrder": {
           "type": "ByteOrderEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
@@ -1574,7 +1574,7 @@
           "is_ref": false,
           "note": "This attribute describes the bitposition of a Pdu within a"
         },
-        "update": {
+        "updateIndicationBitPosition": {
           "type": "Integer",
           "multiplicity": "0..1",
           "kind": "attribute",

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreTopology.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreTopology.classes.json
@@ -376,6 +376,7 @@
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
+          "decorator": "ref_conditional:COMM-CONNECTORS",
           "note": "Reference to the ECUInstance via a Communication assignment of Physical Channels to is expressed with atpVariation"
         },
         "frameTriggerings": {
@@ -455,7 +456,7 @@
       "package": "M2::AUTOSARTemplates::SystemTemplate::Fibex::FibexCore::CoreTopology",
       "is_abstract": true,
       "atp_type": "atpVariation",
-      "parent": null,
+      "parent": "Identifiable",
       "bases": [
         "ARObject",
         "Identifiable",
@@ -486,7 +487,7 @@
         }
       ],
       "attributes": {
-        "wakeUpBy": {
+        "wakeUpByControllerSupported": {
           "type": "Boolean",
           "multiplicity": "0..1",
           "kind": "attribute",

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/abstract_can_communication_controller.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/abstract_can_communication_controller.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Any
 import xml.etree.ElementTree as ET
 
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreTopology.communication_controller import (
+    CommunicationController,
+)
 from armodel.models.M2.builder_base import BuilderBase
 from abc import ABC, abstractmethod
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
 
 
-class AbstractCanCommunicationController(ARObject, ABC):
+class AbstractCanCommunicationController(CommunicationController, ABC):
     """AUTOSAR AbstractCanCommunicationController."""
 
     @property

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/can_communication_controller.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/can_communication_controller.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 from armodel.serialization.decorators import atp_variant
 
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.Fibex4Can.CanTopology.abstract_can_communication_controller import (
+    AbstractCanCommunicationController,
+)
 from armodel.models.M2.builder_base import BuilderBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -17,7 +20,7 @@ from armodel.serialization import SerializationHelper
 
 @atp_variant()
 
-class CanCommunicationController(ARObject):
+class CanCommunicationController(AbstractCanCommunicationController):
     """AUTOSAR CanCommunicationController."""
 
     @property

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdu_to_frame_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdu_to_frame_mapping.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.identifiable import (
+    Identifiable,
+)
 from armodel.models.M2.builder_base import BuilderBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
@@ -24,7 +27,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.serialization import SerializationHelper
 
 
-class PduToFrameMapping(ARObject):
+class PduToFrameMapping(Identifiable):
     """AUTOSAR PduToFrameMapping."""
 
     @property
@@ -36,17 +39,17 @@ class PduToFrameMapping(ARObject):
         """
         return False
 
-    packing_byte: Optional[ByteOrderEnum]
+    packing_byte_order: Optional[ByteOrderEnum]
     pdu_ref: Optional[ARRef]
     start_position: Optional[Integer]
-    update: Optional[Integer]
+    update_indication_bit_position: Optional[Integer]
     def __init__(self) -> None:
         """Initialize PduToFrameMapping."""
         super().__init__()
-        self.packing_byte: Optional[ByteOrderEnum] = None
+        self.packing_byte_order: Optional[ByteOrderEnum] = None
         self.pdu_ref: Optional[ARRef] = None
         self.start_position: Optional[Integer] = None
-        self.update: Optional[Integer] = None
+        self.update_indication_bit_position: Optional[Integer] = None
 
     def serialize(self) -> ET.Element:
         """Serialize PduToFrameMapping to XML element.
@@ -72,12 +75,12 @@ class PduToFrameMapping(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize packing_byte
-        if self.packing_byte is not None:
-            serialized = SerializationHelper.serialize_item(self.packing_byte, "ByteOrderEnum")
+        # Serialize packing_byte_order
+        if self.packing_byte_order is not None:
+            serialized = SerializationHelper.serialize_item(self.packing_byte_order, "ByteOrderEnum")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("PACKING-BYTE")
+                wrapped = ET.Element("PACKING-BYTE-ORDER")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -114,12 +117,12 @@ class PduToFrameMapping(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize update
-        if self.update is not None:
-            serialized = SerializationHelper.serialize_item(self.update, "Integer")
+        # Serialize update_indication_bit_position
+        if self.update_indication_bit_position is not None:
+            serialized = SerializationHelper.serialize_item(self.update_indication_bit_position, "Integer")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("UPDATE")
+                wrapped = ET.Element("UPDATE-INDICATION-BIT-POSITION")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -143,11 +146,11 @@ class PduToFrameMapping(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(PduToFrameMapping, cls).deserialize(element)
 
-        # Parse packing_byte
-        child = SerializationHelper.find_child_element(element, "PACKING-BYTE")
+        # Parse packing_byte_order
+        child = SerializationHelper.find_child_element(element, "PACKING-BYTE-ORDER")
         if child is not None:
-            packing_byte_value = ByteOrderEnum.deserialize(child)
-            obj.packing_byte = packing_byte_value
+            packing_byte_order_value = ByteOrderEnum.deserialize(child)
+            obj.packing_byte_order = packing_byte_order_value
 
         # Parse pdu_ref
         child = SerializationHelper.find_child_element(element, "PDU-REF")
@@ -161,11 +164,11 @@ class PduToFrameMapping(ARObject):
             start_position_value = child.text
             obj.start_position = start_position_value
 
-        # Parse update
-        child = SerializationHelper.find_child_element(element, "UPDATE")
+        # Parse update_indication_bit_position
+        child = SerializationHelper.find_child_element(element, "UPDATE-INDICATION-BIT-POSITION")
         if child is not None:
-            update_value = child.text
-            obj.update = update_value
+            update_indication_bit_position_value = child.text
+            obj.update_indication_bit_position = update_indication_bit_position_value
 
         return obj
 
@@ -180,8 +183,8 @@ class PduToFrameMappingBuilder(BuilderBase):
         self._obj: PduToFrameMapping = PduToFrameMapping()
 
 
-    def with_packing_byte(self, value: Optional[ByteOrderEnum]) -> "PduToFrameMappingBuilder":
-        """Set packing_byte attribute.
+    def with_packing_byte_order(self, value: Optional[ByteOrderEnum]) -> "PduToFrameMappingBuilder":
+        """Set packing_byte_order attribute.
 
         Args:
             value: Value to set
@@ -191,7 +194,7 @@ class PduToFrameMappingBuilder(BuilderBase):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.packing_byte = value
+        self._obj.packing_byte_order = value
         return self
 
     def with_pdu(self, value: Optional[Pdu]) -> "PduToFrameMappingBuilder":
@@ -222,8 +225,8 @@ class PduToFrameMappingBuilder(BuilderBase):
         self._obj.start_position = value
         return self
 
-    def with_update(self, value: Optional[Integer]) -> "PduToFrameMappingBuilder":
-        """Set update attribute.
+    def with_update_indication_bit_position(self, value: Optional[Integer]) -> "PduToFrameMappingBuilder":
+        """Set update_indication_bit_position attribute.
 
         Args:
             value: Value to set
@@ -233,7 +236,7 @@ class PduToFrameMappingBuilder(BuilderBase):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.update = value
+        self._obj.update_indication_bit_position = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/communication_controller.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/communication_controller.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
+from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.identifiable import (
+    Identifiable,
+)
 from armodel.models.M2.builder_base import BuilderBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Boolean,
@@ -18,7 +21,7 @@ from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.
 from armodel.serialization import SerializationHelper
 
 
-class CommunicationController(ARObject, ABC):
+class CommunicationController(Identifiable, ABC):
     """AUTOSAR CommunicationController."""
 
     @property
@@ -30,11 +33,11 @@ class CommunicationController(ARObject, ABC):
         """
         return True
 
-    wake_up_by: Optional[Boolean]
+    wake_up_by_controller_supported: Optional[Boolean]
     def __init__(self) -> None:
         """Initialize CommunicationController."""
         super().__init__()
-        self.wake_up_by: Optional[Boolean] = None
+        self.wake_up_by_controller_supported: Optional[Boolean] = None
 
     def serialize(self) -> ET.Element:
         """Serialize CommunicationController to XML element.
@@ -60,12 +63,12 @@ class CommunicationController(ARObject, ABC):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize wake_up_by
-        if self.wake_up_by is not None:
-            serialized = SerializationHelper.serialize_item(self.wake_up_by, "Boolean")
+        # Serialize wake_up_by_controller_supported
+        if self.wake_up_by_controller_supported is not None:
+            serialized = SerializationHelper.serialize_item(self.wake_up_by_controller_supported, "Boolean")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("WAKE-UP-BY")
+                wrapped = ET.Element("WAKE-UP-BY-CONTROLLER-SUPPORTED")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -89,11 +92,11 @@ class CommunicationController(ARObject, ABC):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(CommunicationController, cls).deserialize(element)
 
-        # Parse wake_up_by
-        child = SerializationHelper.find_child_element(element, "WAKE-UP-BY")
+        # Parse wake_up_by_controller_supported
+        child = SerializationHelper.find_child_element(element, "WAKE-UP-BY-CONTROLLER-SUPPORTED")
         if child is not None:
-            wake_up_by_value = child.text
-            obj.wake_up_by = wake_up_by_value
+            wake_up_by_controller_supported_value = child.text
+            obj.wake_up_by_controller_supported = wake_up_by_controller_supported_value
 
         return obj
 
@@ -108,8 +111,8 @@ class CommunicationControllerBuilder(BuilderBase, ABC):
         self._obj: CommunicationController = CommunicationController()
 
 
-    def with_wake_up_by(self, value: Optional[Boolean]) -> "CommunicationControllerBuilder":
-        """Set wake_up_by attribute.
+    def with_wake_up_by_controller_supported(self, value: Optional[Boolean]) -> "CommunicationControllerBuilder":
+        """Set wake_up_by_controller_supported attribute.
 
         Args:
             value: Value to set
@@ -119,7 +122,7 @@ class CommunicationControllerBuilder(BuilderBase, ABC):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.wake_up_by = value
+        self._obj.wake_up_by_controller_supported = value
         return self
 
 

--- a/tools/generate_models/generators.py
+++ b/tools/generate_models/generators.py
@@ -8,6 +8,7 @@ from ._common import (
     to_snake_case,
     to_autosar_xml_format,
 )
+from armodel.serialization.name_converter import NameConverter
 from .type_utils import (
     detect_circular_import,
     get_python_type,
@@ -1177,9 +1178,11 @@ def _generate_deserialize_method(
                     if decorator_name == "ref_conditional":
                         # Use ref_conditional pattern: container stays as-is, each item wrapped in -REF-CONDITIONAL
                         container_tag = attr_info.get("decorator_params", xml_tag)
-                        singular = container_tag[:-1]  # Remove trailing S
-                        conditional_tag = f"{singular}-REF-CONDITIONAL"
-                        ref_tag = f"{singular}-REF"
+                        # Use the type's XML tag for wrapper/reference generation (handles abbreviated container tags)
+                        type_xml_tag = NameConverter.to_xml_tag(attr_type)
+                        conditional_tag = f"{type_xml_tag}-REF-CONDITIONAL"
+                        ref_tag = f"{type_xml_tag}-REF"
+                        inner_tags = []
                     elif decorator_name == "xml_element_name":
                         # Parse decorator params: can be single value or multi-level path separated by '/'
                         # Examples: "PROVIDED-ENTRYS" or "CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA/CAN-ENTER-EXCLUSIVE-AREA-REF"
@@ -2991,9 +2994,10 @@ def _generate_serialize_method(
                     if decorator_name == "ref_conditional":
                         # Use ref_conditional pattern: container stays as-is, each item wrapped in -REF-CONDITIONAL
                         container_tag = attr_info.get("decorator_params", xml_tag)
-                        singular = container_tag[:-1]  # Remove trailing S
-                        conditional_tag = f"{singular}-REF-CONDITIONAL"
-                        ref_tag = f"{singular}-REF"
+                        # Use the type's XML tag for wrapper/reference generation (handles abbreviated container tags)
+                        type_xml_tag = NameConverter.to_xml_tag(attr_type)
+                        conditional_tag = f"{type_xml_tag}-REF-CONDITIONAL"
+                        ref_tag = f"{type_xml_tag}-REF"
                     elif decorator_name == "xml_element_name":
                         # Parse decorator params: can be single value or multi-level path separated by '/'
                         # Examples: "PROVIDED-ENTRYS" or "CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA/CAN-ENTER-EXCLUSIVE-AREA-REF"


### PR DESCRIPTION
## Summary

This PR fixes the `@ref_conditional` decorator implementation to correctly derive type XML tags from attribute type names rather than simple string truncation of container tags. This ensures proper XML serialization for abbreviated container names like `COMM-CONNECTORS`.

## Changes

### 1. @ref_conditional Decorator Enhancement
- Modified code generator to use `NameConverter.to_xml_tag(attr_type)` to derive correct type XML tags
- Ensures `CommunicationConnector` type → `COMMUNICATION-CONNECTOR-REF-CONDITIONAL` / `COMMUNICATION-CONNECTOR-REF`
- Handles abbreviated container names like `COMM-CONNECTORS` without incorrect truncation

### 2. Documentation Updates
- Updated `docs/designs/decorators.md` with detailed explanation of type tag derivation
- Added real-world example for PhysicalChannel.comm_connector_refs
- Clarified the difference between container tags and type tags

### 3. JSON Mapping Corrections
- Fixed parent class inheritance for:
  - `AbstractCanCommunicationController` → extends `CommunicationController`
  - `CanCommunicationController` → extends `AbstractCanCommunicationController`
  - `PduToFrameMapping` → extends `Identifiable`
  - `CommunicationController` → extends `Identifiable`
- Fixed attribute name corrections:
  - `packingByte` → `packingByteOrder`
  - `update` → `updateIndicationBitPosition`
  - `wakeUpBy` → `wakeUpByControllerSupported`
- Changed attribute kind from "attribute" to "aggr" for:
  - `HwElement.hwElementConnections`
  - `HwElement.hwAttributeValues`
- Added `@ref_conditional("COMM-CONNECTORS")` decorator to `PhysicalChannel.commConnectors`

### 4. Generator Code Updates
- Updated `tools/generate_models/generators.py` to use type-based XML tag derivation
- Applied fix to both serialize and deserialize method generation

## Files Modified

- `docs/designs/decorators.md` - Documentation enhancement
- `docs/json/packages/M2_AUTOSARTemplates_EcuResourceTemplate.classes.json` - Attribute kind corrections
- `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_Fibex4Can_CanTopology.classes.json` - Inheritance fixes
- `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json` - Attribute name fixes
- `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreTopology.classes.json` - Inheritance and decorator fixes
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/abstract_can_communication_controller.py` - Inheritance
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/Fibex4Can/CanTopology/can_communication_controller.py` - Inheritance
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/pdu_to_frame_mapping.py` - Attribute names and inheritance
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/communication_controller.py` - Attribute names and inheritance
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreTopology/physical_channel.py` - @ref_conditional decorator
- `tools/generate_models/generators.py` - Type tag derivation logic

## Test Coverage

All quality checks passed:
- **Ruff linting**: ✅ Pass - No linting errors
- **MyPy type checking**: ✅ Pass - No type errors (2253 source files)
- **Pytest**: ✅ Pass - 260 passed, 3 xfailed

## Requirements

None - this is a bug fix and enhancement for existing functionality

Closes #137