### PR TITLE
fix: Handle XSD simpleContent pattern for direct text content seriali…

### DIFF
--- a/docs/designs/design_rules.md
+++ b/docs/designs/design_rules.md
@@ -29,54 +29,58 @@ Design rules are categorized by their type and scope:
 - **DESIGN_RULE_016**: Use `@xml_attribute` decorator for XML attributes (instead of elements) - see `docs/designs/decorators.md` for complete decorator documentation
 - **DESIGN_RULE_017**: XML tag names are automatically generated from class names
 - **DESIGN_RULE_018**: List attributes create wrapper elements (e.g., `ar_packages` → `<AR-PACKAGES>`)
+- **DESIGN_RULE_019**: simpleContent types (XSD pattern with direct text content) serialize text directly to `elem.text`, not wrapped in child elements
+  - Indicated by `"is_text_content": true` in the JSON mapping
+  - Example: `<SD GID="PROVIDING-HEADER-FILE">Can_GeneralTypes.h</SD>`
+  - Without `is_text_content`: `<SD GID="PROVIDING-HEADER-FILE"><VALUE>Can_GeneralTypes.h</VALUE></SD>`
 
 ### 4. Package Structure
-- **DESIGN_RULE_019**: Package hierarchy must match `mapping.json` package_path exactly
-- **DESIGN_RULE_020**: Each class gets its own file in the matching directory
-- **DESIGN_RULE_021**: `__init__.py` exports all classes in package
+- **DESIGN_RULE_020**: Package hierarchy must match `mapping.json` package_path exactly
+- **DESIGN_RULE_021**: Each class gets its own file in the matching directory
+- **DESIGN_RULE_022**: `__init__.py` exports all classes in package
 
 ### 5. Splitable Elements
-- **DESIGN_RULE_022**: Elements marked as `splitable: true` in mapping.json must include split metadata
-- **DESIGN_RULE_023**: Splitable elements must have `get_split_filename()` method
+- **DESIGN_RULE_023**: Elements marked as `splitable: true` in mapping.json must include split metadata
+- **DESIGN_RULE_024**: Splitable elements must have `get_split_filename()` method
 
 ### 6. Type Safety
-- **DESIGN_RULE_024**: Use type hints for all class attributes
-- **DESIGN_RULE_025**: Use Optional[T] for nullable attributes
-- **DESIGN_RULE_026**: Document complex types with docstrings
+- **DESIGN_RULE_025**: Use type hints for all class attributes
+- **DESIGN_RULE_026**: Use Optional[T] for nullable attributes
+- **DESIGN_RULE_027**: Document complex types with docstrings
 
 ### 7. Validation
-- **DESIGN_RULE_027**: All attributes must be validated in `builder.build()` method
-- **DESIGN_RULE_028**: Raise ValueError for invalid attribute values
-- **DESIGN_RULE_029**: Validate required attributes are present
+- **DESIGN_RULE_028**: All attributes must be validated in `builder.build()` method
+- **DESIGN_RULE_029**: Raise ValueError for invalid attribute values
+- **DESIGN_RULE_030**: Validate required attributes are present
 
 ### 8. Documentation
-- **DESIGN_RULE_030**: Each class must have a docstring
-- **DESIGN_RULE_031**: Each method must have a docstring
-- **DESIGN_RULE_032**: Document complex logic with inline comments
+- **DESIGN_RULE_031**: Each class must have a docstring
+- **DESIGN_RULE_032**: Each method must have a docstring
+- **DESIGN_RULE_033**: Document complex logic with inline comments
 
 ### 9. Testing
-- **DESIGN_RULE_033**: Each class must have unit tests
-- **DESIGN_RULE_034**: Tests must cover serialize/deserialize
-- **DESIGN_RULE_035**: Tests must verify builder functionality
+- **DESIGN_RULE_034**: Each class must have unit tests
+- **DESIGN_RULE_035**: Tests must cover serialize/deserialize
+- **DESIGN_RULE_036**: Tests must verify builder functionality
 
 ### 10. Architecture
-- **DESIGN_RULE_032**: Use class-based architecture instead of module-based
-- **DESIGN_RULE_033**: All infrastructure modules (core, reader, writer, cfg) must use class-based design
-- **DESIGN_RULE_034**: Infrastructure classes should use dependency injection for testability
-- **DESIGN_RULE_035**: Singleton pattern should be used for shared state managers
+- **DESIGN_RULE_037**: Use class-based architecture instead of module-based
+- **DESIGN_RULE_038**: All infrastructure modules (core, reader, writer, cfg) must use class-based design
+- **DESIGN_RULE_039**: Infrastructure classes should use dependency injection for testability
+- **DESIGN_RULE_040**: Singleton pattern should be used for shared state managers
 
 ### 11. Infrastructure Classes
-- **DESIGN_RULE_036**: SchemaVersionManager manages schema version detection and configuration
-- **DESIGN_RULE_037**: ConfigurationManager provides configuration loading with caching
-- **DESIGN_RULE_038**: ARXMLReader handles ARXML file loading and mapping to objects
-- **DESIGN_RULE_039**: ARXMLWriter handles object serialization and ARXML file saving
+- **DESIGN_RULE_041**: SchemaVersionManager manages schema version detection and configuration
+- **DESIGN_RULE_042**: ConfigurationManager provides configuration loading with caching
+- **DESIGN_RULE_043**: ARXMLReader handles ARXML file loading and mapping to objects
+- **DESIGN_RULE_044**: ARXMLWriter handles object serialization and ARXML file saving
 
 ### 12. Code Quality
-- **DESIGN_RULE_029**: No hardcoded values (use config where appropriate)
-- **DESIGN_RULE_030**: Follow PEP 8 style guide
-- **DESIGN_RULE_031**: Maximum line length 100 characters
-- **DESIGN_RULE_040**: All import statements must be defined at the beginning of the file
-- **DESIGN_RULE_041**: Use block import statements and define __all__ in __init__.py files
+- **DESIGN_RULE_045**: No hardcoded values (use config where appropriate)
+- **DESIGN_RULE_046**: Follow PEP 8 style guide
+- **DESIGN_RULE_047**: Maximum line length 100 characters
+- **DESIGN_RULE_048**: All import statements must be defined at the beginning of the file
+- **DESIGN_RULE_049**: Use block import statements and define __all__ in __init__.py files
   - Use full absolute imports with block format (multi-line with parentheses)
   - Block import format for single class: `from armodel2.models.M2.AUTOSARTemplates.Package.module import (\n    Class,\n)`
   - Block import format for multiple classes: `from armodel2.models.M2.AUTOSARTemplates.Package.module import (\n    Class1,\n    Class2,\n    Class3,\n)`

--- a/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
@@ -219,6 +219,7 @@
           "multiplicity": "1",
           "kind": "attribute",
           "is_ref": false,
+          "is_text_content": true,
           "note": "This is the value of the special data."
         },
         "xmlSpace": {

--- a/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sd.py
+++ b/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sd.py
@@ -84,23 +84,17 @@ class Sd(ARObject):
         for child in parent_elem:
             elem.append(child)
 
+        # Serialize text content directly (simpleContent type)
+        if self.value is not None:
+            # Get the raw value from ARPrimitive if it's a primitive type
+            if hasattr(self.value, 'value'):
+                elem.text = str(self.value.value)
+            else:
+                elem.text = str(self.value)
+
         # Serialize gid as XML attribute
         if self.gid is not None:
             elem.attrib["GID"] = str(self.gid)
-
-        # Serialize value
-        if self.value is not None:
-            serialized = SerializationHelper.serialize_item(self.value, "VerbatimStringPlain")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("VALUE")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
 
         # Serialize xml_space
         if self.xml_space is not None:
@@ -131,6 +125,10 @@ class Sd(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(Sd, cls).deserialize(element)
 
+        # Deserialize text content from element.text (simpleContent type)
+        if element.text and element.text.strip():
+            obj.value = VerbatimStringPlain(value=element.text)
+
         # Parse gid from XML attribute
         if "GID" in element.attrib:
             obj.gid = element.attrib["GID"]
@@ -139,9 +137,7 @@ class Sd(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "VALUE":
-                setattr(obj, "value", SerializationHelper.deserialize_by_tag(child, "VerbatimStringPlain"))
-            elif tag == "XML-SPACE":
+            if tag == "XML-SPACE":
                 setattr(obj, "xml_space", SerializationHelper.deserialize_by_tag(child, "XmlSpaceEnum"))
 
         return obj

--- a/tools/generate_models/README.md
+++ b/tools/generate_models/README.md
@@ -126,6 +126,84 @@ Package-specific JSON files with detailed class definitions:
 - `*.enums.json` - Enumeration literals
 - `*.primitives.json` - Primitive type definitions
 
+#### JSON Schema Format
+
+The `*.classes.json` files define AUTOSAR model classes with the following schema:
+
+```json
+{
+  "package": "M2::MSR::AsamHdo::SpecialData",
+  "classes": [
+    {
+      "name": "Sd",
+      "maturity": "draft",
+      "package": "M2::MSR::AsamHdo::SpecialData",
+      "is_abstract": false,
+      "atp_type": null,
+      "parent": "ARObject",
+      "bases": ["ARObject"],
+      "attributes": {
+        "gid": {
+          "type": "NameToken",
+          "multiplicity": "1",
+          "kind": "aggr",
+          "is_ref": false,
+          "decorator": "xml_attribute",
+          "note": "This attributes specifies an identifier."
+        },
+        "value": {
+          "type": "VerbatimStringPlain",
+          "multiplicity": "1",
+          "kind": "attribute",
+          "is_ref": false,
+          "is_text_content": true,
+          "note": "This is the value of the special data."
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Attribute Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | string | The AUTOSAR type name (e.g., `"NameToken"`, `"VerbatimStringPlain"`) |
+| `multiplicity` | string | Cardinality: `"1"`, `"0..1"`, `"*"`, `"0..*"`, `"1..*"` |
+| `kind` | string | Attribute kind: `"attribute"`, `"aggr"`, `"ref"`, `"tref"`, `"iref"` |
+| `is_ref` | boolean | Whether this is a reference type |
+| `decorator` | string | Optional decorator: `"xml_attribute"`, `"atp_variant"`, etc. |
+| `is_text_content` | boolean | Marks simpleContent types (text directly in element, not wrapped) |
+| `note` | string | Human-readable description |
+
+#### Special Attribute Flags
+
+**`is_text_content`**: Indicates that this attribute's value should be serialized as direct text content of the XML element (XSD simpleContent pattern), rather than being wrapped in a child element.
+
+Example:
+```json
+{
+  "name": "Sd",
+  "attributes": {
+    "value": {
+      "type": "VerbatimStringPlain",
+      "is_text_content": true
+    }
+  }
+}
+```
+
+Generates XML:
+```xml
+<SD GID="PROVIDING-HEADER-FILE">Can_GeneralTypes.h</SD>
+```
+
+Without `is_text_content`, it would generate:
+```xml
+<SD GID="PROVIDING-HEADER-FILE"><VALUE>Can_GeneralTypes.h</VALUE></SD>
+```
+
 ### skip_classes.yaml
 
 YAML file specifying classes to skip during generation:

--- a/tools/generate_models/generators.py
+++ b/tools/generate_models/generators.py
@@ -204,6 +204,70 @@ def _is_basic_python_type(type_name: str) -> bool:
     return type_name in ("str", "int", "float", "bool")
 
 
+def _get_simple_content_info(
+    class_name: str,
+    package_path: str,
+    package_data: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Detect if a class uses simpleContent (direct text content + attributes only).
+
+    simpleContent types have text content directly in the element, not wrapped in child elements.
+    This is defined in the XSD with <xsd:simpleContent> and means the element has:
+    - Text content (not wrapped in child elements)
+    - Attributes only (no child elements)
+
+    Auto-detection: If any attribute has 'is_text_content': true, this is a simpleContent type.
+
+    Args:
+        class_name: Name of the class to check
+        package_path: Path to the package containing the class
+        package_data: Package data dictionary
+
+    Returns:
+        Dictionary with:
+        - 'has_simple_content': bool - True if class uses simpleContent
+        - 'text_content_attr': Dict or None - The attribute that holds the text content
+    """
+    result = {
+        'has_simple_content': False,
+        'text_content_attr': None
+    }
+
+    if package_path not in package_data:
+        return result
+
+    class_info = package_data[package_path].get("classes", [])
+    cls = None
+    for c in class_info:
+        if c["name"] == class_name:
+            cls = c
+            break
+
+    if cls is None:
+        return result
+
+    # Auto-detect simpleContent: find the attribute marked as text content
+    for attr_name, attr_info in cls.get("attributes", {}).items():
+        if attr_info.get("is_text_content", False):
+            # Build the same metadata format as _collect_attribute_types_with_flattening
+            attr_type = attr_info["type"]
+            multiplicity = attr_info["multiplicity"]
+            is_ref = attr_info.get("is_ref", False)
+            kind = attr_info.get("kind", "attribute")
+
+            result['has_simple_content'] = True
+            result['text_content_attr'] = {
+                "name": attr_name,
+                "type": attr_type,
+                "multiplicity": multiplicity,
+                "is_ref": is_ref,
+                "kind": kind,
+            }
+            break
+
+    return result
+
+
 def _generate_xml_tag_constant(class_name: str) -> str:
     """Generate _XML_TAG constant for a class."""
     xml_tag = NameConverter.to_xml_tag(class_name)
@@ -457,8 +521,13 @@ def generate_class_code(
         # Collect attribute types for imports (with atpMixed flattening)
         attribute_types = {}
         has_xml_attribute = False
+        simple_content_info = {}
         if include_members and package_path in package_data:
             attribute_types = _collect_attribute_types_with_flattening(
+                class_name, package_path, package_data
+            )
+            # Check if this class uses simpleContent (direct text content)
+            simple_content_info = _get_simple_content_info(
                 class_name, package_path, package_data
             )
             # Check if any attribute uses xml_attribute
@@ -1262,20 +1331,20 @@ class {class_name}(ABC):
             # Parent is ARObject, still need to generate custom methods
             # because ARObject.serialize() only handles checksum and timestamp
             serialize_code = _generate_serialize_method(
-                class_name, attribute_types, parent_class, package_data
+                class_name, attribute_types, parent_class, package_data, None, simple_content_info
             )
             deserialize_code = _generate_deserialize_method(
-                class_name, attribute_types, parent_class, package_data, polymorphic_types
+                class_name, attribute_types, parent_class, package_data, polymorphic_types, simple_content_info
             )
             code += serialize_code + deserialize_code
     else:
         # For other classes, generate optimized serialize() and deserialize() methods
         # These methods parse/serialize XML directly for better performance
         serialize_code = _generate_serialize_method(
-            class_name, attribute_types, parent_class, package_data
+            class_name, attribute_types, parent_class, package_data, None, simple_content_info
         )
         deserialize_code = _generate_deserialize_method(
-            class_name, attribute_types, parent_class, package_data, polymorphic_types
+            class_name, attribute_types, parent_class, package_data, polymorphic_types, simple_content_info
         )
         code += serialize_code + deserialize_code
 
@@ -1288,6 +1357,7 @@ def _generate_deserialize_method(
     parent_class: Optional[str],
     package_data: Dict[str, Dict[str, Any]],
     polymorphic_types: Optional[Dict[str, List[str]]] = None,
+    simple_content_info: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Generate optimized deserialize() method for a class.
 
@@ -1297,12 +1367,15 @@ def _generate_deserialize_method(
         parent_class: Name of parent class (if any)
         package_data: Package data dictionary
         polymorphic_types: Dict mapping base types to lists of concrete implementations
+        simple_content_info: Optional dict with 'has_simple_content' and 'text_content_attr'
 
     Returns:
         Generated deserialize() method code
     """
     if polymorphic_types is None:
         polymorphic_types = {}
+    if simple_content_info is None:
+        simple_content_info = {}
 
     code = f'''    @classmethod
     def deserialize(cls, element: ET.Element) -> "{class_name}":
@@ -1339,6 +1412,25 @@ def _generate_deserialize_method(
         obj.__init__()
 
 """
+
+    # Handle simpleContent - deserialize text content from element.text
+    has_simple_content = simple_content_info.get('has_simple_content', False)
+    text_content_attr = simple_content_info.get('text_content_attr')
+
+    if has_simple_content and text_content_attr:
+        attr_name = text_content_attr['name']
+        attr_type = text_content_attr['type']
+        python_name = get_python_identifier_with_ref(
+            attr_name,
+            text_content_attr.get('is_ref', False),
+            text_content_attr.get('multiplicity', '1'),
+            text_content_attr.get('kind', 'attribute')
+        )
+        code += f'''        # Deserialize text content from element.text (simpleContent type)
+        if element.text and element.text.strip():
+            obj.{python_name} = {attr_type}(value=element.text)
+
+'''
 
     # Handle xml_attribute and lang_abbr attributes (read from element.attrib)
     if attribute_types:
@@ -1379,6 +1471,9 @@ def _generate_deserialize_method(
             if decorator_name == "lang_abbr":
                 continue
             if decorator_name == "lang_prefix":
+                continue
+            # Skip text content attribute for simpleContent types (already handled above)
+            if has_simple_content and text_content_attr and attr_name == text_content_attr['name']:
                 continue
 
             multiplicity = attr_info.get("multiplicity", "1")
@@ -3310,6 +3405,7 @@ def _generate_serialize_method(
     parent_class: Optional[str],
     package_data: Dict[str, Dict[str, Any]],
     polymorphic_types: Optional[Dict[str, List[str]]] = None,
+    simple_content_info: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Generate optimized serialize() method for a class.
 
@@ -3324,12 +3420,15 @@ def _generate_serialize_method(
         parent_class: Name of parent class (if any)
         package_data: Package data dictionary
         polymorphic_types: Dict mapping base types to lists of concrete implementations
+        simple_content_info: Optional dict with 'has_simple_content' and 'text_content_attr'
 
     Returns:
         Generated serialize() method code
     """
     if polymorphic_types is None:
         polymorphic_types = {}
+    if simple_content_info is None:
+        simple_content_info = {}
     code = f'''    def serialize(self) -> ET.Element:
         """Serialize {class_name} to XML element.
 
@@ -3360,9 +3459,34 @@ def _generate_serialize_method(
 
 """
 
+    # Handle simpleContent - serialize text content directly to elem.text
+    has_simple_content = simple_content_info.get('has_simple_content', False)
+    text_content_attr = simple_content_info.get('text_content_attr')
+
+    if has_simple_content and text_content_attr:
+        attr_name = text_content_attr['name']
+        python_name = get_python_identifier_with_ref(
+            attr_name,
+            text_content_attr.get('is_ref', False),
+            text_content_attr.get('multiplicity', '1'),
+            text_content_attr.get('kind', 'attribute')
+        )
+        code += f'''        # Serialize text content directly (simpleContent type)
+        if self.{python_name} is not None:
+            # Get the raw value from ARPrimitive if it's a primitive type
+            if hasattr(self.{python_name}, 'value'):
+                elem.text = str(self.{python_name}.value)
+            else:
+                elem.text = str(self.{python_name})
+
+'''
+
     # Generate code to serialize each attribute
     if attribute_types:
         for attr_name, attr_info in attribute_types.items():
+            # Skip text content attribute for simpleContent types (already handled above)
+            if has_simple_content and text_content_attr and attr_name == text_content_attr['name']:
+                continue
             attr_type = attr_info["type"]
             multiplicity = attr_info["multiplicity"]
             is_ref = attr_info.get("is_ref", False)


### PR DESCRIPTION
…zation

Fix SD element serialization to use direct text content (XSD simpleContent) instead of wrapping in <VALUE> child elements.

Changes:
- Add is_text_content flag to JSON mapping for Sd class
- Update code generator to auto-detect and handle simpleContent types
- Add JSON schema documentation in tools/generate_models/README.md
- Add DESIGN_RULE_019 for simpleContent types

Test Coverage:
- Base_Bswmd.arxml binary comparison test now passes
- SD elements correctly serialize with direct text content

Closes #213