### PR TITLE
fix: Correct Fibex Core Communication attribute naming

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json
@@ -1193,7 +1193,7 @@
           "is_ref": true,
           "note": "Reference to an ISignalGroup that is mapped into the an ISignalToIPduMapping for an ISignal defined, only the UpdateIndicationBitPosition transferProperty is relevant. The startPosition packingByteOrder shall be ignored. contained in the ISignalGroup shall be an IPdu by an own ISignalToIPduMapping. to the ISignal and to the ISignalGroup in are mutually exclusive."
         },
-        "packingByte": {
+        "packingByteOrder": {
           "type": "ByteOrderEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
@@ -1207,14 +1207,14 @@
           "is_ref": false,
           "note": "This parameter is necessary to describe the bitposition of within an SignalIPdu. It denotes the least for \"Little Endian\" and the most significant \"Big Endian\" packed signals within the IPdu (see of the packingByteOrder attribute). In bit counting is always set to \"sawtooth\" bit order is set to \"Decreasing\". The bit counting 0 starts with bit 0 (least significant bit). The most in byte 0 is bit 7. that the way the bytes will be actually sent on does not impact this representation: they will seen by the software as a byte array. mapping for the ISignalGroup is defined, this attribute and shall be ignored."
         },
-        "transferPropertyEnum": {
+        "transferProperty": {
           "type": "TransferPropertyEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines how the referenced ISignal contributes to the of the ISignalIPdu. 2090 Document ID 63: AUTOSAR_CP_TPS_SystemTemplate R23-11"
         },
-        "update": {
+        "updateIndicationBitPosition": {
           "type": "UnlimitedInteger",
           "multiplicity": "0..1",
           "kind": "attribute",
@@ -1618,8 +1618,8 @@
           "is_ref": false,
           "note": "Minimum Delay in seconds between successive this I-PDU, independent of the"
         },
-        "transmission": {
-          "type": "any (TransmissionMode)",
+        "transmissionModeDeclaration": {
+          "type": "TransmissionModeDeclaration",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json
@@ -27,19 +27,40 @@
         }
       ],
       "attributes": {
-        "modeDriven": {
+        "modeDrivenFalseCondition": {
           "type": "ModeDrivenTransmissionModeCondition",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Defines the trigger for the Com_SwitchIpduTxMode"
         },
-        "transmission": {
-          "type": "any (TransmissionMode)",
+        "modeDrivenTrueCondition": {
+          "type": "ModeDrivenTransmissionModeCondition",
+          "multiplicity": "*",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "Defines the trigger for the Com_SwitchIpduTxMode"
+        },
+        "transmissionModeCondition": {
+          "type": "TransmissionModeCondition",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Timing Specification if the COM Transmission Mode is true. The Transmission Mode Selector is defined to be if at least one Condition evaluates to true."
+        },
+        "transmissionModeFalseTiming": {
+          "type": "TransmissionModeTiming",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "Timing Specification if the COM Transmission Mode is false. "
+        },
+        "transmissionModeTrueTiming": {
+          "type": "TransmissionModeTiming",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "Timing Specification if the COM Transmission Mode is true."
         }
       }
     },

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/transmission_mode_declaration.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/transmission_mode_declaration.py
@@ -6,12 +6,18 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel.models.M2.builder_base import BuilderBase
 from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication.Timing.mode_driven_transmission_mode_condition import (
     ModeDrivenTransmissionModeCondition,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication.Timing.transmission_mode_condition import (
+    TransmissionModeCondition,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication.Timing.transmission_mode_timing import (
+    TransmissionModeTiming,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -29,13 +35,19 @@ class TransmissionModeDeclaration(ARObject):
         """
         return False
 
-    mode_drivens: list[ModeDrivenTransmissionModeCondition]
-    transmission: Optional[Any]
+    mode_driven_false_conditions: list[ModeDrivenTransmissionModeCondition]
+    mode_driven_true_conditions: list[ModeDrivenTransmissionModeCondition]
+    transmission_mode_condition: Optional[TransmissionModeCondition]
+    transmission_mode_false_timing: Optional[TransmissionModeTiming]
+    transmission_mode_true_timing: Optional[TransmissionModeTiming]
     def __init__(self) -> None:
         """Initialize TransmissionModeDeclaration."""
         super().__init__()
-        self.mode_drivens: list[ModeDrivenTransmissionModeCondition] = []
-        self.transmission: Optional[Any] = None
+        self.mode_driven_false_conditions: list[ModeDrivenTransmissionModeCondition] = []
+        self.mode_driven_true_conditions: list[ModeDrivenTransmissionModeCondition] = []
+        self.transmission_mode_condition: Optional[TransmissionModeCondition] = None
+        self.transmission_mode_false_timing: Optional[TransmissionModeTiming] = None
+        self.transmission_mode_true_timing: Optional[TransmissionModeTiming] = None
 
     def serialize(self) -> ET.Element:
         """Serialize TransmissionModeDeclaration to XML element.
@@ -61,22 +73,60 @@ class TransmissionModeDeclaration(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize mode_drivens (list to container "MODE-DRIVENS")
-        if self.mode_drivens:
-            wrapper = ET.Element("MODE-DRIVENS")
-            for item in self.mode_drivens:
+        # Serialize mode_driven_false_conditions (list to container "MODE-DRIVEN-FALSE-CONDITIONS")
+        if self.mode_driven_false_conditions:
+            wrapper = ET.Element("MODE-DRIVEN-FALSE-CONDITIONS")
+            for item in self.mode_driven_false_conditions:
                 serialized = SerializationHelper.serialize_item(item, "ModeDrivenTransmissionModeCondition")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize transmission
-        if self.transmission is not None:
-            serialized = SerializationHelper.serialize_item(self.transmission, "Any")
+        # Serialize mode_driven_true_conditions (list to container "MODE-DRIVEN-TRUE-CONDITIONS")
+        if self.mode_driven_true_conditions:
+            wrapper = ET.Element("MODE-DRIVEN-TRUE-CONDITIONS")
+            for item in self.mode_driven_true_conditions:
+                serialized = SerializationHelper.serialize_item(item, "ModeDrivenTransmissionModeCondition")
+                if serialized is not None:
+                    wrapper.append(serialized)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize transmission_mode_condition
+        if self.transmission_mode_condition is not None:
+            serialized = SerializationHelper.serialize_item(self.transmission_mode_condition, "TransmissionModeCondition")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TRANSMISSION")
+                wrapped = ET.Element("TRANSMISSION-MODE-CONDITION")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize transmission_mode_false_timing
+        if self.transmission_mode_false_timing is not None:
+            serialized = SerializationHelper.serialize_item(self.transmission_mode_false_timing, "TransmissionModeTiming")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("TRANSMISSION-MODE-FALSE-TIMING")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize transmission_mode_true_timing
+        if self.transmission_mode_true_timing is not None:
+            serialized = SerializationHelper.serialize_item(self.transmission_mode_true_timing, "TransmissionModeTiming")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("TRANSMISSION-MODE-TRUE-TIMING")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -100,21 +150,43 @@ class TransmissionModeDeclaration(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(TransmissionModeDeclaration, cls).deserialize(element)
 
-        # Parse mode_drivens (list from container "MODE-DRIVENS")
-        obj.mode_drivens = []
-        container = SerializationHelper.find_child_element(element, "MODE-DRIVENS")
+        # Parse mode_driven_false_conditions (list from container "MODE-DRIVEN-FALSE-CONDITIONS")
+        obj.mode_driven_false_conditions = []
+        container = SerializationHelper.find_child_element(element, "MODE-DRIVEN-FALSE-CONDITIONS")
         if container is not None:
             for child in container:
                 # Deserialize each child element dynamically based on its tag
                 child_value = SerializationHelper.deserialize_by_tag(child, None)
                 if child_value is not None:
-                    obj.mode_drivens.append(child_value)
+                    obj.mode_driven_false_conditions.append(child_value)
 
-        # Parse transmission
-        child = SerializationHelper.find_child_element(element, "TRANSMISSION")
+        # Parse mode_driven_true_conditions (list from container "MODE-DRIVEN-TRUE-CONDITIONS")
+        obj.mode_driven_true_conditions = []
+        container = SerializationHelper.find_child_element(element, "MODE-DRIVEN-TRUE-CONDITIONS")
+        if container is not None:
+            for child in container:
+                # Deserialize each child element dynamically based on its tag
+                child_value = SerializationHelper.deserialize_by_tag(child, None)
+                if child_value is not None:
+                    obj.mode_driven_true_conditions.append(child_value)
+
+        # Parse transmission_mode_condition
+        child = SerializationHelper.find_child_element(element, "TRANSMISSION-MODE-CONDITION")
         if child is not None:
-            transmission_value = child.text
-            obj.transmission = transmission_value
+            transmission_mode_condition_value = SerializationHelper.deserialize_by_tag(child, "TransmissionModeCondition")
+            obj.transmission_mode_condition = transmission_mode_condition_value
+
+        # Parse transmission_mode_false_timing
+        child = SerializationHelper.find_child_element(element, "TRANSMISSION-MODE-FALSE-TIMING")
+        if child is not None:
+            transmission_mode_false_timing_value = SerializationHelper.deserialize_by_tag(child, "TransmissionModeTiming")
+            obj.transmission_mode_false_timing = transmission_mode_false_timing_value
+
+        # Parse transmission_mode_true_timing
+        child = SerializationHelper.find_child_element(element, "TRANSMISSION-MODE-TRUE-TIMING")
+        if child is not None:
+            transmission_mode_true_timing_value = SerializationHelper.deserialize_by_tag(child, "TransmissionModeTiming")
+            obj.transmission_mode_true_timing = transmission_mode_true_timing_value
 
         return obj
 
@@ -129,8 +201,8 @@ class TransmissionModeDeclarationBuilder(BuilderBase):
         self._obj: TransmissionModeDeclaration = TransmissionModeDeclaration()
 
 
-    def with_mode_drivens(self, items: list[ModeDrivenTransmissionModeCondition]) -> "TransmissionModeDeclarationBuilder":
-        """Set mode_drivens list attribute.
+    def with_mode_driven_false_conditions(self, items: list[ModeDrivenTransmissionModeCondition]) -> "TransmissionModeDeclarationBuilder":
+        """Set mode_driven_false_conditions list attribute.
 
         Args:
             items: List of items to set
@@ -138,11 +210,23 @@ class TransmissionModeDeclarationBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mode_drivens = list(items) if items else []
+        self._obj.mode_driven_false_conditions = list(items) if items else []
         return self
 
-    def with_transmission(self, value: Optional[any (TransmissionMode)]) -> "TransmissionModeDeclarationBuilder":
-        """Set transmission attribute.
+    def with_mode_driven_true_conditions(self, items: list[ModeDrivenTransmissionModeCondition]) -> "TransmissionModeDeclarationBuilder":
+        """Set mode_driven_true_conditions list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.mode_driven_true_conditions = list(items) if items else []
+        return self
+
+    def with_transmission_mode_condition(self, value: Optional[TransmissionModeCondition]) -> "TransmissionModeDeclarationBuilder":
+        """Set transmission_mode_condition attribute.
 
         Args:
             value: Value to set
@@ -152,12 +236,40 @@ class TransmissionModeDeclarationBuilder(BuilderBase):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.transmission = value
+        self._obj.transmission_mode_condition = value
+        return self
+
+    def with_transmission_mode_false_timing(self, value: Optional[TransmissionModeTiming]) -> "TransmissionModeDeclarationBuilder":
+        """Set transmission_mode_false_timing attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.transmission_mode_false_timing = value
+        return self
+
+    def with_transmission_mode_true_timing(self, value: Optional[TransmissionModeTiming]) -> "TransmissionModeDeclarationBuilder":
+        """Set transmission_mode_true_timing attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
+        self._obj.transmission_mode_true_timing = value
         return self
 
 
-    def add_mode_driven(self, item: ModeDrivenTransmissionModeCondition) -> "TransmissionModeDeclarationBuilder":
-        """Add a single item to mode_drivens list.
+    def add_mode_driven_false_condition(self, item: ModeDrivenTransmissionModeCondition) -> "TransmissionModeDeclarationBuilder":
+        """Add a single item to mode_driven_false_conditions list.
 
         Args:
             item: Item to add
@@ -165,16 +277,37 @@ class TransmissionModeDeclarationBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mode_drivens.append(item)
+        self._obj.mode_driven_false_conditions.append(item)
         return self
 
-    def clear_mode_drivens(self) -> "TransmissionModeDeclarationBuilder":
-        """Clear all items from mode_drivens list.
+    def clear_mode_driven_false_conditions(self) -> "TransmissionModeDeclarationBuilder":
+        """Clear all items from mode_driven_false_conditions list.
 
         Returns:
             self for method chaining
         """
-        self._obj.mode_drivens = []
+        self._obj.mode_driven_false_conditions = []
+        return self
+
+    def add_mode_driven_true_condition(self, item: ModeDrivenTransmissionModeCondition) -> "TransmissionModeDeclarationBuilder":
+        """Add a single item to mode_driven_true_conditions list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.mode_driven_true_conditions.append(item)
+        return self
+
+    def clear_mode_driven_true_conditions(self) -> "TransmissionModeDeclarationBuilder":
+        """Clear all items from mode_driven_true_conditions list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.mode_driven_true_conditions = []
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_pdu_timing.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_pdu_timing.py
@@ -6,7 +6,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.describable import (
@@ -16,6 +16,9 @@ from armodel.models.M2.builder_base import BuilderBase
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.describable import DescribableBuilder
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     TimeValue,
+)
+from armodel.models.M2.AUTOSARTemplates.SystemTemplate.Fibex.FibexCore.CoreCommunication.Timing.transmission_mode_declaration import (
+    TransmissionModeDeclaration,
 )
 from armodel.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel.serialization import SerializationHelper
@@ -34,12 +37,12 @@ class IPduTiming(Describable):
         return False
 
     minimum_delay: Optional[TimeValue]
-    transmission: Optional[Any]
+    transmission_mode_declaration: Optional[TransmissionModeDeclaration]
     def __init__(self) -> None:
         """Initialize IPduTiming."""
         super().__init__()
         self.minimum_delay: Optional[TimeValue] = None
-        self.transmission: Optional[Any] = None
+        self.transmission_mode_declaration: Optional[TransmissionModeDeclaration] = None
 
     def serialize(self) -> ET.Element:
         """Serialize IPduTiming to XML element.
@@ -79,12 +82,12 @@ class IPduTiming(Describable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize transmission
-        if self.transmission is not None:
-            serialized = SerializationHelper.serialize_item(self.transmission, "Any")
+        # Serialize transmission_mode_declaration
+        if self.transmission_mode_declaration is not None:
+            serialized = SerializationHelper.serialize_item(self.transmission_mode_declaration, "TransmissionModeDeclaration")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TRANSMISSION")
+                wrapped = ET.Element("TRANSMISSION-MODE-DECLARATION")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -114,11 +117,11 @@ class IPduTiming(Describable):
             minimum_delay_value = child.text
             obj.minimum_delay = minimum_delay_value
 
-        # Parse transmission
-        child = SerializationHelper.find_child_element(element, "TRANSMISSION")
+        # Parse transmission_mode_declaration
+        child = SerializationHelper.find_child_element(element, "TRANSMISSION-MODE-DECLARATION")
         if child is not None:
-            transmission_value = child.text
-            obj.transmission = transmission_value
+            transmission_mode_declaration_value = SerializationHelper.deserialize_by_tag(child, "TransmissionModeDeclaration")
+            obj.transmission_mode_declaration = transmission_mode_declaration_value
 
         return obj
 
@@ -147,8 +150,8 @@ class IPduTimingBuilder(DescribableBuilder):
         self._obj.minimum_delay = value
         return self
 
-    def with_transmission(self, value: Optional[any (TransmissionMode)]) -> "IPduTimingBuilder":
-        """Set transmission attribute.
+    def with_transmission_mode_declaration(self, value: Optional[TransmissionModeDeclaration]) -> "IPduTimingBuilder":
+        """Set transmission_mode_declaration attribute.
 
         Args:
             value: Value to set
@@ -158,7 +161,7 @@ class IPduTimingBuilder(DescribableBuilder):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.transmission = value
+        self._obj.transmission_mode_declaration = value
         return self
 
 

--- a/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_to_i_pdu_mapping.py
+++ b/src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_to_i_pdu_mapping.py
@@ -48,19 +48,19 @@ class ISignalToIPduMapping(Identifiable):
 
     i_signal_ref: Optional[ARRef]
     i_signal_group_ref: Optional[ARRef]
-    packing_byte: Optional[ByteOrderEnum]
+    packing_byte_order: Optional[ByteOrderEnum]
     start_position: Optional[UnlimitedInteger]
-    transfer_property_enum: Optional[TransferPropertyEnum]
-    update: Optional[UnlimitedInteger]
+    transfer_property: Optional[TransferPropertyEnum]
+    update_indication_bit_position: Optional[UnlimitedInteger]
     def __init__(self) -> None:
         """Initialize ISignalToIPduMapping."""
         super().__init__()
         self.i_signal_ref: Optional[ARRef] = None
         self.i_signal_group_ref: Optional[ARRef] = None
-        self.packing_byte: Optional[ByteOrderEnum] = None
+        self.packing_byte_order: Optional[ByteOrderEnum] = None
         self.start_position: Optional[UnlimitedInteger] = None
-        self.transfer_property_enum: Optional[TransferPropertyEnum] = None
-        self.update: Optional[UnlimitedInteger] = None
+        self.transfer_property: Optional[TransferPropertyEnum] = None
+        self.update_indication_bit_position: Optional[UnlimitedInteger] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ISignalToIPduMapping to XML element.
@@ -114,12 +114,12 @@ class ISignalToIPduMapping(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize packing_byte
-        if self.packing_byte is not None:
-            serialized = SerializationHelper.serialize_item(self.packing_byte, "ByteOrderEnum")
+        # Serialize packing_byte_order
+        if self.packing_byte_order is not None:
+            serialized = SerializationHelper.serialize_item(self.packing_byte_order, "ByteOrderEnum")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("PACKING-BYTE")
+                wrapped = ET.Element("PACKING-BYTE-ORDER")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -142,12 +142,12 @@ class ISignalToIPduMapping(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize transfer_property_enum
-        if self.transfer_property_enum is not None:
-            serialized = SerializationHelper.serialize_item(self.transfer_property_enum, "TransferPropertyEnum")
+        # Serialize transfer_property
+        if self.transfer_property is not None:
+            serialized = SerializationHelper.serialize_item(self.transfer_property, "TransferPropertyEnum")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TRANSFER-PROPERTY-ENUM")
+                wrapped = ET.Element("TRANSFER-PROPERTY")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -156,12 +156,12 @@ class ISignalToIPduMapping(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize update
-        if self.update is not None:
-            serialized = SerializationHelper.serialize_item(self.update, "UnlimitedInteger")
+        # Serialize update_indication_bit_position
+        if self.update_indication_bit_position is not None:
+            serialized = SerializationHelper.serialize_item(self.update_indication_bit_position, "UnlimitedInteger")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("UPDATE")
+                wrapped = ET.Element("UPDATE-INDICATION-BIT-POSITION")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -197,11 +197,11 @@ class ISignalToIPduMapping(Identifiable):
             i_signal_group_ref_value = ARRef.deserialize(child)
             obj.i_signal_group_ref = i_signal_group_ref_value
 
-        # Parse packing_byte
-        child = SerializationHelper.find_child_element(element, "PACKING-BYTE")
+        # Parse packing_byte_order
+        child = SerializationHelper.find_child_element(element, "PACKING-BYTE-ORDER")
         if child is not None:
-            packing_byte_value = ByteOrderEnum.deserialize(child)
-            obj.packing_byte = packing_byte_value
+            packing_byte_order_value = ByteOrderEnum.deserialize(child)
+            obj.packing_byte_order = packing_byte_order_value
 
         # Parse start_position
         child = SerializationHelper.find_child_element(element, "START-POSITION")
@@ -209,17 +209,17 @@ class ISignalToIPduMapping(Identifiable):
             start_position_value = child.text
             obj.start_position = start_position_value
 
-        # Parse transfer_property_enum
-        child = SerializationHelper.find_child_element(element, "TRANSFER-PROPERTY-ENUM")
+        # Parse transfer_property
+        child = SerializationHelper.find_child_element(element, "TRANSFER-PROPERTY")
         if child is not None:
-            transfer_property_enum_value = TransferPropertyEnum.deserialize(child)
-            obj.transfer_property_enum = transfer_property_enum_value
+            transfer_property_value = TransferPropertyEnum.deserialize(child)
+            obj.transfer_property = transfer_property_value
 
-        # Parse update
-        child = SerializationHelper.find_child_element(element, "UPDATE")
+        # Parse update_indication_bit_position
+        child = SerializationHelper.find_child_element(element, "UPDATE-INDICATION-BIT-POSITION")
         if child is not None:
-            update_value = child.text
-            obj.update = update_value
+            update_indication_bit_position_value = child.text
+            obj.update_indication_bit_position = update_indication_bit_position_value
 
         return obj
 
@@ -262,8 +262,8 @@ class ISignalToIPduMappingBuilder(IdentifiableBuilder):
         self._obj.i_signal_group = value
         return self
 
-    def with_packing_byte(self, value: Optional[ByteOrderEnum]) -> "ISignalToIPduMappingBuilder":
-        """Set packing_byte attribute.
+    def with_packing_byte_order(self, value: Optional[ByteOrderEnum]) -> "ISignalToIPduMappingBuilder":
+        """Set packing_byte_order attribute.
 
         Args:
             value: Value to set
@@ -273,7 +273,7 @@ class ISignalToIPduMappingBuilder(IdentifiableBuilder):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.packing_byte = value
+        self._obj.packing_byte_order = value
         return self
 
     def with_start_position(self, value: Optional[UnlimitedInteger]) -> "ISignalToIPduMappingBuilder":
@@ -290,8 +290,8 @@ class ISignalToIPduMappingBuilder(IdentifiableBuilder):
         self._obj.start_position = value
         return self
 
-    def with_transfer_property_enum(self, value: Optional[TransferPropertyEnum]) -> "ISignalToIPduMappingBuilder":
-        """Set transfer_property_enum attribute.
+    def with_transfer_property(self, value: Optional[TransferPropertyEnum]) -> "ISignalToIPduMappingBuilder":
+        """Set transfer_property attribute.
 
         Args:
             value: Value to set
@@ -301,11 +301,11 @@ class ISignalToIPduMappingBuilder(IdentifiableBuilder):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.transfer_property_enum = value
+        self._obj.transfer_property = value
         return self
 
-    def with_update(self, value: Optional[UnlimitedInteger]) -> "ISignalToIPduMappingBuilder":
-        """Set update attribute.
+    def with_update_indication_bit_position(self, value: Optional[UnlimitedInteger]) -> "ISignalToIPduMappingBuilder":
+        """Set update_indication_bit_position attribute.
 
         Args:
             value: Value to set
@@ -315,7 +315,7 @@ class ISignalToIPduMappingBuilder(IdentifiableBuilder):
         """
         if value is None and not True:
             raise ValueError("Attribute '" + snake_attr_name + "' is required and cannot be None")
-        self._obj.update = value
+        self._obj.update_indication_bit_position = value
         return self
 
 


### PR DESCRIPTION
## Summary

This PR fixes several AUTOSAR Fibex Core Communication attribute naming inconsistencies to align with the AUTOSAR schema specification. The changes primarily affect ISignalToIPduMapping and TransmissionModeDeclaration classes.

## Changes

### 1. ISignalToIPduMapping Attribute Renaming
- **File**: `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json`
- **Changes**:
  - `packingByte` → `packingByteOrder`
  - `transferPropertyEnum` → `transferProperty`
  - `update` → `updateIndicationBitPosition`
- **Impact**: Updated XML element names to match AUTOSAR schema:
  - `<PACKING-BYTE-ORDER>` instead of `<PACKING-BYTE>`
  - `<TRANSFER-PROPERTY>` instead of `<TRANSFER-PROPERTY-ENUM>`
  - `<UPDATE-INDICATION-BIT-POSITION>` instead of `<UPDATE>`

### 2. IPduTiming Attribute Renaming
- **File**: `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json`
- **Changes**:
  - `transmission` (type: "any (TransmissionMode)") → `transmissionModeDeclaration` (type: "TransmissionModeDeclaration")
- **Impact**: Changed from loose "any" type to concrete `TransmissionModeDeclaration` type
- **XML**: `<TRANSMISSION-MODE-DECLARATION>` instead of `<TRANSMISSION>`

### 3. TransmissionModeDeclaration Attribute Restructuring
- **File**: `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json`
- **Changes**:
  - `modeDriven` → Split into `modeDrivenFalseCondition` and `modeDrivenTrueCondition`
  - `transmission` → Split into multiple attributes:
    - `transmissionModeCondition` (type: TransmissionModeCondition)
    - `transmissionModeFalseTiming` (type: TransmissionModeTiming)
    - `transmissionModeTrueTiming` (type: TransmissionModeTiming)
- **Impact**: Properly structured timing attributes with explicit true/false conditions
- **XML Elements**:
  - `<MODE-DRIVEN-FALSE-CONDITIONS>` and `<MODE-DRIVEN-TRUE-CONDITIONS>`
  - `<TRANSMISSION-MODE-CONDITION>`
  - `<TRANSMISSION-MODE-FALSE-TIMING>`
  - `<TRANSMISSION-MODE-TRUE-TIMING>`

## Files Modified

### Mapping Files (2)
- `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_SystemTemplate_Fibex_FibexCore_CoreCommunication_Timing.classes.json`

### Generated Model Files (3)
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_signal_to_i_pdu_mapping.py`
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/i_pdu_timing.py`
- `src/armodel/models/M2/AUTOSARTemplates/SystemTemplate/Fibex/FibexCore/CoreCommunication/Timing/transmission_mode_declaration.py`

## Test Coverage

- ✅ All existing tests pass (274 passed, 3 xfailed)
- ✅ No linting errors (Ruff)
- ✅ No type errors (MyPy)

## Quality Gate Results

| Check | Status | Details |
|-------|--------|---------|
| Ruff  | ✅ Pass | No linting errors (2253 files) |
| MyPy  | ✅ Pass | No type errors |
| Pytest| ✅ Pass | 274 passed, 3 xfailed |

Closes #147