### PR TITLE
fix: Preserve line endings in ARXML writer for binary comparison tests

### DIFF
--- a/scripts/format_arxml.sh
+++ b/scripts/format_arxml.sh
@@ -53,6 +53,18 @@ while [[ $# -gt 0 ]]; do
             PRESET="validated"
             shift
             ;;
+        --test)
+            INPUT_DIR="demos/test"
+            OUTPUT_DIR="data/test"
+            PRESET="test"
+            shift
+            ;;
+        --test_validated)
+            INPUT_DIR="demos/test_validated"
+            OUTPUT_DIR="data/test_validated"
+            PRESET="test_validated"
+            shift
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS] [files...]"
             echo ""
@@ -63,6 +75,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --input, -i DIR     Set input directory (default: demos/arxml)"
             echo "  --output, -o DIR    Set output directory (default: data/arxml)"
             echo "  --validated         Use demos/validated → data/validated"
+            echo "  --test              Use demos/test → data/test"
+            echo "  --test_validated    Use demos/test_validated → data/test_validated"
             echo "  --help, -h          Show this help message"
             echo ""
             echo "Examples:"
@@ -71,6 +85,8 @@ while [[ $# -gt 0 ]]; do
             echo "  $0 --verbose                         # Format all with error details"
             echo "  $0 --dry-run                         # List files without formatting"
             echo "  $0 --validated                       # Format from demos/validated"
+            echo "  $0 --test                            # Format from demos/test"
+            echo "  $0 --test_validated                  # Format from demos/test_validated"
             echo "  $0 --input demos/validated --output data/validated  # Custom directories"
             echo "  $0 --encoding UTF-8                  # Use UTF-8 encoding"
             exit 0
@@ -192,7 +208,7 @@ if [ $failed_count -gt 0 ]; then
     echo "To debug individual files:"
     for i in "${!failed_files[@]}"; do
         filename="${failed_files[$i]}"
-        echo "  armodel2 format demos/arxml/$filename -o data/output.arxml --encoding $ENCODING -v"
+        echo "  armodel2 format $INPUT_DIR/$filename -o data/output.arxml --encoding $ENCODING -v"
     done
 fi
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
@@ -87,6 +87,24 @@ class AUTOSAR(ARObject):
         """
         return self._encoding
 
+    @property
+    def line_ending(self) -> str:
+        """Get the line ending style from the loaded ARXML file.
+
+        Returns:
+            The line ending string ('\\r\\n' for Windows CRLF, '\\n' for Unix LF)
+        """
+        return self._line_ending
+
+    @line_ending.setter
+    def line_ending(self, value: str) -> None:
+        """Set the line ending style.
+
+        Args:
+            value: The line ending string ('\\r\\n' or '\\n')
+        """
+        self._line_ending = value
+
     admin_data: Optional[AdminData]
     ar_packages: list[ARPackage]
     file_info_comment: Optional[FileInfoComment]
@@ -123,6 +141,7 @@ class AUTOSAR(ARObject):
         self.introduction: Optional[DocumentationBlock] = None
         self.schema_location: Optional[str] = None
         self._encoding: Optional[str] = None
+        self._line_ending: str = '\n'  # Default to Unix LF
 
         self._initialized = True
 
@@ -145,6 +164,7 @@ class AUTOSAR(ARObject):
         self.introduction = None
         self.schema_location = None
         self._encoding = None
+        self._line_ending = '\n'  # Reset to default Unix LF
 
     @classmethod
     def reset(cls) -> None:

--- a/src/armodel2/reader/reader.py
+++ b/src/armodel2/reader/reader.py
@@ -71,12 +71,13 @@ class ARXMLReader:
         if autosar is None:
             autosar = AUTOSAR()
 
-        root, encoding = self._load_file(filepath)
+        root, encoding, line_ending = self._load_file(filepath)
         self._populate_autosar(autosar, root)
 
-        # Store detected encoding in AUTOSAR object
+        # Store detected encoding and line ending in AUTOSAR object
         if encoding is not None:
             autosar._encoding = encoding
+        autosar._line_ending = line_ending
 
         if validate:
             self._validate_against_schema(root, autosar)
@@ -113,14 +114,14 @@ class ARXMLReader:
         AUTOSAR().clear()
         return self.load_arxml(filepath, validate=validate)
 
-    def _load_file(self, filepath: Union[str, Path]) -> tuple[ET.Element, Optional[str]]:
-        """Load ARXML file and return root element and detected encoding.
+    def _load_file(self, filepath: Union[str, Path]) -> tuple[ET.Element, Optional[str], str]:
+        """Load ARXML file and return root element, detected encoding, and line ending.
 
         Args:
             filepath: Path to ARXML file
 
         Returns:
-            Tuple of (root XML element, detected encoding string or None)
+            Tuple of (root XML element, detected encoding string or None, line ending string)
 
         Raises:
             FileNotFoundError: If file doesn't exist
@@ -135,11 +136,14 @@ class ARXMLReader:
         # Detect encoding from XML declaration
         encoding = self._detect_encoding(filepath)
 
+        # Detect line ending style
+        line_ending = self._detect_line_ending(filepath)
+
         # Let Python's XML parser handle encoding detection automatically
         # Python's ET.parse() detects encoding from BOM and XML declaration
         tree = ET.parse(filepath)
 
-        return tree.getroot(), encoding
+        return tree.getroot(), encoding, line_ending
 
     def _detect_encoding(self, filepath: Path) -> Optional[str]:
         """Detect encoding from XML declaration.
@@ -172,6 +176,30 @@ class ARXMLReader:
         except Exception:
             # If detection fails, return None (will use default)
             return None
+
+    def _detect_line_ending(self, filepath: Path) -> str:
+        """Detect line ending style from file.
+
+        Reads the first 4KB of the file to determine if it uses
+        Windows CRLF (\\r\\n) or Unix LF (\\n) line endings.
+
+        Args:
+            filepath: Path to ARXML file
+
+        Returns:
+            '\\r\\n' for CRLF (Windows), '\\n' for LF (Unix)
+        """
+        try:
+            with open(filepath, 'rb') as f:
+                content = f.read(4096)  # Read first 4KB
+
+            # Check for CRLF
+            if b'\r\n' in content:
+                return '\r\n'
+            return '\n'  # Default to LF
+        except Exception:
+            # If detection fails, return default LF
+            return '\n'
 
     def _populate_autosar(self, autosar: AUTOSAR, root: ET.Element) -> AUTOSAR:
         """Populate AUTOSAR object from XML element.
@@ -250,5 +278,5 @@ class ARXMLReader:
         Returns:
             Schema version string or None if unknown
         """
-        root, _ = self._load_file(filepath)
+        root, _, _ = self._load_file(filepath)
         return self._version_manager.detect_schema_version(root)

--- a/src/armodel2/writer/writer.py
+++ b/src/armodel2/writer/writer.py
@@ -90,7 +90,7 @@ class ARXMLWriter:
         Args:
             root: Root XML element
             filepath: Output file path
-            autosar: AUTOSAR object to get encoding from (optional)
+            autosar: AUTOSAR object to get encoding and line ending from (optional)
         """
         filepath = Path(filepath)
 
@@ -101,6 +101,11 @@ class ARXMLWriter:
         encoding = self._encoding
         if autosar is not None and autosar.encoding is not None:
             encoding = autosar.encoding
+
+        # Get line ending from AUTOSAR object or default to LF
+        line_ending = '\n'
+        if autosar is not None and hasattr(autosar, '_line_ending'):
+            line_ending = autosar._line_ending
 
         # Create tree and write
         tree = ET.ElementTree(root)
@@ -122,6 +127,9 @@ class ARXMLWriter:
 
         # Preserve HTML entity encoding in text content
         self._preserve_html_entities_file(filepath, encoding)
+
+        # Convert line endings to match original file
+        self._convert_line_endings_file(filepath, line_ending)
 
     def _fix_empty_elements_file(self, filepath: Path) -> None:
         """Convert self-closing empty elements to separate opening and closing tags.
@@ -256,8 +264,31 @@ class ARXMLWriter:
         # This regex matches >...< where ... is any text (including newlines)
         # but not another tag (which starts with <)
         processed_str = re.sub(r'>([^<]*?)<', escape_quotes_in_text, xml_str, flags=re.DOTALL)
-        
+
         return processed_str
+
+    def _convert_line_endings_file(self, filepath: Path, line_ending: str) -> None:
+        """Convert file line endings to match original.
+
+        xml.etree.ElementTree always uses Unix LF (\\n) line endings.
+        This method converts them to match the original file's line ending style.
+
+        Args:
+            filepath: Path to the ARXML file
+            line_ending: Target line ending ('\\r\\n' for CRLF, '\\n' for LF)
+        """
+        # Only convert if target is CRLF (ElementTree always outputs LF)
+        if line_ending != '\r\n':
+            return
+
+        with open(filepath, 'rb') as f:
+            content = f.read()
+
+        # Convert LF to CRLF
+        content = content.replace(b'\n', b'\r\n')
+
+        with open(filepath, 'wb') as f:
+            f.write(content)
 
     def _indent(self, elem: ET.Element, level: int = 0) -> None:
         """Add indentation to XML element for pretty printing.

--- a/tests/integration/test_binary_comparison.py
+++ b/tests/integration/test_binary_comparison.py
@@ -18,10 +18,21 @@ Traceability:
 """
 import pytest
 import shlex
+import sys
 from pathlib import Path
 
 from armodel2.reader import ARXMLReader
 from armodel2.writer import ARXMLWriter
+
+
+def _get_test_validated_files() -> list[str]:
+    """Discover all ARXML files in demos/test_validated/."""
+    test_validated_path = Path("demos/test_validated")
+    if not test_validated_path.exists():
+        return []
+    return sorted([f.name for f in test_validated_path.glob("*.arxml")])
+
+
 class TestIndividualFiles:
     """Test individual ARXML files with specific assertions.
 
@@ -55,13 +66,18 @@ class TestIndividualFiles:
             writer: ARXML writer instance
             tmp_path: Pytest temporary directory
         """
-        # Check both demos/validated and demos/arxml for compatibility
-        arxml_file = Path("demos/validated") / filename
+        # Check demos/test_validated first, then demos/validated, then demos/arxml
+        arxml_file = Path("demos/test_validated") / filename
+        if not arxml_file.exists():
+            arxml_file = Path("demos/validated") / filename
         if not arxml_file.exists():
             arxml_file = Path("demos/arxml") / filename
 
         if not arxml_file.exists():
             pytest.skip(f"File not found: {arxml_file}")
+
+        # Print file being tested (flush immediately for visibility)
+        print(f"\nTesting: {arxml_file}", file=sys.stderr, flush=True)
 
         # Read original
         original_bytes = arxml_file.read_bytes()
@@ -581,6 +597,56 @@ class TestIndividualFiles:
         """
         self._test_single_file_binary_comparison(
             "SwRecordDemo.arxml",
+            reader,
+            writer,
+            tmp_path
+        )
+
+
+class TestTestValidated:
+    """Test all ARXML files in demos/test_validated/ with wildcard discovery.
+
+    Any .arxml file added to demos/test_validated/ will be automatically tested.
+
+    Test IDs: SWITS-INT-0229+
+    """
+
+    @pytest.fixture
+    def reader(self) -> ARXMLReader:
+        """ARXML reader instance."""
+        return ARXMLReader()
+
+    @pytest.fixture
+    def writer(self) -> ARXMLWriter:
+        """ARXML writer instance."""
+        return ARXMLWriter(pretty_print=True, encoding="UTF-8")
+
+    @pytest.mark.parametrize(
+        "filename",
+        _get_test_validated_files(),
+        ids=lambda x: x.replace(".arxml", "")
+    )
+    def test_wildcard_binary_comparison(
+        self,
+        filename: str,
+        reader: ARXMLReader,
+        writer: ARXMLWriter,
+        tmp_path: Path
+    ) -> None:
+        """Test ARXML file from demos/test_validated/ for binary exact round-trip.
+
+        This test uses wildcard discovery - any .arxml file added to
+        demos/test_validated/ will be automatically tested.
+
+        Args:
+            filename: Name of the ARXML file to test
+            reader: ARXML reader instance
+            writer: ARXML writer instance
+            tmp_path: Pytest temporary directory
+        """
+        test_instance = TestIndividualFiles()
+        test_instance._test_single_file_binary_comparison(
+            filename,
             reader,
             writer,
             tmp_path

--- a/tests/integration/test_reader_encoding.py
+++ b/tests/integration/test_reader_encoding.py
@@ -69,8 +69,8 @@ class TestReaderEncoding:
 
         Test ID: SWITS-INT-0302
         """
-        # BswM.arxml uses UTF-8 encoding
-        arxml_file = Path("demos/arxml/BswM.arxml")
+        # AUTOSAR_Datatypes.arxml uses UTF-8 encoding
+        arxml_file = Path("demos/validated/AUTOSAR_Datatypes.arxml")
         if not arxml_file.exists():
             pytest.skip(f"File not found: {arxml_file}")
 


### PR DESCRIPTION
## Summary

Fix binary comparison test failures caused by line ending differences. The test files in `demos/test_validated/` use Windows CRLF (\r\n) line endings, but the writer always outputs Unix LF (\n) line endings.

## Changes

### Core Implementation

**ARXMLReader** (`src/armodel2/reader/reader.py`)
- Added `_detect_line_ending()` method to detect CRLF vs LF line endings from input files
- Updated `_load_file()` to return line ending as third tuple element
- Updated `load_arxml()` to store detected line ending in AUTOSAR object

**AUTOSAR Class** (`src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py`)
- Added `_line_ending` attribute to store detected line ending style (default: \n)
- Added `line_ending` property with getter and setter
- Updated `__init__()` and `clear()` methods to handle `_line_ending`

**ARXMLWriter** (`src/armodel2/writer/writer.py`)
- Added `_convert_line_endings_file()` method to convert LF to CRLF when needed
- Updated `_save_to_file()` to get line ending from AUTOSAR object and apply conversion

### Test Infrastructure

**test_binary_comparison.py**
- Added wildcard test discovery for `demos/test_validated/` directory
- Added `TestTestValidated` class for automated testing of all files in test_validated

**format_arxml.sh**
- Added `--test` and `--test_validated` options for directory presets

## Files Modified

1. `src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py`
2. `src/armodel2/reader/reader.py`
3. `src/armodel2/writer/writer.py`
4. `tests/integration/test_binary_comparison.py`
5. `tests/integration/test_reader_encoding.py`
6. `scripts/format_arxml.sh`

## Test Coverage

All 33 binary comparison tests now pass, including 4 previously failing tests:
- `Adc_Bswmd.arxml` - PASSED
- `Atomics_Bswmd.arxml` - PASSED
- `BootMgr_swc_interface.arxml` - PASSED
- `BootMgr_swc_internal.arxml` - PASSED

```
============================= 33 passed in 2.34s ==============================
```

## Quality Checks

- Ruff: All checks passed
- MyPy: No issues found
- Pytest: 287 tests passed

## Related Issues

Closes #190