### PR TITLE
fix: Add encoding detection for ARXML files

### DIFF
--- a/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
@@ -78,6 +78,15 @@ class AUTOSAR(ARObject):
         """
         return False
 
+    @property
+    def encoding(self) -> Optional[str]:
+        """Get the encoding from the loaded ARXML file.
+
+        Returns:
+            The encoding string (e.g., "UTF-8", "ISO-8859-1") or None if not set
+        """
+        return self._encoding
+
     admin_data: Optional[AdminData]
     ar_packages: list[ARPackage]
     file_info_comment: Optional[FileInfoComment]
@@ -113,6 +122,7 @@ class AUTOSAR(ARObject):
         self.file_info_comment: Optional[FileInfoComment] = None
         self.introduction: Optional[DocumentationBlock] = None
         self.schema_location: Optional[str] = None
+        self._encoding: Optional[str] = None
 
         self._initialized = True
 
@@ -134,6 +144,7 @@ class AUTOSAR(ARObject):
         self.file_info_comment = None
         self.introduction = None
         self.schema_location = None
+        self._encoding = None
 
     @classmethod
     def reset(cls) -> None:

--- a/src/armodel2/reader/reader.py
+++ b/src/armodel2/reader/reader.py
@@ -71,8 +71,12 @@ class ARXMLReader:
         if autosar is None:
             autosar = AUTOSAR()
 
-        root = self._load_file(filepath)
+        root, encoding = self._load_file(filepath)
         self._populate_autosar(autosar, root)
+
+        # Store detected encoding in AUTOSAR object
+        if encoding is not None:
+            autosar._encoding = encoding
 
         if validate:
             self._validate_against_schema(root, autosar)
@@ -109,32 +113,65 @@ class ARXMLReader:
         AUTOSAR().clear()
         return self.load_arxml(filepath, validate=validate)
 
-    def _load_file(self, filepath: Union[str, Path]) -> ET.Element:
-        """Load ARXML file and return root element.
+    def _load_file(self, filepath: Union[str, Path]) -> tuple[ET.Element, Optional[str]]:
+        """Load ARXML file and return root element and detected encoding.
 
         Args:
             filepath: Path to ARXML file
 
         Returns:
-            Root XML element
+            Tuple of (root XML element, detected encoding string or None)
 
         Raises:
             FileNotFoundError: If file doesn't exist
             ET.ParseError: If XML is malformed
-            UnicodeDecodeError: If file is not valid UTF-8
+            UnicodeDecodeError: If file encoding is not supported
         """
         filepath = Path(filepath)
 
         if not filepath.exists():
             raise FileNotFoundError(f"ARXML file not found: {filepath}")
 
-        # Explicitly open with UTF-8 encoding to avoid system default encoding issues
-        # On Windows with non-UTF-8 locales (e.g., Chinese GBK), ET.parse(filepath)
-        # would use system default encoding instead of the XML declaration's encoding
-        with open(filepath, 'r', encoding='utf-8') as f:
-            tree = ET.parse(f)
+        # Detect encoding from XML declaration
+        encoding = self._detect_encoding(filepath)
 
-        return tree.getroot()
+        # Let Python's XML parser handle encoding detection automatically
+        # Python's ET.parse() detects encoding from BOM and XML declaration
+        tree = ET.parse(filepath)
+
+        return tree.getroot(), encoding
+
+    def _detect_encoding(self, filepath: Path) -> Optional[str]:
+        """Detect encoding from XML declaration.
+
+        Reads the first few lines of the file to find the XML declaration
+        and extract the encoding attribute.
+
+        Args:
+            filepath: Path to ARXML file
+
+        Returns:
+            Encoding string (e.g., "UTF-8", "ISO-8859-1") or None if not found
+        """
+        try:
+            # Read first 1KB to find XML declaration
+            with open(filepath, 'rb') as f:
+                header = f.read(1024)
+
+            # Decode as ASCII to search for encoding attribute
+            # XML declaration is always ASCII
+            header_str = header.decode('ascii', errors='ignore')
+
+            # Search for encoding="..." or encoding='...'
+            import re
+            match = re.search(r'encoding=["\']([^"\']+)["\']', header_str)
+            if match:
+                return match.group(1)
+
+            return None
+        except Exception:
+            # If detection fails, return None (will use default)
+            return None
 
     def _populate_autosar(self, autosar: AUTOSAR, root: ET.Element) -> AUTOSAR:
         """Populate AUTOSAR object from XML element.
@@ -213,5 +250,5 @@ class ARXMLReader:
         Returns:
             Schema version string or None if unknown
         """
-        root = self._load_file(filepath)
+        root, _ = self._load_file(filepath)
         return self._version_manager.detect_schema_version(root)

--- a/src/armodel2/writer/writer.py
+++ b/src/armodel2/writer/writer.py
@@ -62,7 +62,7 @@ class ARXMLWriter:
             autosar = AUTOSAR()
 
         root = self._serialize_to_xml(autosar)
-        self._save_to_file(root, filepath)
+        self._save_to_file(root, filepath, autosar)
 
     def _serialize_to_xml(self, autosar: AUTOSAR) -> ET.Element:
         """Serialize AUTOSAR object to XML element.
@@ -84,17 +84,23 @@ class ARXMLWriter:
         root = autosar.serialize()
         return root
 
-    def _save_to_file(self, root: ET.Element, filepath: Union[str, Path]) -> None:
+    def _save_to_file(self, root: ET.Element, filepath: Union[str, Path], autosar: Optional[AUTOSAR] = None) -> None:
         """Save XML element to ARXML file.
 
         Args:
             root: Root XML element
             filepath: Output file path
+            autosar: AUTOSAR object to get encoding from (optional)
         """
         filepath = Path(filepath)
 
         # Ensure parent directory exists
         filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        # Use encoding from AUTOSAR object if available, otherwise use configured encoding
+        encoding = self._encoding
+        if autosar is not None and autosar.encoding is not None:
+            encoding = autosar.encoding
 
         # Create tree and write
         tree = ET.ElementTree(root)
@@ -105,17 +111,17 @@ class ARXMLWriter:
             if tree_root is not None:
                 self._indent(tree_root)
 
-        tree.write(str(filepath), encoding=self._encoding, xml_declaration=True)
-        
+        tree.write(str(filepath), encoding=encoding, xml_declaration=True)
+
         # Fix XML declaration quotes
-        self._fix_xml_declaration_quotes_file(filepath)
-        
+        self._fix_xml_declaration_quotes_file(filepath, encoding)
+
         # Convert self-closing empty elements to separate opening and closing tags
         # xml.etree.ElementTree serializes empty elements as <TAG /> but AUTOSAR uses <TAG></TAG>
         self._fix_empty_elements_file(filepath)
-        
+
         # Preserve HTML entity encoding in text content
-        self._preserve_html_entities_file(filepath)
+        self._preserve_html_entities_file(filepath, encoding)
 
     def _fix_empty_elements_file(self, filepath: Path) -> None:
         """Convert self-closing empty elements to separate opening and closing tags.
@@ -156,22 +162,27 @@ class ARXMLWriter:
         with open(filepath, 'wb') as f_out:
             f_out.write(content)
 
-    def _fix_xml_declaration_quotes_file(self, filepath: Path) -> None:
+    def _fix_xml_declaration_quotes_file(self, filepath: Path, encoding: str) -> None:
         """Replace single quotes with double quotes in XML declaration.
 
         Post-processes the file to convert:
-        <?xml version='1.0' encoding='UTF-8'?>
+        <?xml version='1.0' encoding='ISO-8859-1'?>
         to:
-        <?xml version="1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="ISO-8859-1"?>
 
         Args:
             filepath: Path to the ARXML file to fix
+            encoding: File encoding to use in the XML declaration
         """
         with open(filepath, 'rb') as f:
             content = f.read()
-        
-        content = content.replace(b"<?xml version='1.0'", b'<?xml version="1.0"')
-        content = content.replace(b"encoding='UTF-8'?>", b'encoding="UTF-8"?>')
+
+        # Replace the entire XML declaration at once
+        # Pattern: <?xml version='1.0' encoding='ANY_VALUE'?>
+        import re
+        pattern = rb"<\?xml version='1\.0' encoding='([^']+)'\?\>"
+        replacement = b'<?xml version="1.0" encoding="' + encoding.encode('ascii') + b'"?>'
+        content = re.sub(pattern, replacement, content)
         
         with open(filepath, 'wb') as f:
             f.write(content)
@@ -189,7 +200,7 @@ class ARXMLWriter:
         xml_str = xml_str.replace("encoding='UTF-8'?>", 'encoding="UTF-8"?>')
         return xml_str
 
-    def _preserve_html_entities_file(self, filepath: Path) -> None:
+    def _preserve_html_entities_file(self, filepath: Path, encoding: str) -> None:
         """Preserve HTML entity encoding in text content.
 
         Post-processes the file to escape special characters in text content
@@ -197,19 +208,20 @@ class ARXMLWriter:
 
         Args:
             filepath: Path to the ARXML file to process
+            encoding: File encoding to use for decoding/encoding
         """
         with open(filepath, 'rb') as f:
             content = f.read()
-        
+
         # Decode to string for processing
-        xml_str = content.decode(self._encoding)
-        
+        xml_str = content.decode(encoding)
+
         # Apply HTML entity preservation
         xml_str = self._preserve_html_entities_str(xml_str)
-        
+
         # Write back
         with open(filepath, 'wb') as f:
-            f.write(xml_str.encode(self._encoding))
+            f.write(xml_str.encode(encoding))
 
     def _preserve_html_entities_str(self, xml_str: str) -> str:
         """Preserve HTML entity encoding in XML string.

--- a/tests/integration/test_reader_encoding.py
+++ b/tests/integration/test_reader_encoding.py
@@ -1,0 +1,176 @@
+"""
+Integration tests for ARXML reader encoding detection.
+
+This test module validates that the ARXMLReader correctly handles
+files with different encodings, respecting the encoding declaration
+in the XML header.
+
+Test Strategy:
+- Test reading ISO-8859-1 encoded files
+- Test reading UTF-8 encoded files
+- Test reading files without encoding declaration
+- Validate round-trip serialization preserves encoding
+
+Traceability:
+- Test Documentation: docs/tests/integration/test_reader_encoding.md
+- SWITS IDs: SWITS-INT-0300 through SWITS-INT-0399
+"""
+import pytest
+from pathlib import Path
+
+from armodel2.reader import ARXMLReader
+from armodel2.writer import ARXMLWriter
+from armodel2.models.M2.AUTOSARTemplates.AutosarTopLevelStructure.autosar import AUTOSAR
+
+
+class TestReaderEncoding:
+    """Test ARXML reader encoding detection and handling.
+
+    Test IDs: SWITS-INT-0300 to SWITS-INT-0399
+    """
+
+    @pytest.fixture
+    def reader(self) -> ARXMLReader:
+        """ARXML reader instance."""
+        return ARXMLReader()
+
+    @pytest.fixture
+    def writer(self) -> ARXMLWriter:
+        """ARXML writer instance."""
+        return ARXMLWriter(pretty_print=True, encoding="UTF-8")
+
+    def test_read_iso_8859_1_file(self, reader: ARXMLReader) -> None:
+        """Test reading an ISO-8859-1 encoded ARXML file.
+
+        Validates that the reader correctly detects and reads
+        files with ISO-8859-1 encoding from the XML declaration.
+
+        Test ID: SWITS-INT-0301
+        """
+        # Adc_Bswmd.arxml uses ISO-8859-1 encoding
+        arxml_file = Path("demos/arxml/Adc_Bswmd.arxml")
+        if not arxml_file.exists():
+            pytest.skip(f"File not found: {arxml_file}")
+
+        AUTOSAR.reset()
+        autosar = AUTOSAR()
+
+        # Should not raise UnicodeDecodeError
+        reader.load_arxml(str(arxml_file), autosar)
+
+        # Validate that data was loaded
+        assert autosar.ar_packages is not None
+        assert len(autosar.ar_packages) > 0
+
+    def test_read_utf_8_file(self, reader: ARXMLReader) -> None:
+        """Test reading a UTF-8 encoded ARXML file.
+
+        Validates that the reader correctly handles UTF-8 encoded files.
+
+        Test ID: SWITS-INT-0302
+        """
+        # BswM.arxml uses UTF-8 encoding
+        arxml_file = Path("demos/arxml/BswM.arxml")
+        if not arxml_file.exists():
+            pytest.skip(f"File not found: {arxml_file}")
+
+        AUTOSAR.reset()
+        autosar = AUTOSAR()
+
+        # Should read successfully
+        reader.load_arxml(str(arxml_file), autosar)
+
+        # Validate that data was loaded
+        assert autosar.ar_packages is not None
+        assert len(autosar.ar_packages) > 0
+
+        # Verify encoding was detected and stored
+        assert autosar.encoding == "UTF-8"
+
+    def test_iso_8859_1_round_trip(self, reader: ARXMLReader, writer: ARXMLWriter, tmp_path: Path) -> None:
+        """Test round-trip serialization of ISO-8859-1 file.
+
+        Validates that reading an ISO-8859-1 file and writing it back
+        produces a valid ARXML file with ISO-8859-1 encoding preserved.
+
+        Test ID: SWITS-INT-0303
+        """
+        arxml_file = Path("demos/arxml/Adc_Bswmd.arxml")
+        if not arxml_file.exists():
+            pytest.skip(f"File not found: {arxml_file}")
+
+        AUTOSAR.reset()
+        autosar = AUTOSAR()
+
+        # Read ISO-8859-1 file
+        reader.load_arxml(str(arxml_file), autosar)
+
+        # Verify encoding was detected and stored
+        assert autosar.encoding == "ISO-8859-1"
+
+        # Write back (should preserve ISO-8859-1 encoding)
+        output_file = tmp_path / "Adc_Bswmd_output.arxml"
+        writer.save_arxml(str(output_file), autosar)
+
+        # Validate output file exists and is valid XML
+        assert output_file.exists()
+        content = output_file.read_text(encoding="ISO-8859-1")
+        assert "<?xml" in content
+        assert "AUTOSAR" in content
+
+        # Verify the XML declaration preserves the encoding
+        assert 'encoding="ISO-8859-1"' in content
+
+    def test_read_multiple_iso_8859_1_files(self, reader: ARXMLReader) -> None:
+        """Test reading multiple ISO-8859-1 encoded files.
+
+        Validates that the reader can handle various ISO-8859-1 files
+        from the demos directory.
+
+        Test ID: SWITS-INT-0304
+        """
+        # List of ISO-8859-1 files to test
+        iso_8859_1_files = [
+            "Adc_Bswmd.arxml",
+            "Atomics_Bswmd.arxml",
+            "Base_Bswmd.arxml",
+        ]
+
+        for filename in iso_8859_1_files:
+            arxml_file = Path("demos/arxml") / filename
+            if not arxml_file.exists():
+                pytest.skip(f"File not found: {arxml_file}")
+
+            AUTOSAR.reset()
+            autosar = AUTOSAR()
+
+            # Should read successfully
+            reader.load_arxml(str(arxml_file), autosar)
+
+            # Validate that data was loaded
+            assert autosar.ar_packages is not None
+            assert len(autosar.ar_packages) > 0
+
+    def test_load_arxml_with_clear_iso_8859_1(self, reader: ARXMLReader) -> None:
+        """Test load_arxml_with_clear with ISO-8859-1 file.
+
+        Validates that the convenience method load_arxml_with_clear
+        correctly handles ISO-8859-1 encoded files.
+
+        Test ID: SWITS-INT-0305
+        """
+        arxml_file = Path("demos/arxml/Adc_Bswmd.arxml")
+        if not arxml_file.exists():
+            pytest.skip(f"File not found: {arxml_file}")
+
+        # Load with clear
+        autosar = reader.load_arxml_with_clear(str(arxml_file))
+
+        # Validate that data was loaded
+        assert autosar.ar_packages is not None
+        assert len(autosar.ar_packages) > 0
+
+        # Load again - should have fresh state
+        autosar2 = reader.load_arxml_with_clear(str(arxml_file))
+        assert autosar2 is autosar  # Same singleton instance
+        assert len(autosar2.ar_packages) == len(autosar.ar_packages)


### PR DESCRIPTION
## Summary
Add encoding detection and preservation for ARXML files to correctly handle non-UTF-8 encoded files (e.g., ISO-8859-1).

## Changes
- Added `_detect_encoding()` method in `ARXMLReader` to extract encoding from XML declaration
- Modified `_load_file()` to return both root element and detected encoding
- Added `encoding` property to `AUTOSAR` class to store detected encoding
- Updated `ARXMLWriter._save_to_file()` to use detected encoding from AUTOSAR object
- Fixed XML declaration generation to preserve original file encoding

## Files Modified
- `src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py` - Added encoding property
- `src/armodel2/reader/reader.py` - Added encoding detection logic
- `src/armodel2/writer/writer.py` - Updated to preserve encoding
- `tests/integration/test_reader_encoding.py` - New integration tests

## Test Coverage
New integration tests added:
- `test_read_iso_8859_1_file` - Validates ISO-8859-1 file reading
- `test_read_utf_8_file` - Validates UTF-8 file reading
- `test_iso_8859_1_round_trip` - Validates round-trip encoding preservation
- `test_read_multiple_iso_8859_1_files` - Tests multiple ISO-8859-1 files
- `test_load_arxml_with_clear_iso_8859_1` - Tests convenience method

Test IDs: SWITS-INT-0300 to SWITS-INT-0399

## Requirements Traceability
Closes #184