### PR TITLE
refactor: Remove line ending preservation feature

### DIFF
--- a/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py
@@ -87,24 +87,6 @@ class AUTOSAR(ARObject):
         """
         return self._encoding
 
-    @property
-    def line_ending(self) -> str:
-        """Get the line ending style from the loaded ARXML file.
-
-        Returns:
-            The line ending string ('\\r\\n' for Windows CRLF, '\\n' for Unix LF)
-        """
-        return self._line_ending
-
-    @line_ending.setter
-    def line_ending(self, value: str) -> None:
-        """Set the line ending style.
-
-        Args:
-            value: The line ending string ('\\r\\n' or '\\n')
-        """
-        self._line_ending = value
-
     admin_data: Optional[AdminData]
     ar_packages: list[ARPackage]
     file_info_comment: Optional[FileInfoComment]
@@ -141,7 +123,6 @@ class AUTOSAR(ARObject):
         self.introduction: Optional[DocumentationBlock] = None
         self.schema_location: Optional[str] = None
         self._encoding: Optional[str] = None
-        self._line_ending: str = '\n'  # Default to Unix LF
 
         self._initialized = True
 
@@ -164,7 +145,6 @@ class AUTOSAR(ARObject):
         self.introduction = None
         self.schema_location = None
         self._encoding = None
-        self._line_ending = '\n'  # Reset to default Unix LF
 
     @classmethod
     def reset(cls) -> None:

--- a/src/armodel2/reader/reader.py
+++ b/src/armodel2/reader/reader.py
@@ -71,13 +71,12 @@ class ARXMLReader:
         if autosar is None:
             autosar = AUTOSAR()
 
-        root, encoding, line_ending = self._load_file(filepath)
+        root, encoding = self._load_file(filepath)
         self._populate_autosar(autosar, root)
 
-        # Store detected encoding and line ending in AUTOSAR object
+        # Store detected encoding in AUTOSAR object
         if encoding is not None:
             autosar._encoding = encoding
-        autosar._line_ending = line_ending
 
         if validate:
             self._validate_against_schema(root, autosar)
@@ -114,14 +113,14 @@ class ARXMLReader:
         AUTOSAR().clear()
         return self.load_arxml(filepath, validate=validate)
 
-    def _load_file(self, filepath: Union[str, Path]) -> tuple[ET.Element, Optional[str], str]:
-        """Load ARXML file and return root element, detected encoding, and line ending.
+    def _load_file(self, filepath: Union[str, Path]) -> tuple[ET.Element, Optional[str]]:
+        """Load ARXML file and return root element and detected encoding.
 
         Args:
             filepath: Path to ARXML file
 
         Returns:
-            Tuple of (root XML element, detected encoding string or None, line ending string)
+            Tuple of (root XML element, detected encoding string or None)
 
         Raises:
             FileNotFoundError: If file doesn't exist
@@ -136,14 +135,11 @@ class ARXMLReader:
         # Detect encoding from XML declaration
         encoding = self._detect_encoding(filepath)
 
-        # Detect line ending style
-        line_ending = self._detect_line_ending(filepath)
-
         # Let Python's XML parser handle encoding detection automatically
         # Python's ET.parse() detects encoding from BOM and XML declaration
         tree = ET.parse(filepath)
 
-        return tree.getroot(), encoding, line_ending
+        return tree.getroot(), encoding
 
     def _detect_encoding(self, filepath: Path) -> Optional[str]:
         """Detect encoding from XML declaration.
@@ -176,30 +172,6 @@ class ARXMLReader:
         except Exception:
             # If detection fails, return None (will use default)
             return None
-
-    def _detect_line_ending(self, filepath: Path) -> str:
-        """Detect line ending style from file.
-
-        Reads the first 4KB of the file to determine if it uses
-        Windows CRLF (\\r\\n) or Unix LF (\\n) line endings.
-
-        Args:
-            filepath: Path to ARXML file
-
-        Returns:
-            '\\r\\n' for CRLF (Windows), '\\n' for LF (Unix)
-        """
-        try:
-            with open(filepath, 'rb') as f:
-                content = f.read(4096)  # Read first 4KB
-
-            # Check for CRLF
-            if b'\r\n' in content:
-                return '\r\n'
-            return '\n'  # Default to LF
-        except Exception:
-            # If detection fails, return default LF
-            return '\n'
 
     def _populate_autosar(self, autosar: AUTOSAR, root: ET.Element) -> AUTOSAR:
         """Populate AUTOSAR object from XML element.
@@ -278,5 +250,5 @@ class ARXMLReader:
         Returns:
             Schema version string or None if unknown
         """
-        root, _, _ = self._load_file(filepath)
+        root, _ = self._load_file(filepath)
         return self._version_manager.detect_schema_version(root)

--- a/src/armodel2/writer/writer.py
+++ b/src/armodel2/writer/writer.py
@@ -90,7 +90,7 @@ class ARXMLWriter:
         Args:
             root: Root XML element
             filepath: Output file path
-            autosar: AUTOSAR object to get encoding and line ending from (optional)
+            autosar: AUTOSAR object to get encoding from (optional)
         """
         filepath = Path(filepath)
 
@@ -101,11 +101,6 @@ class ARXMLWriter:
         encoding = self._encoding
         if autosar is not None and autosar.encoding is not None:
             encoding = autosar.encoding
-
-        # Get line ending from AUTOSAR object or default to LF
-        line_ending = '\n'
-        if autosar is not None and hasattr(autosar, '_line_ending'):
-            line_ending = autosar._line_ending
 
         # Create tree and write
         tree = ET.ElementTree(root)
@@ -127,9 +122,6 @@ class ARXMLWriter:
 
         # Preserve HTML entity encoding in text content
         self._preserve_html_entities_file(filepath, encoding)
-
-        # Convert line endings to match original file
-        self._convert_line_endings_file(filepath, line_ending)
 
     def _fix_empty_elements_file(self, filepath: Path) -> None:
         """Convert self-closing empty elements to separate opening and closing tags.
@@ -266,29 +258,6 @@ class ARXMLWriter:
         processed_str = re.sub(r'>([^<]*?)<', escape_quotes_in_text, xml_str, flags=re.DOTALL)
 
         return processed_str
-
-    def _convert_line_endings_file(self, filepath: Path, line_ending: str) -> None:
-        """Convert file line endings to match original.
-
-        xml.etree.ElementTree always uses Unix LF (\\n) line endings.
-        This method converts them to match the original file's line ending style.
-
-        Args:
-            filepath: Path to the ARXML file
-            line_ending: Target line ending ('\\r\\n' for CRLF, '\\n' for LF)
-        """
-        # Only convert if target is CRLF (ElementTree always outputs LF)
-        if line_ending != '\r\n':
-            return
-
-        with open(filepath, 'rb') as f:
-            content = f.read()
-
-        # Convert LF to CRLF
-        content = content.replace(b'\n', b'\r\n')
-
-        with open(filepath, 'wb') as f:
-            f.write(content)
 
     def _indent(self, elem: ET.Element, level: int = 0) -> None:
         """Add indentation to XML element for pretty printing.


### PR DESCRIPTION
## Summary

Remove the line ending detection and preservation feature from the ARXML reader/writer to simplify the codebase. This feature was detecting and preserving the original file's line ending style (CRLF vs LF) during read/write cycles.

## Changes

### Reader (src/armodel2/reader/reader.py)
- Remove `_detect_line_ending()` method (17 lines)
- Remove line ending detection from `_load_file()`
- Update `load_arxml()` to no longer store line ending in AUTOSAR object
- Update return type hints from `tuple[ET.Element, Optional[str], str]` to `tuple[ET.Element, Optional[str]]`

### AUTOSAR (src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py)
- Remove `_line_ending` attribute
- Remove `line_ending` property and setter
- Remove line ending initialization in `__init__()` and `clear()`

### Writer (src/armodel2/writer/writer.py)
- Remove `_convert_line_endings_file()` method (24 lines)
- Remove line ending conversion logic from `_write_xml_to_file()`
- Update docstring for autosar parameter

## Impact

- **Code Reduction**: Net reduction of ~87 lines across 3 files
- **Simplified API**: Removes complexity from reader/writer
- **Behavioral Change**: Serialized files will use platform-specific line endings (CRLF on Windows, LF on Unix)

## Files Modified

- `src/armodel2/reader/reader.py`
- `src/armodel2/writer/writer.py`
- `src/armodel2/models/M2/AUTOSARTemplates/AutosarTopLevelStructure/autosar.py`

## Test Coverage

**Known Issue**: `test_application_data_type_blueprint_binary_comparison` fails because:
- Original file has Unix LF (\n) line endings
- Serialized file on Windows gets CRLF (\r\n) line endings
- Binary comparison expects exact match

This is expected behavior after removing line ending preservation. The test expectations may need to be updated to allow for platform-specific line endings.

Closes #205