### PR TITLE
fix: Fix atp_mixed wrapper attribute handling

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswBehavior.classes.json
@@ -89,21 +89,6 @@
           "is_ref": false,
           "note": "Indicates an abstract partition context in which the enclosing BswModuleEntity can be executed. atpVariation"
         },
-        "entity": {
-          "type": "BswModuleEntity",
-          "multiplicity": "*",
-          "kind": "aggr",
-          "is_ref": false,
-          "decorator": "polymorphic:ENTITYS=BswModuleEntity",
-          "note": "A code entity for which the behavior is described atpVariation"
-        },
-        "event": {
-          "type": "BswEvent",
-          "multiplicity": "*",
-          "kind": "aggr",
-          "is_ref": false,
-          "note": "An event required by this module behavior. atpVariation"
-        },
         "exclusiveAreaPolicy": {
           "type": "BswExclusiveAreaPolicy",
           "multiplicity": "*",
@@ -138,6 +123,21 @@
           "kind": "aggr",
           "is_ref": false,
           "note": "Policy for an internalTriggeringPoint in this BswInternal Behavior.. The policy selects the options of the Schedule API generation. atpVariation"
+        },
+        "entity": {
+          "type": "BswModuleEntity",
+          "multiplicity": "*",
+          "kind": "aggr",
+          "is_ref": false,
+          "decorator": "polymorphic:ENTITYS=BswModuleEntity",
+          "note": "A code entity for which the behavior is described atpVariation"
+        },
+        "event": {
+          "type": "BswEvent",
+          "multiplicity": "*",
+          "kind": "aggr",
+          "is_ref": false,
+          "note": "An event required by this module behavior. atpVariation"
         },
         "modeSenderPolicy": {
           "type": "BswModeSenderPolicy",
@@ -282,6 +282,7 @@
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
+          "decorator": "ref_conditional:ACTIVATION-POINTS",
           "note": "Activation point used by the module entity to activate one more internal triggers. atpVariation"
         },
         "callPoint": {

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
@@ -68,13 +68,6 @@
           "is_ref": false,
           "note": "Refers to the service identifier of the Standardized AUTOSAR basic software. For it can optionally be used for"
         },
-        "argument": {
-          "type": "SwServiceArg",
-          "multiplicity": "*",
-          "kind": "aggr",
-          "is_ref": false,
-          "note": "An argument belonging to this BswModuleEntry."
-        },
         "bswEntryKind": {
           "type": "BswEntryKindEnum",
           "multiplicity": "0..1",
@@ -117,6 +110,13 @@
           "is_ref": false,
           "note": "This attribute is used to control the generation of function"
         },
+        "swServiceImplPolicy": {
+          "type": "SwServiceImplPolicyEnum",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on because it determines the signature of the"
+        },
         "returnType": {
           "type": "SwServiceArg",
           "multiplicity": "0..1",
@@ -124,20 +124,19 @@
           "is_ref": false,
           "note": "The return type belonging to this bswModuleEntry."
         },
+        "argument": {
+          "type": "SwServiceArg",
+          "multiplicity": "*",
+          "kind": "aggr",
+          "is_ref": false,
+          "note": "An argument belonging to this BswModuleEntry."
+        },
         "role": {
           "type": "Identifier",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
           "note": "Specifies the role of the entry in the given context. It shall"
-        },
-        
-        "swServiceImplPolicy": {
-          "type": "SwServiceImplPolicyEnum",
-          "multiplicity": "0..1",
-          "kind": "attribute",
-          "is_ref": false,
-          "note": "Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on because it determines the signature of the"
         }
       }
     },
@@ -296,7 +295,7 @@
     },
     {
       "name": "BswModuleClientServerEntry",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::BswModuleTemplate::BswInterfaces",
       "is_abstract": false,
       "atp_type": null,

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
@@ -106,12 +106,20 @@
           "is_ref": true,
           "note": "Specifies an entry provided by this module which can be by other modules. This includes \"main\" functions, and callbacks. Replacement of expectedCallback. atpVariation"
         },
+        "providedEntry": {
+          "type": "BswModuleEntry",
+          "multiplicity": "*",
+          "kind": "ref",
+          "is_ref": true,
+          "revision": "4.0.3",
+          "decorator": "ref_conditional:PROVIDED-ENTRYS",
+          "note": "Specifies an entry provided by this module which can be called by other modules. This includes \"main\" functions and interrupt routines, but not callbacks (because the signature of a callback is defined by the caller)."
+        },
         "providedClientServerEntry": {
           "type": "BswModuleClientServerEntry",
           "multiplicity": "*",
           "kind": "aggr",
           "is_ref": false,
-          "decorator": "xml_element_name:PROVIDED-ENTRYS",
           "note": "Specifies that this module provides a client server entry which can be called from another partition or core.This declared locally to this context and will be the requiredClientServerEntry of another or module via the configuration of the BSW atpVariation"
         },
         "providedData": {

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_PrimitiveTypes.enums.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_PrimitiveTypes.enums.json
@@ -3,7 +3,7 @@
   "enumerations": [
     {
       "name": "ArgumentDirectionEnum",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::PrimitiveTypes",
       "note": "Use cases: • Arguments in ClientServerOperation can have different directions that need to be formally indicated because they have an impact on how the function signature looks like eventually. • Arguments in BswModuleEntry already determine a function signature, but the direction is used to specify the semantics, especially of pointer arguments. Aggregated by ArgumentDataPrototype.direction, SwServiceArg.direction",
       "sources": [

--- a/docs/json/packages/M2_MSR_DataDictionary_ServiceProcessTask.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_ServiceProcessTask.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "SwServiceArg",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::ServiceProcessTask",
       "is_abstract": false,
       "atp_type": null,
@@ -66,14 +66,14 @@
         "swArraysize": {
           "type": "ValueList",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "This turns the argument of the service to an array."
         },
-        "swDataDef": {
+        "swDataDefProps": {
           "type": "SwDataDefProps",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Data properties of this SwServiceArg."
         }

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_internal_behavior.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_internal_behavior.py
@@ -93,13 +93,13 @@ class BswInternalBehavior(InternalBehavior):
     bsw_per_instance_memory_policies: list[BswPerInstanceMemoryPolicy]
     client_policies: list[BswClientPolicy]
     distinguished_partitions: list[BswDistinguishedPartition]
-    _entities: list[BswModuleEntity]
-    events: list[BswEvent]
     exclusive_area_policies: list[BswExclusiveAreaPolicy]
     included_data_type_sets: list[IncludedDataTypeSet]
     included_mode_declaration_group_sets: list[IncludedModeDeclarationGroupSet]
     internal_triggering_points: list[BswInternalTriggeringPoint]
     internal_triggering_point_policies: list[BswInternalTriggeringPointPolicy]
+    _entities: list[BswModuleEntity]
+    events: list[BswEvent]
     mode_sender_policies: list[BswModeSenderPolicy]
     mode_receiver_policies: list[BswModeReceiverPolicy]
     parameter_policies: list[BswParameterPolicy]
@@ -116,13 +116,13 @@ class BswInternalBehavior(InternalBehavior):
         "BSW-PER-INSTANCE-MEMORY-POLICYS": lambda obj, elem: obj.bsw_per_instance_memory_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswPerInstanceMemoryPolicy")),
         "CLIENT-POLICYS": lambda obj, elem: obj.client_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswClientPolicy")),
         "DISTINGUISHED-PARTITIONS": lambda obj, elem: obj.distinguished_partitions.append(SerializationHelper.deserialize_by_tag(elem, "BswDistinguishedPartition")),
-        "ENTITYS": ("_POLYMORPHIC_LIST", "_entities", ["BswCalledEntity", "BswInterruptEntity", "BswSchedulableEntity"]),
-        "EVENTS": ("_POLYMORPHIC_LIST", "events", ["BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswDataReceivedEvent", "BswExternalTriggerOccurredEvent", "BswInternalTriggerOccurredEvent", "BswInterruptEvent", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswScheduleEvent", "BswTimingEvent"]),
         "EXCLUSIVE-AREA-POLICYS": lambda obj, elem: obj.exclusive_area_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswExclusiveAreaPolicy")),
         "INCLUDED-DATA-TYPE-SETS": lambda obj, elem: obj.included_data_type_sets.append(SerializationHelper.deserialize_by_tag(elem, "IncludedDataTypeSet")),
         "INCLUDED-MODE-DECLARATION-GROUP-SETS": lambda obj, elem: obj.included_mode_declaration_group_sets.append(SerializationHelper.deserialize_by_tag(elem, "IncludedModeDeclarationGroupSet")),
         "INTERNAL-TRIGGERING-POINTS": lambda obj, elem: obj.internal_triggering_points.append(SerializationHelper.deserialize_by_tag(elem, "BswInternalTriggeringPoint")),
         "INTERNAL-TRIGGERING-POINT-POLICYS": lambda obj, elem: obj.internal_triggering_point_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswInternalTriggeringPointPolicy")),
+        "ENTITYS": ("_POLYMORPHIC_LIST", "_entities", ["BswCalledEntity", "BswInterruptEntity", "BswSchedulableEntity"]),
+        "EVENTS": ("_POLYMORPHIC_LIST", "events", ["BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswDataReceivedEvent", "BswExternalTriggerOccurredEvent", "BswInternalTriggerOccurredEvent", "BswInterruptEvent", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswScheduleEvent", "BswTimingEvent"]),
         "MODE-SENDER-POLICYS": lambda obj, elem: obj.mode_sender_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswModeSenderPolicy")),
         "MODE-RECEIVER-POLICYS": lambda obj, elem: obj.mode_receiver_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswModeReceiverPolicy")),
         "PARAMETER-POLICYS": lambda obj, elem: obj.parameter_policies.append(SerializationHelper.deserialize_by_tag(elem, "BswParameterPolicy")),
@@ -144,13 +144,13 @@ class BswInternalBehavior(InternalBehavior):
         self.bsw_per_instance_memory_policies: list[BswPerInstanceMemoryPolicy] = []
         self.client_policies: list[BswClientPolicy] = []
         self.distinguished_partitions: list[BswDistinguishedPartition] = []
-        self._entities: list[BswModuleEntity] = []
-        self.events: list[BswEvent] = []
         self.exclusive_area_policies: list[BswExclusiveAreaPolicy] = []
         self.included_data_type_sets: list[IncludedDataTypeSet] = []
         self.included_mode_declaration_group_sets: list[IncludedModeDeclarationGroupSet] = []
         self.internal_triggering_points: list[BswInternalTriggeringPoint] = []
         self.internal_triggering_point_policies: list[BswInternalTriggeringPointPolicy] = []
+        self._entities: list[BswModuleEntity] = []
+        self.events: list[BswEvent] = []
         self.mode_sender_policies: list[BswModeSenderPolicy] = []
         self.mode_receiver_policies: list[BswModeReceiverPolicy] = []
         self.parameter_policies: list[BswParameterPolicy] = []
@@ -237,25 +237,6 @@ class BswInternalBehavior(InternalBehavior):
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize entities (list with polymorphic wrapper "ENTITYS")
-        if self.entities:
-            container = ET.Element("ENTITYS")
-            for item in self.entities:
-                serialized = SerializationHelper.serialize_item(item, "BswModuleEntity")
-                if serialized is not None:
-                    container.append(serialized)
-            elem.append(container)
-
-        # Serialize events (list to container "EVENTS")
-        if self.events:
-            wrapper = ET.Element("EVENTS")
-            for item in self.events:
-                serialized = SerializationHelper.serialize_item(item, "BswEvent")
-                if serialized is not None:
-                    wrapper.append(serialized)
-            if len(wrapper) > 0:
-                elem.append(wrapper)
-
         # Serialize exclusive_area_policies (list to container "EXCLUSIVE-AREA-POLICYS")
         if self.exclusive_area_policies:
             wrapper = ET.Element("EXCLUSIVE-AREA-POLICYS")
@@ -301,6 +282,25 @@ class BswInternalBehavior(InternalBehavior):
             wrapper = ET.Element("INTERNAL-TRIGGERING-POINT-POLICYS")
             for item in self.internal_triggering_point_policies:
                 serialized = SerializationHelper.serialize_item(item, "BswInternalTriggeringPointPolicy")
+                if serialized is not None:
+                    wrapper.append(serialized)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize entities (list with polymorphic wrapper "ENTITYS")
+        if self.entities:
+            container = ET.Element("ENTITYS")
+            for item in self.entities:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntity")
+                if serialized is not None:
+                    container.append(serialized)
+            elem.append(container)
+
+        # Serialize events (list to container "EVENTS")
+        if self.events:
+            wrapper = ET.Element("EVENTS")
+            for item in self.events:
+                serialized = SerializationHelper.serialize_item(item, "BswEvent")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
@@ -451,6 +451,26 @@ class BswInternalBehavior(InternalBehavior):
                 # Iterate through wrapper children
                 for item_elem in child:
                     obj.distinguished_partitions.append(SerializationHelper.deserialize_by_tag(item_elem, "BswDistinguishedPartition"))
+            elif tag == "EXCLUSIVE-AREA-POLICYS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.exclusive_area_policies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswExclusiveAreaPolicy"))
+            elif tag == "INCLUDED-DATA-TYPE-SETS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.included_data_type_sets.append(SerializationHelper.deserialize_by_tag(item_elem, "IncludedDataTypeSet"))
+            elif tag == "INCLUDED-MODE-DECLARATION-GROUP-SETS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.included_mode_declaration_group_sets.append(SerializationHelper.deserialize_by_tag(item_elem, "IncludedModeDeclarationGroupSet"))
+            elif tag == "INTERNAL-TRIGGERING-POINTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.internal_triggering_points.append(SerializationHelper.deserialize_by_tag(item_elem, "BswInternalTriggeringPoint"))
+            elif tag == "INTERNAL-TRIGGERING-POINT-POLICYS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.internal_triggering_point_policies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswInternalTriggeringPointPolicy"))
             elif tag == "ENTITYS":
                 # Iterate through all child elements and deserialize each based on its concrete type
                 for item_elem in child:
@@ -491,26 +511,6 @@ class BswInternalBehavior(InternalBehavior):
                         obj.events.append(SerializationHelper.deserialize_by_tag(item_elem, "BswScheduleEvent"))
                     elif concrete_tag == "BSW-TIMING-EVENT":
                         obj.events.append(SerializationHelper.deserialize_by_tag(item_elem, "BswTimingEvent"))
-            elif tag == "EXCLUSIVE-AREA-POLICYS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.exclusive_area_policies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswExclusiveAreaPolicy"))
-            elif tag == "INCLUDED-DATA-TYPE-SETS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.included_data_type_sets.append(SerializationHelper.deserialize_by_tag(item_elem, "IncludedDataTypeSet"))
-            elif tag == "INCLUDED-MODE-DECLARATION-GROUP-SETS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.included_mode_declaration_group_sets.append(SerializationHelper.deserialize_by_tag(item_elem, "IncludedModeDeclarationGroupSet"))
-            elif tag == "INTERNAL-TRIGGERING-POINTS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.internal_triggering_points.append(SerializationHelper.deserialize_by_tag(item_elem, "BswInternalTriggeringPoint"))
-            elif tag == "INTERNAL-TRIGGERING-POINT-POLICYS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.internal_triggering_point_policies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswInternalTriggeringPointPolicy"))
             elif tag == "MODE-SENDER-POLICYS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -619,30 +619,6 @@ class BswInternalBehaviorBuilder(InternalBehaviorBuilder):
         self._obj.distinguished_partitions = list(items) if items else []
         return self
 
-    def with_entities(self, items: list[BswModuleEntity]) -> "BswInternalBehaviorBuilder":
-        """Set entities list attribute.
-
-        Args:
-            items: List of items to set
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.entities = list(items) if items else []
-        return self
-
-    def with_events(self, items: list[BswEvent]) -> "BswInternalBehaviorBuilder":
-        """Set events list attribute.
-
-        Args:
-            items: List of items to set
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.events = list(items) if items else []
-        return self
-
     def with_exclusive_area_policies(self, items: list[BswExclusiveAreaPolicy]) -> "BswInternalBehaviorBuilder":
         """Set exclusive_area_policies list attribute.
 
@@ -701,6 +677,30 @@ class BswInternalBehaviorBuilder(InternalBehaviorBuilder):
             self for method chaining
         """
         self._obj.internal_triggering_point_policies = list(items) if items else []
+        return self
+
+    def with_entities(self, items: list[BswModuleEntity]) -> "BswInternalBehaviorBuilder":
+        """Set entities list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.entities = list(items) if items else []
+        return self
+
+    def with_events(self, items: list[BswEvent]) -> "BswInternalBehaviorBuilder":
+        """Set events list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.events = list(items) if items else []
         return self
 
     def with_mode_sender_policies(self, items: list[BswModeSenderPolicy]) -> "BswInternalBehaviorBuilder":
@@ -920,48 +920,6 @@ class BswInternalBehaviorBuilder(InternalBehaviorBuilder):
         self._obj.distinguished_partitions = []
         return self
 
-    def add_entity(self, item: BswModuleEntity) -> "BswInternalBehaviorBuilder":
-        """Add a single item to entities list.
-
-        Args:
-            item: Item to add
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.entities.append(item)
-        return self
-
-    def clear_entities(self) -> "BswInternalBehaviorBuilder":
-        """Clear all items from entities list.
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.entities = []
-        return self
-
-    def add_event(self, item: BswEvent) -> "BswInternalBehaviorBuilder":
-        """Add a single item to events list.
-
-        Args:
-            item: Item to add
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.events.append(item)
-        return self
-
-    def clear_events(self) -> "BswInternalBehaviorBuilder":
-        """Clear all items from events list.
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.events = []
-        return self
-
     def add_exclusive_area_policy(self, item: BswExclusiveAreaPolicy) -> "BswInternalBehaviorBuilder":
         """Add a single item to exclusive_area_policies list.
 
@@ -1065,6 +1023,48 @@ class BswInternalBehaviorBuilder(InternalBehaviorBuilder):
             self for method chaining
         """
         self._obj.internal_triggering_point_policies = []
+        return self
+
+    def add_entity(self, item: BswModuleEntity) -> "BswInternalBehaviorBuilder":
+        """Add a single item to entities list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.entities.append(item)
+        return self
+
+    def clear_entities(self) -> "BswInternalBehaviorBuilder":
+        """Clear all items from entities list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.entities = []
+        return self
+
+    def add_event(self, item: BswEvent) -> "BswInternalBehaviorBuilder":
+        """Add a single item to events list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.events.append(item)
+        return self
+
+    def clear_events(self) -> "BswInternalBehaviorBuilder":
+        """Clear all items from events list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.events = []
         return self
 
     def add_mode_sender_policy(self, item: BswModeSenderPolicy) -> "BswInternalBehaviorBuilder":

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_entity.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_entity.py
@@ -57,7 +57,7 @@ class BswModuleEntity(ExecutableEntity, ABC):
         return True
 
     _accessed_mode_group_refs: list[ARRef]
-    activation_point_refs: list[ARRef]
+    _activation_point_refs: list[ARRef]
     call_points: list[BswModuleCallPoint]
     data_receive_points: list[BswVariableAccess]
     data_send_points: list[BswVariableAccess]
@@ -67,7 +67,7 @@ class BswModuleEntity(ExecutableEntity, ABC):
     scheduler_name_prefix_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "ACCESSED-MODE-GROUP-REFS": lambda obj, elem: [obj._accessed_mode_group_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
-        "ACTIVATION-POINT-REFS": lambda obj, elem: [obj.activation_point_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "ACTIVATION-POINT-REFS": lambda obj, elem: [obj._activation_point_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "CALL-POINTS": ("_POLYMORPHIC_LIST", "call_points", ["Bsw", "BswAsynchronousServerCallPoint", "BswAsynchronousServerCallResultPoint", "BswDirectCallPoint"]),
         "DATA-RECEIVE-POINTS": lambda obj, elem: obj.data_receive_points.append(SerializationHelper.deserialize_by_tag(elem, "BswVariableAccess")),
         "DATA-SEND-POINTS": lambda obj, elem: obj.data_send_points.append(SerializationHelper.deserialize_by_tag(elem, "BswVariableAccess")),
@@ -82,7 +82,7 @@ class BswModuleEntity(ExecutableEntity, ABC):
         """Initialize BswModuleEntity."""
         super().__init__()
         self._accessed_mode_group_refs: list[ARRef] = []
-        self.activation_point_refs: list[ARRef] = []
+        self._activation_point_refs: list[ARRef] = []
         self.call_points: list[BswModuleCallPoint] = []
         self.data_receive_points: list[BswVariableAccess] = []
         self.data_send_points: list[BswVariableAccess] = []
@@ -100,6 +100,17 @@ class BswModuleEntity(ExecutableEntity, ABC):
     def accessed_mode_group_refs(self, value: list[ARRef]) -> None:
         """Set accessed_mode_group_refs with ref_conditional wrapper."""
         self._accessed_mode_group_refs = value
+
+    @property
+    @ref_conditional("ACTIVATION-POINTS")
+    def activation_point_refs(self) -> list[ARRef]:
+        """Get activation_point_refs with ref_conditional wrapper."""
+        return self._activation_point_refs
+
+    @activation_point_refs.setter
+    def activation_point_refs(self, value: list[ARRef]) -> None:
+        """Set activation_point_refs with ref_conditional wrapper."""
+        self._activation_point_refs = value
 
     @property
     @ref_conditional("MANAGED-MODE-GROUPS")
@@ -156,20 +167,23 @@ class BswModuleEntity(ExecutableEntity, ABC):
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize activation_point_refs (list to container "ACTIVATION-POINT-REFS")
+        # Serialize activation_point_refs (list to container "ACTIVATION-POINTS")
         if self.activation_point_refs:
-            wrapper = ET.Element("ACTIVATION-POINT-REFS")
+            wrapper = ET.Element("ACTIVATION-POINTS")
             for item in self.activation_point_refs:
                 serialized = SerializationHelper.serialize_item(item, "BswInternalTriggeringPoint")
                 if serialized is not None:
-                    child_elem = ET.Element("ACTIVATION-POINT-REF")
+                    # Wrap in BSW-INTERNAL-TRIGGERING-POINT-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-INTERNAL-TRIGGERING-POINT-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-INTERNAL-TRIGGERING-POINT-REF")
                     if hasattr(serialized, 'attrib'):
-                        child_elem.attrib.update(serialized.attrib)
+                        ref_elem.attrib.update(serialized.attrib)
                     if serialized.text:
-                        child_elem.text = serialized.text
+                        ref_elem.text = serialized.text
                     for child in serialized:
-                        child_elem.append(child)
-                    wrapper.append(child_elem)
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
@@ -294,10 +308,13 @@ class BswModuleEntity(ExecutableEntity, ABC):
                     if len(item_elem) > 0:
                         ref_elem = item_elem[0]
                         obj._accessed_mode_group_refs.append(ARRef.deserialize(ref_elem))
-            elif tag == "ACTIVATION-POINT-REFS":
-                # Iterate through wrapper children
+            elif tag == "ACTIVATION-POINTS":
+                # Unwrap ref_conditional pattern
                 for item_elem in child:
-                    obj.activation_point_refs.append(ARRef.deserialize(item_elem))
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._activation_point_refs.append(ARRef.deserialize(ref_elem))
             elif tag == "CALL-POINTS":
                 # Iterate through all child elements and deserialize each based on its concrete type
                 for item_elem in child:

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py
@@ -6,14 +6,14 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.referrable import (
     Referrable,
 )
-from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
-from armodel2.serialization import SerializationHelper
+from armodel2.models.M2.builder_base import BuilderBase
+from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.referrable import ReferrableBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Boolean,
@@ -21,18 +21,12 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces.bsw_module_entry import (
     BswModuleEntry,
 )
-from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes.identifier import (
-    Identifier,
-)
-from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.short_name_fragment import (
-    ShortNameFragment,
-)
+from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
+from armodel2.serialization import SerializationHelper
 
 
 class BswModuleClientServerEntry(Referrable):
     """AUTOSAR BswModuleClientServerEntry."""
-
-    _XML_TAG = "BSW-MODULE-ENTRY-REF-CONDITIONAL"
 
     @property
     def is_abstract(self) -> bool:
@@ -43,9 +37,19 @@ class BswModuleClientServerEntry(Referrable):
         """
         return False
 
+    _XML_TAG = "BSW-MODULE-CLIENT-SERVER-ENTRY"
+
+
     encapsulated_entry_ref: Optional[ARRef]
     is_reentrant: Optional[Boolean]
     is_synchronous: Optional[Boolean]
+    _DESERIALIZE_DISPATCH = {
+        "ENCAPSULATED-ENTRY-REF": lambda obj, elem: setattr(obj, "encapsulated_entry_ref", ARRef.deserialize(elem)),
+        "IS-REENTRANT": lambda obj, elem: setattr(obj, "is_reentrant", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
+        "IS-SYNCHRONOUS": lambda obj, elem: setattr(obj, "is_synchronous", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
+    }
+
+
     def __init__(self) -> None:
         """Initialize BswModuleClientServerEntry."""
         super().__init__()
@@ -56,28 +60,67 @@ class BswModuleClientServerEntry(Referrable):
     def serialize(self) -> ET.Element:
         """Serialize BswModuleClientServerEntry to XML element.
 
-        BswModuleClientServerEntry is serialized as BSW-MODULE-ENTRY-REF-CONDITIONAL
-        element containing BSW-MODULE-ENTRY-REF inner element.
-
         Returns:
             xml.etree.ElementTree.Element representing this object
         """
-        # Serialize as BSW-MODULE-ENTRY-REF-CONDITIONAL element
+        # Use pre-computed _XML_TAG constant
         elem = ET.Element(self._XML_TAG)
 
-        # Serialize encapsulated_entry_ref as BSW-MODULE-ENTRY-REF
+        # First, call parent's serialize to handle inherited attributes
+        parent_elem = super(BswModuleClientServerEntry, self).serialize()
+
+        # Copy all attributes from parent element
+        elem.attrib.update(parent_elem.attrib)
+
+        # Copy text from parent element
+        if parent_elem.text:
+            elem.text = parent_elem.text
+
+        # Copy all children from parent element
+        for child in parent_elem:
+            elem.append(child)
+
+        # Serialize encapsulated_entry_ref
         if self.encapsulated_entry_ref is not None:
-            inner_ref = ET.Element("BSW-MODULE-ENTRY-REF")
-            # Set DEST attribute
-            if hasattr(self.encapsulated_entry_ref, '_dest') and self.encapsulated_entry_ref._dest is not None:
-                inner_ref.set("DEST", self.encapsulated_entry_ref._dest)
-            else:
-                inner_ref.set("DEST", "BSW-MODULE-ENTRY")
-            # Set text content (reference path)
-            if hasattr(self.encapsulated_entry_ref, '_value') and self.encapsulated_entry_ref._value is not None:
-                inner_ref.text = self.encapsulated_entry_ref._value
-            # Append inner ref to element
-            elem.append(inner_ref)
+            serialized = SerializationHelper.serialize_item(self.encapsulated_entry_ref, "BswModuleEntry")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("ENCAPSULATED-ENTRY-REF")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize is_reentrant
+        if self.is_reentrant is not None:
+            serialized = SerializationHelper.serialize_item(self.is_reentrant, "Boolean")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("IS-REENTRANT")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize is_synchronous
+        if self.is_synchronous is not None:
+            serialized = SerializationHelper.serialize_item(self.is_synchronous, "Boolean")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("IS-SYNCHRONOUS")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
 
         return elem
 
@@ -85,64 +128,38 @@ class BswModuleClientServerEntry(Referrable):
     def deserialize(cls, element: ET.Element) -> "BswModuleClientServerEntry":
         """Deserialize XML element to BswModuleClientServerEntry object.
 
-        BswModuleClientServerEntry is deserialized from BSW-MODULE-ENTRY-REF-CONDITIONAL
-        element containing BSW-MODULE-ENTRY-REF inner element.
-
         Args:
-            element: XML element to deserialize from (BSW-MODULE-ENTRY-REF-CONDITIONAL)
+            element: XML element to deserialize from
 
         Returns:
             Deserialized BswModuleClientServerEntry object
         """
-        obj = cls.__new__(cls)
-        obj.__init__()
+        # First, call parent's deserialize to handle inherited attributes
+        obj = super(BswModuleClientServerEntry, cls).deserialize(element)
 
-        # Extract BSW-MODULE-ENTRY-REF from the wrapper
+        # Single-pass deserialization with if-elif-else chain
+        ns_split = '}'
         for child in element:
-            child_tag = child.tag.split('}', 1)[1] if child.tag.startswith('{') else child.tag
-            if child_tag == "BSW-MODULE-ENTRY-REF":
-                encapsulated_entry_ref_value = ARRef.deserialize(child)
-                obj.encapsulated_entry_ref = encapsulated_entry_ref_value
-                break
+            tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
+            if tag == "ENCAPSULATED-ENTRY-REF":
+                setattr(obj, "encapsulated_entry_ref", ARRef.deserialize(child))
+            elif tag == "IS-REENTRANT":
+                setattr(obj, "is_reentrant", SerializationHelper.deserialize_by_tag(child, "Boolean"))
+            elif tag == "IS-SYNCHRONOUS":
+                setattr(obj, "is_synchronous", SerializationHelper.deserialize_by_tag(child, "Boolean"))
 
         return obj
 
 
 
-class BswModuleClientServerEntryBuilder:
+class BswModuleClientServerEntryBuilder(ReferrableBuilder):
     """Builder for BswModuleClientServerEntry with fluent API."""
 
     def __init__(self) -> None:
         """Initialize builder with defaults."""
-        pass
+        super().__init__()
         self._obj: BswModuleClientServerEntry = BswModuleClientServerEntry()
 
-
-    def with_short_name(self, value: Identifier) -> "BswModuleClientServerEntryBuilder":
-        """Set short_name attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not False:
-            raise ValueError("Attribute 'short_name' is required and cannot be None")
-        self._obj.short_name = value
-        return self
-
-    def with_short_name_fragments(self, items: list[ShortNameFragment]) -> "BswModuleClientServerEntryBuilder":
-        """Set short_name_fragments list attribute.
-
-        Args:
-            items: List of items to set
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.short_name_fragments = list(items) if items else []
-        return self
 
     def with_encapsulated_entry(self, value: Optional[BswModuleEntry]) -> "BswModuleClientServerEntryBuilder":
         """Set encapsulated_entry attribute.
@@ -187,136 +204,17 @@ class BswModuleClientServerEntryBuilder:
         return self
 
 
-    def add_short_name_fragment(self, item: ShortNameFragment) -> "BswModuleClientServerEntryBuilder":
-        """Add a single item to short_name_fragments list.
 
-        Args:
-            item: Item to add
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.short_name_fragments.append(item)
-        return self
-
-    def clear_short_name_fragments(self) -> "BswModuleClientServerEntryBuilder":
-        """Clear all items from short_name_fragments list.
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.short_name_fragments = []
-        return self
-
-
-    @staticmethod
-    def _coerce_to_int(value: Any) -> int:
-        """Coerce value to int.
-
-        Args:
-            value: Value to coerce
-
-        Returns:
-            Integer value
-
-        Raises:
-            ValueError: If value cannot be coerced to int
-        """
-        if isinstance(value, int):
-            return value
-        if isinstance(value, str) and value.isdigit():
-            return int(value)
-        if isinstance(value, float):
-            return int(value)
-        if isinstance(value, bool):
-            return int(value)
-        raise ValueError(f"Cannot coerce {type(value).__name__} to int: {value}")
-
-    @staticmethod
-    def _coerce_to_float(value: Any) -> float:
-        """Coerce value to float.
-
-        Args:
-            value: Value to coerce
-
-        Returns:
-            Float value
-
-        Raises:
-            ValueError: If value cannot be coerced to float
-        """
-        if isinstance(value, float):
-            return value
-        if isinstance(value, int):
-            return float(value)
-        if isinstance(value, str):
-            try:
-                return float(value)
-            except ValueError:
-                pass
-        raise ValueError(f"Cannot coerce {type(value).__name__} to float: {value}")
-
-    @staticmethod
-    def _coerce_to_bool(value: Any) -> bool:
-        """Coerce value to bool.
-
-        Args:
-            value: Value to coerce
-
-        Returns:
-            Boolean value
-
-        Raises:
-            ValueError: If value cannot be coerced to bool
-        """
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, int):
-            return bool(value)
-        if isinstance(value, str):
-            if value.lower() in ("true", "1", "yes"):
-                return True
-            if value.lower() in ("false", "0", "no"):
-                return False
-        raise ValueError(f"Cannot coerce {type(value).__name__} to bool: {value}")
-
-    @staticmethod
-    def _coerce_to_str(value: Any) -> str:
-        """Coerce value to str.
-
-        Args:
-            value: Value to coerce
-
-        Returns:
-            String value
-        """
-        return str(value)
-
-
-    @staticmethod
-    def _coerce_to_list(value: Any, item_type: str) -> list:
-        """Coerce value to list.
-
-        Args:
-            value: Value to coerce
-            item_type: Expected item type (for error messages)
-
-        Returns:
-            List value
-
-        Raises:
-            ValueError: If value cannot be coerced to list
-        """
-        if isinstance(value, list):
-            return value
-        if isinstance(value, tuple):
-            return list(value)
-        raise ValueError(f"Cannot coerce {type(value).__name__} to list[{item_type}]: {value}")
+    # Pre-computed validation constants (generated from JSON schema)
+    _OPTIONAL_ATTRIBUTES = {
+        "encapsulatedEntry",
+        "isReentrant",
+        "isSynchronous",
+    }
 
 
     def _validate_instance(self) -> None:
         """Validate the built instance based on settings."""
-        from typing import get_type_hints
         from armodel2.core import GlobalSettingsManager, BuilderValidationMode
 
         settings = GlobalSettingsManager()
@@ -325,71 +223,10 @@ class BswModuleClientServerEntryBuilder:
         if mode == BuilderValidationMode.DISABLED:
             return
 
-        # Get type hints for the class
-        try:
-            type_hints_dict = get_type_hints(type(self._obj))
-        except Exception:
-            # Cannot resolve type hints (e.g., forward references), skip validation
-            return
-
-        for attr_name, attr_type in type_hints_dict.items():
-            if attr_name.startswith("_"):
-                continue
-
-            value = getattr(self._obj, attr_name)
-
-            # Check required fields (not Optional)
-            if value is None and not self._is_optional_type(attr_type):
-                if mode == BuilderValidationMode.STRICT:
-                    raise ValueError(
-                        f"Required attribute '{attr_name}' is None"
-                    )
-                elif mode == BuilderValidationMode.LENIENT:
-                    import warnings
-                    warnings.warn(
-                        f"Required attribute '{attr_name}' is None",
-                        UserWarning
-                    )
-
-    @staticmethod
-    def _is_optional_type(type_hint: Any) -> bool:
-        """Check if a type hint is Optional.
-
-        Args:
-            type_hint: Type hint to check
-
-        Returns:
-            True if type is Optional, False otherwise
-        """
-        origin = getattr(type_hint, "__origin__", None)
-        return origin is Union
-
-    @staticmethod
-    def _get_expected_type(type_hint: Any) -> type:
-        """Extract expected type from type hint.
-
-        Args:
-            type_hint: Type hint to extract from
-
-        Returns:
-            Expected type
-        """
-        if isinstance(type_hint, str):
-            return object
-        origin = getattr(type_hint, "__origin__", None)
-        if origin is Union:
-            args = getattr(type_hint, "__args__", [])
-            for arg in args:
-                if arg is not type(None):
-                    return arg
-        elif origin is list:
-            args = getattr(type_hint, "__args__", [object])
-            return args[0] if args else object
-        return type_hint if isinstance(type_hint, type) else object
+        # No required attributes to validate (all are optional)
 
 
     def build(self) -> BswModuleClientServerEntry:
         """Build and return the BswModuleClientServerEntry instance with validation."""
         self._validate_instance()
-        pass
         return self._obj

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py
@@ -58,28 +58,28 @@ class BswModuleEntry(ARElement):
 
 
     service_id: Optional[PositiveInteger]
-    arguments: list[SwServiceArg]
     bsw_entry_kind: Optional[BswEntryKindEnum]
     is_reentrant: Optional[Boolean]
     is_synchronous: Optional[Boolean]
     call_type: Optional[BswCallType]
     execution_context: Optional[BswExecutionContext]
     function_prototype_emitter: Optional[NameToken]
-    return_type: Optional[SwServiceArg]
-    role: Optional[Identifier]
     sw_service_impl_policy: Optional[SwServiceImplPolicyEnum]
+    return_type: Optional[SwServiceArg]
+    arguments: list[SwServiceArg]
+    role: Optional[Identifier]
     _DESERIALIZE_DISPATCH = {
         "SERVICE-ID": lambda obj, elem: setattr(obj, "service_id", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
-        "ARGUMENTS": lambda obj, elem: obj.arguments.append(SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
         "BSW-ENTRY-KIND": lambda obj, elem: setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(elem)),
         "IS-REENTRANT": lambda obj, elem: setattr(obj, "is_reentrant", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
         "IS-SYNCHRONOUS": lambda obj, elem: setattr(obj, "is_synchronous", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
         "CALL-TYPE": lambda obj, elem: setattr(obj, "call_type", BswCallType.deserialize(elem)),
         "EXECUTION-CONTEXT": lambda obj, elem: setattr(obj, "execution_context", BswExecutionContext.deserialize(elem)),
         "FUNCTION-PROTOTYPE-EMITTER": lambda obj, elem: setattr(obj, "function_prototype_emitter", SerializationHelper.deserialize_by_tag(elem, "NameToken")),
-        "RETURN-TYPE": lambda obj, elem: setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
-        "ROLE": lambda obj, elem: setattr(obj, "role", SerializationHelper.deserialize_by_tag(elem, "Identifier")),
         "SW-SERVICE-IMPL-POLICY": lambda obj, elem: setattr(obj, "sw_service_impl_policy", SwServiceImplPolicyEnum.deserialize(elem)),
+        "RETURN-TYPE": lambda obj, elem: setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
+        "ARGUMENTS": lambda obj, elem: obj.arguments.append(SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
+        "ROLE": lambda obj, elem: setattr(obj, "role", SerializationHelper.deserialize_by_tag(elem, "Identifier")),
     }
 
 
@@ -87,16 +87,16 @@ class BswModuleEntry(ARElement):
         """Initialize BswModuleEntry."""
         super().__init__()
         self.service_id: Optional[PositiveInteger] = None
-        self.arguments: list[SwServiceArg] = []
         self.bsw_entry_kind: Optional[BswEntryKindEnum] = None
         self.is_reentrant: Optional[Boolean] = None
         self.is_synchronous: Optional[Boolean] = None
         self.call_type: Optional[BswCallType] = None
         self.execution_context: Optional[BswExecutionContext] = None
         self.function_prototype_emitter: Optional[NameToken] = None
-        self.return_type: Optional[SwServiceArg] = None
-        self.role: Optional[Identifier] = None
         self.sw_service_impl_policy: Optional[SwServiceImplPolicyEnum] = None
+        self.return_type: Optional[SwServiceArg] = None
+        self.arguments: list[SwServiceArg] = []
+        self.role: Optional[Identifier] = None
 
     def serialize(self) -> ET.Element:
         """Serialize BswModuleEntry to XML element.
@@ -134,16 +134,6 @@ class BswModuleEntry(ARElement):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
-
-        # Serialize arguments (list to container "ARGUMENTS")
-        if self.arguments:
-            wrapper = ET.Element("ARGUMENTS")
-            for item in self.arguments:
-                serialized = SerializationHelper.serialize_item(item, "SwServiceArg")
-                if serialized is not None:
-                    wrapper.append(serialized)
-            if len(wrapper) > 0:
-                elem.append(wrapper)
 
         # Serialize bsw_entry_kind
         if self.bsw_entry_kind is not None:
@@ -229,6 +219,20 @@ class BswModuleEntry(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize sw_service_impl_policy
+        if self.sw_service_impl_policy is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_service_impl_policy, "SwServiceImplPolicyEnum")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-SERVICE-IMPL-POLICY")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
         # Serialize return_type
         if self.return_type is not None:
             serialized = SerializationHelper.serialize_item(self.return_type, "SwServiceArg")
@@ -243,26 +247,22 @@ class BswModuleEntry(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize arguments (list to container "ARGUMENTS")
+        if self.arguments:
+            wrapper = ET.Element("ARGUMENTS")
+            for item in self.arguments:
+                serialized = SerializationHelper.serialize_item(item, "SwServiceArg")
+                if serialized is not None:
+                    wrapper.append(serialized)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize role
         if self.role is not None:
             serialized = SerializationHelper.serialize_item(self.role, "Identifier")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("ROLE")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
-
-        # Serialize sw_service_impl_policy
-        if self.sw_service_impl_policy is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_service_impl_policy, "SwServiceImplPolicyEnum")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SW-SERVICE-IMPL-POLICY")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -292,10 +292,6 @@ class BswModuleEntry(ARElement):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "SERVICE-ID":
                 setattr(obj, "service_id", SerializationHelper.deserialize_by_tag(child, "PositiveInteger"))
-            elif tag == "ARGUMENTS":
-                # Iterate through wrapper children
-                for item_elem in child:
-                    obj.arguments.append(SerializationHelper.deserialize_by_tag(item_elem, "SwServiceArg"))
             elif tag == "BSW-ENTRY-KIND":
                 setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(child))
             elif tag == "IS-REENTRANT":
@@ -308,12 +304,16 @@ class BswModuleEntry(ARElement):
                 setattr(obj, "execution_context", BswExecutionContext.deserialize(child))
             elif tag == "FUNCTION-PROTOTYPE-EMITTER":
                 setattr(obj, "function_prototype_emitter", SerializationHelper.deserialize_by_tag(child, "NameToken"))
-            elif tag == "RETURN-TYPE":
-                setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(child, "SwServiceArg"))
-            elif tag == "ROLE":
-                setattr(obj, "role", SerializationHelper.deserialize_by_tag(child, "Identifier"))
             elif tag == "SW-SERVICE-IMPL-POLICY":
                 setattr(obj, "sw_service_impl_policy", SwServiceImplPolicyEnum.deserialize(child))
+            elif tag == "RETURN-TYPE":
+                setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(child, "SwServiceArg"))
+            elif tag == "ARGUMENTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.arguments.append(SerializationHelper.deserialize_by_tag(item_elem, "SwServiceArg"))
+            elif tag == "ROLE":
+                setattr(obj, "role", SerializationHelper.deserialize_by_tag(child, "Identifier"))
 
         return obj
 
@@ -340,18 +340,6 @@ class BswModuleEntryBuilder(ARElementBuilder):
         if value is None and not True:
             raise ValueError("Attribute 'service_id' is required and cannot be None")
         self._obj.service_id = value
-        return self
-
-    def with_arguments(self, items: list[SwServiceArg]) -> "BswModuleEntryBuilder":
-        """Set arguments list attribute.
-
-        Args:
-            items: List of items to set
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.arguments = list(items) if items else []
         return self
 
     def with_bsw_entry_kind(self, value: Optional[BswEntryKindEnum]) -> "BswModuleEntryBuilder":
@@ -438,6 +426,20 @@ class BswModuleEntryBuilder(ARElementBuilder):
         self._obj.function_prototype_emitter = value
         return self
 
+    def with_sw_service_impl_policy(self, value: Optional[SwServiceImplPolicyEnum]) -> "BswModuleEntryBuilder":
+        """Set sw_service_impl_policy attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_service_impl_policy' is required and cannot be None")
+        self._obj.sw_service_impl_policy = value
+        return self
+
     def with_return_type(self, value: Optional[SwServiceArg]) -> "BswModuleEntryBuilder":
         """Set return_type attribute.
 
@@ -452,6 +454,18 @@ class BswModuleEntryBuilder(ARElementBuilder):
         self._obj.return_type = value
         return self
 
+    def with_arguments(self, items: list[SwServiceArg]) -> "BswModuleEntryBuilder":
+        """Set arguments list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.arguments = list(items) if items else []
+        return self
+
     def with_role(self, value: Optional[Identifier]) -> "BswModuleEntryBuilder":
         """Set role attribute.
 
@@ -464,20 +478,6 @@ class BswModuleEntryBuilder(ARElementBuilder):
         if value is None and not True:
             raise ValueError("Attribute 'role' is required and cannot be None")
         self._obj.role = value
-        return self
-
-    def with_sw_service_impl_policy(self, value: Optional[SwServiceImplPolicyEnum]) -> "BswModuleEntryBuilder":
-        """Set sw_service_impl_policy attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not True:
-            raise ValueError("Attribute 'sw_service_impl_policy' is required and cannot be None")
-        self._obj.sw_service_impl_policy = value
         return self
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_element_name
+from armodel2.serialization.decorators import ref_conditional
 
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage.ar_element import (
     ARElement,
@@ -75,7 +76,8 @@ class BswModuleDescription(ARElement):
     bsw_module_documentation: Optional[SwComponentDocumentation]
     expected_entry_refs: list[ARRef]
     implemented_entry_refs: list[ARRef]
-    _provided_client_server_entries: list[BswModuleClientServerEntry]
+    _provided_entry_refs: list[ARRef]
+    provided_client_server_entries: list[BswModuleClientServerEntry]
     provided_datas: list[VariableDataPrototype]
     provided_mode_groups: list[ModeDeclarationGroupPrototype]
     released_triggers: list[Trigger]
@@ -90,7 +92,8 @@ class BswModuleDescription(ARElement):
         "BSW-MODULE-DOCUMENTATION": lambda obj, elem: setattr(obj, "bsw_module_documentation", SerializationHelper.deserialize_by_tag(elem, "SwComponentDocumentation")),
         "EXPECTED-ENTRY-REFS": lambda obj, elem: [obj.expected_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "IMPLEMENTED-ENTRY-REFS": lambda obj, elem: [obj.implemented_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
-        "PROVIDED-ENTRYS": lambda obj, elem: obj._provided_client_server_entries.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleClientServerEntry")),
+        "PROVIDED-ENTRY-REFS": lambda obj, elem: [obj._provided_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "PROVIDED-CLIENT-SERVER-ENTRYS": lambda obj, elem: obj.provided_client_server_entries.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleClientServerEntry")),
         "PROVIDED-DATAS": lambda obj, elem: obj.provided_datas.append(SerializationHelper.deserialize_by_tag(elem, "VariableDataPrototype")),
         "PROVIDED-MODE-GROUPS": lambda obj, elem: obj.provided_mode_groups.append(SerializationHelper.deserialize_by_tag(elem, "ModeDeclarationGroupPrototype")),
         "RELEASED-TRIGGERS": lambda obj, elem: obj.released_triggers.append(SerializationHelper.deserialize_by_tag(elem, "Trigger")),
@@ -110,7 +113,8 @@ class BswModuleDescription(ARElement):
         self.bsw_module_documentation: Optional[SwComponentDocumentation] = None
         self.expected_entry_refs: list[ARRef] = []
         self.implemented_entry_refs: list[ARRef] = []
-        self._provided_client_server_entries: list[BswModuleClientServerEntry] = []
+        self._provided_entry_refs: list[ARRef] = []
+        self.provided_client_server_entries: list[BswModuleClientServerEntry] = []
         self.provided_datas: list[VariableDataPrototype] = []
         self.provided_mode_groups: list[ModeDeclarationGroupPrototype] = []
         self.released_triggers: list[Trigger] = []
@@ -120,15 +124,15 @@ class BswModuleDescription(ARElement):
         self.required_triggers: list[Trigger] = []
         self.internal_behaviors: list[BswInternalBehavior] = []
     @property
-    @xml_element_name("PROVIDED-ENTRYS")
-    def provided_client_server_entries(self) -> list[BswModuleClientServerEntry]:
-        """Get provided_client_server_entries with custom XML element name."""
-        return self._provided_client_server_entries
+    @ref_conditional("PROVIDED-ENTRYS")
+    def provided_entry_refs(self) -> list[ARRef]:
+        """Get provided_entry_refs with ref_conditional wrapper."""
+        return self._provided_entry_refs
 
-    @provided_client_server_entries.setter
-    def provided_client_server_entries(self, value: list[BswModuleClientServerEntry]) -> None:
-        """Set provided_client_server_entries with custom XML element name."""
-        self._provided_client_server_entries = value
+    @provided_entry_refs.setter
+    def provided_entry_refs(self, value: list[ARRef]) -> None:
+        """Set provided_entry_refs with ref_conditional wrapper."""
+        self._provided_entry_refs = value
 
     @property
     @xml_element_name("REQUIRED-ENTRYS")
@@ -237,9 +241,29 @@ class BswModuleDescription(ARElement):
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize provided_client_server_entries (list to container "PROVIDED-ENTRYS")
-        if self.provided_client_server_entries:
+        # Serialize provided_entry_refs (list to container "PROVIDED-ENTRYS")
+        if self.provided_entry_refs:
             wrapper = ET.Element("PROVIDED-ENTRYS")
+            for item in self.provided_entry_refs:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
+                if serialized is not None:
+                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
+                    if hasattr(serialized, 'attrib'):
+                        ref_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        ref_elem.text = serialized.text
+                    for child in serialized:
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize provided_client_server_entries (list to container "PROVIDED-CLIENT-SERVER-ENTRYS")
+        if self.provided_client_server_entries:
+            wrapper = ET.Element("PROVIDED-CLIENT-SERVER-ENTRYS")
             for item in self.provided_client_server_entries:
                 serialized = SerializationHelper.serialize_item(item, "BswModuleClientServerEntry")
                 if serialized is not None:
@@ -363,9 +387,16 @@ class BswModuleDescription(ARElement):
                 for item_elem in child:
                     obj.implemented_entry_refs.append(ARRef.deserialize(item_elem))
             elif tag == "PROVIDED-ENTRYS":
+                # Unwrap ref_conditional pattern
+                for item_elem in child:
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._provided_entry_refs.append(ARRef.deserialize(ref_elem))
+            elif tag == "PROVIDED-CLIENT-SERVER-ENTRYS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj._provided_client_server_entries.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleClientServerEntry"))
+                    obj.provided_client_server_entries.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleClientServerEntry"))
             elif tag == "PROVIDED-DATAS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -474,6 +505,18 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.implemented_entries = list(items) if items else []
+        return self
+
+    def with_provided_entries(self, items: list[BswModuleEntry]) -> "BswModuleDescriptionBuilder":
+        """Set provided_entries list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.provided_entries = list(items) if items else []
         return self
 
     def with_provided_client_server_entries(self, items: list[BswModuleClientServerEntry]) -> "BswModuleDescriptionBuilder":
@@ -646,6 +689,27 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.implemented_entries = []
+        return self
+
+    def add_provided_entry(self, item: BswModuleEntry) -> "BswModuleDescriptionBuilder":
+        """Add a single item to provided_entries list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.provided_entries.append(item)
+        return self
+
+    def clear_provided_entries(self) -> "BswModuleDescriptionBuilder":
+        """Clear all items from provided_entries list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.provided_entries = []
         return self
 
     def add_provided_client_server_entry(self, item: BswModuleClientServerEntry) -> "BswModuleDescriptionBuilder":
@@ -848,6 +912,7 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         "moduleId",
         "providedClientServerEntry",
         "providedData",
+        "providedEntry",
         "providedModeGroup",
         "releasedTrigger",
         "requiredClientServerEntry",

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py
@@ -23,6 +23,9 @@ from armodel2.models.M2.MSR.DataDictionary.RecordLayout import (
 from armodel2.models.M2.MSR.AsamHdo.Units.unit import (
     Unit,
 )
+from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.value_list import (
+    ValueList,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -44,12 +47,14 @@ class RuleBasedAxisCont(ARObject):
 
     category: Optional[CalprmAxisCategoryEnum]
     rule_based: Optional[Any]
+    sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
     sw_axis_index: Optional[AxisIndexType]
     unit_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "CATEGORY": lambda obj, elem: setattr(obj, "category", CalprmAxisCategoryEnum.deserialize(elem)),
         "RULE-BASED": lambda obj, elem: setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(elem, "any (RuleBasedValue)")),
+        "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-AXIS-INDEX": lambda obj, elem: setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(elem, "AxisIndexType")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
@@ -61,6 +66,7 @@ class RuleBasedAxisCont(ARObject):
         super().__init__()
         self.category: Optional[CalprmAxisCategoryEnum] = None
         self.rule_based: Optional[Any] = None
+        self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
         self.sw_axis_index: Optional[AxisIndexType] = None
         self.unit_ref: Optional[ARRef] = None
@@ -115,6 +121,19 @@ class RuleBasedAxisCont(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize sw_arraysize_ref (atp_mixed - append children directly)
+        if self.sw_arraysize_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_arraysize_ref, "ValueList")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize v
         if self.v is not None:
@@ -181,6 +200,8 @@ class RuleBasedAxisCont(ARObject):
                 setattr(obj, "category", CalprmAxisCategoryEnum.deserialize(child))
             elif tag == "RULE-BASED":
                 setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(child, "any (RuleBasedValue)"))
+            elif tag == "SW-ARRAYSIZE-REF":
+                setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "SW-AXIS-INDEX":
@@ -227,6 +248,20 @@ class RuleBasedAxisContBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'rule_based' is required and cannot be None")
         self._obj.rule_based = value
+        return self
+
+    def with_sw_arraysize(self, value: Optional[ValueList]) -> "RuleBasedAxisContBuilder":
+        """Set sw_arraysize attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_arraysize' is required and cannot be None")
+        self._obj.sw_arraysize = value
         return self
 
     def with_v(self, value: Optional[Numerical]) -> "RuleBasedAxisContBuilder":

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py
@@ -18,6 +18,9 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.MSR.AsamHdo.Units.unit import (
     Unit,
 )
+from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.value_list import (
+    ValueList,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -38,10 +41,12 @@ class RuleBasedValueCont(ARObject):
 
 
     rule_based: Optional[Any]
+    sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
     unit_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "RULE-BASED": lambda obj, elem: setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(elem, "any (RuleBasedValue)")),
+        "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
     }
@@ -51,6 +56,7 @@ class RuleBasedValueCont(ARObject):
         """Initialize RuleBasedValueCont."""
         super().__init__()
         self.rule_based: Optional[Any] = None
+        self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
         self.unit_ref: Optional[ARRef] = None
 
@@ -90,6 +96,19 @@ class RuleBasedValueCont(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize sw_arraysize_ref (atp_mixed - append children directly)
+        if self.sw_arraysize_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_arraysize_ref, "ValueList")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize v
         if self.v is not None:
@@ -140,6 +159,8 @@ class RuleBasedValueCont(ARObject):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "RULE-BASED":
                 setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(child, "any (RuleBasedValue)"))
+            elif tag == "SW-ARRAYSIZE-REF":
+                setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "UNIT-REF":
@@ -170,6 +191,20 @@ class RuleBasedValueContBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'rule_based' is required and cannot be None")
         self._obj.rule_based = value
+        return self
+
+    def with_sw_arraysize(self, value: Optional[ValueList]) -> "RuleBasedValueContBuilder":
+        """Set sw_arraysize attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_arraysize' is required and cannot be None")
+        self._obj.sw_arraysize = value
         return self
 
     def with_v(self, value: Optional[Numerical]) -> "RuleBasedValueContBuilder":

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_specification.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_specification.py
@@ -20,6 +20,9 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.numerical_or_text import (
     NumericalOrText,
 )
+from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.rule_arguments import (
+    RuleArguments,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -39,6 +42,7 @@ class RuleBasedValueSpecification(ARObject):
     _XML_TAG = "RULE-BASED-VALUE-SPECIFICATION"
 
 
+    arguments: Optional[RuleArguments]
     v: Optional[Numerical]
     vf: Optional[Numerical]
     vt: Optional[VerbatimString]
@@ -46,6 +50,7 @@ class RuleBasedValueSpecification(ARObject):
     max_size_to_fill: Optional[Integer]
     rule: Optional[Identifier]
     _DESERIALIZE_DISPATCH = {
+        "ARGUMENTS": lambda obj, elem: setattr(obj, "arguments", SerializationHelper.deserialize_by_tag(elem, "RuleArguments")),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VT": lambda obj, elem: setattr(obj, "vt", SerializationHelper.deserialize_by_tag(elem, "VerbatimString")),
@@ -58,6 +63,7 @@ class RuleBasedValueSpecification(ARObject):
     def __init__(self) -> None:
         """Initialize RuleBasedValueSpecification."""
         super().__init__()
+        self.arguments: Optional[RuleArguments] = None
         self.v: Optional[Numerical] = None
         self.vf: Optional[Numerical] = None
         self.vt: Optional[VerbatimString] = None
@@ -87,6 +93,19 @@ class RuleBasedValueSpecification(ARObject):
         # Copy all children from parent element
         for child in parent_elem:
             elem.append(child)
+
+        # Serialize arguments (atp_mixed - append children directly)
+        if self.arguments is not None:
+            serialized = SerializationHelper.serialize_item(self.arguments, "RuleArguments")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize v
         if self.v is not None:
@@ -191,7 +210,9 @@ class RuleBasedValueSpecification(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "V":
+            if tag == "ARGUMENTS":
+                setattr(obj, "arguments", SerializationHelper.deserialize_by_tag(child, "RuleArguments"))
+            elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VF":
                 setattr(obj, "vf", SerializationHelper.deserialize_by_tag(child, "Numerical"))
@@ -216,6 +237,20 @@ class RuleBasedValueSpecificationBuilder(BuilderBase):
         super().__init__()
         self._obj: RuleBasedValueSpecification = RuleBasedValueSpecification()
 
+
+    def with_arguments(self, value: Optional[RuleArguments]) -> "RuleBasedValueSpecificationBuilder":
+        """Set arguments attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'arguments' is required and cannot be None")
+        self._obj.arguments = value
+        return self
 
     def with_v(self, value: Optional[Numerical]) -> "RuleBasedValueSpecificationBuilder":
         """Set v attribute.

--- a/src/armodel2/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_group.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_group.py
@@ -15,13 +15,20 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 )
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.identifiable import IdentifiableBuilder
+from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel2.models.M2.AUTOSARTemplates.EcuResourceTemplate.hw_pin import (
     HwPin,
 )
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.AUTOSARTemplates.EcuResourceTemplate.hw_pin_group_content import (
+        HwPinGroupContent,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class HwPinGroup(Identifiable):
     """AUTOSAR HwPinGroup."""
 
@@ -37,9 +44,11 @@ class HwPinGroup(Identifiable):
     _XML_TAG = "HW-PIN-GROUP"
 
 
+    hw_pin_group_content_ref: Optional[ARRef]
     hw_pin: Optional[HwPin]
     hw_pin_group: Optional[HwPinGroup]
     _DESERIALIZE_DISPATCH = {
+        "HW-PIN-GROUP-CONTENT-REF": lambda obj, elem: setattr(obj, "hw_pin_group_content_ref", ARRef.deserialize(elem)),
         "HW-PIN": lambda obj, elem: setattr(obj, "hw_pin", SerializationHelper.deserialize_by_tag(elem, "HwPin")),
         "HW-PIN-GROUP": lambda obj, elem: setattr(obj, "hw_pin_group", SerializationHelper.deserialize_by_tag(elem, "HwPinGroup")),
     }
@@ -48,6 +57,7 @@ class HwPinGroup(Identifiable):
     def __init__(self) -> None:
         """Initialize HwPinGroup."""
         super().__init__()
+        self.hw_pin_group_content_ref: Optional[ARRef] = None
         self.hw_pin: Optional[HwPin] = None
         self.hw_pin_group: Optional[HwPinGroup] = None
 
@@ -73,6 +83,19 @@ class HwPinGroup(Identifiable):
         # Copy all children from parent element
         for child in parent_elem:
             elem.append(child)
+
+        # Serialize hw_pin_group_content_ref (atp_mixed - append children directly)
+        if self.hw_pin_group_content_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.hw_pin_group_content_ref, "HwPinGroupContent")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize hw_pin
         if self.hw_pin is not None:
@@ -121,7 +144,9 @@ class HwPinGroup(Identifiable):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "HW-PIN":
+            if tag == "HW-PIN-GROUP-CONTENT-REF":
+                setattr(obj, "hw_pin_group_content_ref", ARRef.deserialize(child))
+            elif tag == "HW-PIN":
                 setattr(obj, "hw_pin", SerializationHelper.deserialize_by_tag(child, "HwPin"))
             elif tag == "HW-PIN-GROUP":
                 setattr(obj, "hw_pin_group", SerializationHelper.deserialize_by_tag(child, "HwPinGroup"))
@@ -138,6 +163,20 @@ class HwPinGroupBuilder(IdentifiableBuilder):
         super().__init__()
         self._obj: HwPinGroup = HwPinGroup()
 
+
+    def with_hw_pin_group_content(self, value: Optional[HwPinGroupContent]) -> "HwPinGroupBuilder":
+        """Set hw_pin_group_content attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'hw_pin_group_content' is required and cannot be None")
+        self._obj.hw_pin_group_content = value
+        return self
 
     def with_hw_pin(self, value: Optional[HwPin]) -> "HwPinGroupBuilder":
         """Set hw_pin attribute.

--- a/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg.py
+++ b/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg.py
@@ -6,10 +6,16 @@ References:
   - AUTOSAR_FO_TPS_FeatureModelExchangeFormat.pdf (page 78)
   - AUTOSAR_FO_TPS_GenericStructureTemplate.pdf (page 90)
 
-JSON Source: docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json"""
+JSON Source: docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
+
+NOTE: This file is manually maintained to properly handle the atp_mixed pattern
+where multiple SD/SDF/SDG/SDX/SDXF children can appear under SDG.
+The sdg_contents_type attribute stores SdgContents, whose children serialize
+directly under SDG (atp_mixed pattern).
+"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, List
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_attribute
 
@@ -29,12 +35,28 @@ from armodel2.models.M2.MSR.AsamHdo.SpecialData.sdf import (
 from armodel2.models.M2.MSR.AsamHdo.SpecialData.sdg_caption import (
     SdgCaption,
 )
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.MSR.AsamHdo.SpecialData.sdg_contents import (
+        SdgContents,
+    )
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
 
 class Sdg(ARObject):
-    """AUTOSAR Sdg."""
+    """AUTOSAR Sdg.
+
+    The Sdg class represents special data groups in AUTOSAR. It uses the
+    atp_mixed pattern where the SdgContents children serialize directly
+    under the SDG element without a wrapper.
+
+    Attributes:
+        gid: The GID attribute (group identifier)
+        sdg_caption: Optional caption for the SDG
+        sdg_contents_type: Container for SD/SDF/SDG/SDX/SDXF children (atp_mixed)
+    """
 
     @property
     def is_abstract(self) -> bool:
@@ -47,34 +69,32 @@ class Sdg(ARObject):
 
     _XML_TAG = "SDG"
 
-
-    _gid: NameToken
-    sdg_caption: Optional[SdgCaption]
+    # Legacy single-value attributes (kept for backward compatibility)
+    # These are set to the first child element during deserialization
     sd: Optional[Sd]
     sdf: Optional[Sdf]
-    sdg: Optional[Sdg]
+    sdg: Optional["Sdg"]
     sdx: Optional[Referrable]
     sdxf: Optional[Referrable]
-    _DESERIALIZE_DISPATCH = {
-        "SDG-CAPTION": lambda obj, elem: setattr(obj, "sdg_caption", SerializationHelper.deserialize_by_tag(elem, "SdgCaption")),
-        "SD": lambda obj, elem: setattr(obj, "sd", SerializationHelper.deserialize_by_tag(elem, "Sd")),
-        "SDF": lambda obj, elem: setattr(obj, "sdf", SerializationHelper.deserialize_by_tag(elem, "Sdf")),
-        "SDG": lambda obj, elem: setattr(obj, "sdg", SerializationHelper.deserialize_by_tag(elem, "Sdg")),
-        "SDX": ("_POLYMORPHIC", "sdx", ["ARPackage", "AclObjectSet", "AclOperation", "AclPermission", "AclRole", "AgeConstraint", "AggregationTailoring", "AliasNameSet", "AnalyzedExecutionTime", "AppOsTaskProxyToEcuTaskProxyMapping", "ApplicationArrayDataType", "ApplicationArrayElement", "ApplicationEndpoint", "ApplicationError", "ApplicationPartition", "ApplicationPartitionToEcuPartitionMapping", "ApplicationPrimitiveDataType", "ApplicationRecordDataType", "ApplicationRecordElement", "ApplicationSwComponentType", "ArbitraryEventTriggering", "ArgumentDataPrototype", "AssemblySwConnector", "AsynchronousServerCallPoint", "AsynchronousServerCallResultPoint", "AsynchronousServerCallReturnsEvent", "AtpDefinition", "AutosarOperationArgumentInstance", "AutosarVariableInstance", "BackgroundEvent", "BinaryManifestItem", "BinaryManifestItemDefinition", "BinaryManifestMetaDataField", "BinaryManifestProvideResource", "BinaryManifestRequireResource", "BinaryManifestResourceDefinition", "BlockState", "BlueprintMappingSet", "BswAsynchronousServerCallPoint", "BswAsynchronousServerCallResultPoint", "BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswCalledEntity", "BswCompositionTiming", "BswDataReceivedEvent", "BswDirectCallPoint", "BswDistinguishedPartition", "BswEntryRelationshipSet", "BswExternalTriggerOccurredEvent", "BswImplementation", "BswInternalBehavior", "BswInternalTriggerOccurredEvent", "BswInternalTriggeringPoint", "BswInterruptEntity", "BswInterruptEvent", "BswMgrNeeds", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswModuleCallPoint", "BswModuleClientServerEntry", "BswModuleDependency", "BswModuleDescription", "BswModuleEntry", "BswModuleTiming", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswSchedulableEntity", "BswSchedulerNamePrefix", "BswServiceDependencyIdent", "BswTimingEvent", "BswVariableAccess", "BuildAction", "BuildActionEnvironment", "BuildActionManifest", "BulkNvDataDescriptor", "BurstPatternEventTriggering", "BusMirrorChannelMappingCan", "BusMirrorChannelMappingFlexray", "BusMirrorChannelMappingIp", "CalibrationParameterValueSet", "CanCluster", "CanCommunicationConnector", "CanCommunicationController", "CanFrame", "CanFrameTriggering", "CanNmCluster", "CanNmNode", "CanPhysicalChannel", "CanTpAddress", "CanTpChannel", "CanTpConfig", "CanTpNode", "Caption", "Chapter", "ClassContentConditional", "ClientIdDefinition", "ClientIdDefinitionSet", "ClientServerInterface", "ClientServerInterfaceMapping", "ClientServerInterfaceToBswModuleEntryBlueprintMapping", "ClientServerOperation", "Code", "Collection", "ComManagementMapping", "ComMgrUserNeeds", "Compiler", "ComplexDeviceDriverSwComponentType", "CompositionSwComponentType", "CompuMethod", "ConcreteClassTailoring", "ConcretePatternEventTriggering", "ConsistencyNeeds", "ConsistencyNeedsBlueprintSet", "ConstantSpecification", "ConstantSpecificationMappingSet", "ConstraintTailoring", "ConsumedEventGroup", "ConsumedProvidedServiceInstanceGroup", "ConsumedServiceInstance", "ContainerIPdu", "CouplingElement", "CouplingElementSwitchDetails", "CouplingPort", "CouplingPortFifo", "CouplingPortScheduler", "CouplingPortShaper", "CouplingPortTrafficClassAssignment", "CpSoftwareCluster", "CpSoftwareClusterBinaryManifestDescriptor", "CpSoftwareClusterCommunicationResource", "CpSoftwareClusterMappingSet", "CpSoftwareClusterResourcePool", "CpSoftwareClusterResourceToApplicationPartitionMapping", "CpSoftwareClusterServiceResource", "CpSoftwareClusterToApplicationPartitionMapping", "CpSoftwareClusterToEcuInstanceMapping", "CpSoftwareClusterToResourceMapping", "CpSwClusterResourceToDiagDataElemMapping", "CpSwClusterResourceToDiagFunctionIdMapping", "CpSwClusterToDiagEventMapping", "CpSwClusterToDiagRoutineSubfunctionMapping", "CryptoEllipticCurveProps", "CryptoKeyManagementNeeds", "CryptoServiceCertificate", "CryptoServiceJobNeeds", "CryptoServiceKey", "CryptoServiceNeeds", "CryptoServicePrimitive", "CryptoServiceQueue", "CryptoSignatureScheme", "DataConstr", "DataExchangePoint", "DataPrototypeGroup", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataTransformationSet", "DataTypeMappingSet", "DataWriteCompletedEvent", "DcmIPdu", "DdsCpConfig", "DdsCpConsumedServiceInstance", "DdsCpDomain", "DdsCpPartition", "DdsCpProvidedServiceInstance", "DdsCpQosProfile", "DdsCpTopic", "DefItem", "DelegationSwConnector", "DependencyOnArtifact", "DevelopmentError", "DiagEventDebounceCounterBased", "DiagEventDebounceMonitorInternal", "DiagnosticAccessPermission", "DiagnosticAging", "DiagnosticAuthRole", "DiagnosticAuthTransmitCertificate", "DiagnosticAuthTransmitCertificateEvaluation", "DiagnosticAuthTransmitCertificateMapping", "DiagnosticAuthenticationClass", "DiagnosticAuthenticationConfiguration", "DiagnosticClearDiagnosticInformation", "DiagnosticClearDiagnosticInformationClass", "DiagnosticClearResetEmissionRelatedInfo", "DiagnosticClearResetEmissionRelatedInfoClass", "DiagnosticComControl", "DiagnosticComControlClass", "DiagnosticCommunicationManagerNeeds", "DiagnosticComponentNeeds", "DiagnosticConnectedIndicator", "DiagnosticConnection", "DiagnosticContributionSet", "DiagnosticControlDTCSetting", "DiagnosticControlDTCSettingClass", "DiagnosticControlNeeds", "DiagnosticCustomServiceClass", "DiagnosticCustomServiceInstance", "DiagnosticDataElement", "DiagnosticDataIdentifier", "DiagnosticDataIdentifierSet", "DiagnosticDataTransfer", "DiagnosticDataTransferClass", "DiagnosticDeAuthentication", "DiagnosticDebounceAlgorithmProps", "DiagnosticDemProvidedDataMapping", "DiagnosticDynamicDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifierClass", "DiagnosticEcuInstanceProps", "DiagnosticEcuReset", "DiagnosticEcuResetClass", "DiagnosticEnableCondition", "DiagnosticEnableConditionGroup", "DiagnosticEnableConditionNeeds", "DiagnosticEnableConditionPortMapping", "DiagnosticEnvBswModeElement", "DiagnosticEnvModeElement", "DiagnosticEnvSwcModeElement", "DiagnosticEnvironmentalCondition", "DiagnosticEvent", "DiagnosticEventInfoNeeds", "DiagnosticEventManagerNeeds", "DiagnosticEventNeeds", "DiagnosticEventPortMapping", "DiagnosticEventToDebounceAlgorithmMapping", "DiagnosticEventToEnableConditionGroupMapping", "DiagnosticEventToOperationCycleMapping", "DiagnosticEventToSecurityEventMapping", "DiagnosticEventToStorageConditionGroupMapping", "DiagnosticEventToTroubleCodeJ1939Mapping", "DiagnosticEventToTroubleCodeUdsMapping", "DiagnosticExtendedDataRecord", "DiagnosticFimAliasEvent", "DiagnosticFimAliasEventGroup", "DiagnosticFimAliasEventGroupMapping", "DiagnosticFimAliasEventMapping", "DiagnosticFimEventGroup", "DiagnosticFimFunctionMapping", "DiagnosticFreezeFrame", "DiagnosticFunctionIdentifier", "DiagnosticFunctionIdentifierInhibit", "DiagnosticFunctionInhibitSource", "DiagnosticIOControl", "DiagnosticIndicator", "DiagnosticInfoType", "DiagnosticInhibitSourceEventMapping", "DiagnosticIoControlClass", "DiagnosticIoControlNeeds", "DiagnosticIumpr", "DiagnosticIumprDenominatorGroup", "DiagnosticIumprGroup", "DiagnosticIumprToFunctionIdentifierMapping", "DiagnosticJ1939ExpandedFreezeFrame", "DiagnosticJ1939FreezeFrame", "DiagnosticJ1939Node", "DiagnosticJ1939Spn", "DiagnosticJ1939SpnMapping", "DiagnosticJ1939SwMapping", "DiagnosticMasterToSlaveEventMapping", "DiagnosticMeasurementIdentifier", "DiagnosticMemoryDestinationPrimary", "DiagnosticMemoryDestinationUserDefined", "DiagnosticMemoryIdentifier", "DiagnosticOperationCycle", "DiagnosticOperationCycleNeeds", "DiagnosticOperationCyclePortMapping", "DiagnosticParameterElement", "DiagnosticParameterIdent", "DiagnosticParameterIdentifier", "DiagnosticPowertrainFreezeFrame", "DiagnosticProofOfOwnership", "DiagnosticProtocol", "DiagnosticReadDTCInformation", "DiagnosticReadDTCInformationClass", "DiagnosticReadDataByIdentifier", "DiagnosticReadDataByIdentifierClass", "DiagnosticReadDataByPeriodicID", "DiagnosticReadDataByPeriodicIDClass", "DiagnosticReadMemoryByAddress", "DiagnosticReadMemoryByAddressClass", "DiagnosticReadScalingDataByIdentifier", "DiagnosticReadScalingDataByIdentifierClass", "DiagnosticRequestControlOfOnBoardDevice", "DiagnosticRequestControlOfOnBoardDeviceClass", "DiagnosticRequestCurrentPowertrainData", "DiagnosticRequestCurrentPowertrainDataClass", "DiagnosticRequestDownload", "DiagnosticRequestDownloadClass", "DiagnosticRequestEmissionRelatedDTC", "DiagnosticRequestEmissionRelatedDTCClass", "DiagnosticRequestEmissionRelatedDTCPermanentStatus", "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass", "DiagnosticRequestFileTransfer", "DiagnosticRequestFileTransferClass", "DiagnosticRequestFileTransferNeeds", "DiagnosticRequestOnBoardMonitoringTestResults", "DiagnosticRequestOnBoardMonitoringTestResultsClass", "DiagnosticRequestPowertrainFreezeFrameData", "DiagnosticRequestPowertrainFreezeFrameDataClass", "DiagnosticRequestRoutineResults", "DiagnosticRequestUpload", "DiagnosticRequestUploadClass", "DiagnosticRequestVehicleInfo", "DiagnosticRequestVehicleInfoClass", "DiagnosticResponseOnEvent", "DiagnosticResponseOnEventClass", "DiagnosticRoutine", "DiagnosticRoutineControl", "DiagnosticRoutineControlClass", "DiagnosticRoutineNeeds", "DiagnosticSecureCodingMapping", "DiagnosticSecurityAccess", "DiagnosticSecurityAccessClass", "DiagnosticSecurityEventReportingModeMapping", "DiagnosticSecurityLevel", "DiagnosticServiceDataMapping", "DiagnosticServiceSwMapping", "DiagnosticServiceTable", "DiagnosticSession", "DiagnosticSessionControl", "DiagnosticSessionControlClass", "DiagnosticStartRoutine", "DiagnosticStopRoutine", "DiagnosticStorageCondition", "DiagnosticStorageConditionGroup", "DiagnosticStorageConditionNeeds", "DiagnosticStorageConditionPortMapping", "DiagnosticTestResult", "DiagnosticTestRoutineIdentifier", "DiagnosticTransferExit", "DiagnosticTransferExitClass", "DiagnosticTroubleCodeGroup", "DiagnosticTroubleCodeJ1939", "DiagnosticTroubleCodeObd", "DiagnosticTroubleCodeProps", "DiagnosticTroubleCodeUds", "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping", "DiagnosticUploadDownloadNeeds", "DiagnosticValueNeeds", "DiagnosticVerifyCertificateBidirectional", "DiagnosticWriteDataByIdentifierClass", "DiagnosticWriteMemoryByAddressClass", "DiagnosticsCommunicationSecurityNeeds", "DltApplication", "DltArgument", "DltContext", "DltEcu", "DltLogChannel", "DltMessage", "DltUserNeeds", "DoIpActivationLineNeeds", "DoIpGidNeeds", "DoIpGidSynchronizationNeeds", "DoIpInterface", "DoIpLogicAddress", "DoIpLogicTargetAddressProps", "DoIpLogicTesterAddressProps", "DoIpPowerModeStatusNeeds", "DoIpRoutingActivation", "DoIpRoutingActivationAuthenticationNeeds", "DoIpRoutingActivationConfirmationNeeds", "DoIpTpConfig", "DocumentElementScope", "Documentation", "DocumentationContext", "DtcStatusChangeNotificationNeeds", "E2EProfileCompatibilityProps", "ECUMapping", "EOCEventRef", "EOCExecutableEntityRef", "EOCExecutableEntityRefGroup", "EcuAbstractionSwComponentType", "EcuInstance", "EcuPartition", "EcuStateMgrUserNeeds", "EcuTiming", "EcucAddInfoParamDef", "EcucBooleanParamDef", "EcucChoiceContainerDef", "EcucChoiceReferenceDef", "EcucContainerValue", "EcucDefinitionCollection", "EcucDestinationUriDef", "EcucDestinationUriDefSet", "EcucEnumerationLiteralDef", "EcucEnumerationParamDef", "EcucFloatParamDef", "EcucForeignReferenceDef", "EcucFunctionNameDef", "EcucInstanceReferenceDef", "EcucIntegerParamDef", "EcucLinkerSymbolDef", "EcucModuleConfigurationValues", "EcucModuleDef", "EcucMultilineStringParamDef", "EcucParamConfContainerDef", "EcucQuery", "EcucReferenceDef", "EcucStringParamDef", "EcucUriReferenceDef", "EcucValidationCondition", "EcucValueCollection", "EndToEndProtection", "EndToEndProtectionSet", "EnumerationMappingTable", "ErrorTracerNeeds", "EthIpProps", "EthTcpIpIcmpProps", "EthTcpIpProps", "EthTpConfig", "EthernetCluster", "EthernetCommunicationConnector", "EthernetCommunicationController", "EthernetFrameTriggering", "EthernetPhysicalChannel", "EthernetPriorityRegeneration", "EthernetWakeupSleepOnDatalineConfig", "EthernetWakeupSleepOnDatalineConfigSet", "EvaluatedVariantSet", "EventHandler", "ExclusiveArea", "ExclusiveAreaNestingOrder", "ExecutableEntityActivationReason", "ExecutionOrderConstraint", "ExecutionTimeConstraint", "ExternalTriggerOccurredEvent", "ExternalTriggeringPointIdent", "FMAttributeDef", "FMFeature", "FMFeatureMap", "FMFeatureMapAssertion", "FMFeatureMapCondition", "FMFeatureMapElement", "FMFeatureModel", "FMFeatureRelation", "FMFeatureRestriction", "FMFeatureSelection", "FMFeatureSelectionSet", "FirewallRule", "FlatInstanceDescriptor", "FlatMap", "FlexrayArTpConfig", "FlexrayArTpNode", "FlexrayCluster", "FlexrayCommunicationConnector", "FlexrayCommunicationController", "FlexrayFrame", "FlexrayFrameTriggering", "FlexrayNmCluster", "FlexrayNmNode", "FlexrayPhysicalChannel", "FlexrayTpConfig", "FlexrayTpConnectionControl", "FlexrayTpNode", "FlexrayTpPduPool", "FramePort", "FunctionInhibitionAvailabilityNeeds", "FunctionInhibitionNeeds", "Gateway", "GeneralPurposeConnection", "GeneralPurposeIPdu", "GeneralPurposePdu", "GenericEthernetFrame", "GlobalSupervisionNeeds", "GlobalTimeCanMaster", "GlobalTimeCanSlave", "GlobalTimeDomain", "GlobalTimeEthMaster", "GlobalTimeEthSlave", "GlobalTimeFrMaster", "GlobalTimeFrSlave", "GlobalTimeGateway", "HardwareTestNeeds", "HwAttributeDef", "HwAttributeLiteralDef", "HwCategory", "HwDescriptionEntity", "HwElement", "HwPin", "HwPinGroup", "HwType", "IEEE1722TpAafConnection", "IEEE1722TpAcfCan", "IEEE1722TpAcfCanPart", "IEEE1722TpAcfConnection", "IEEE1722TpAcfLin", "IEEE1722TpAcfLinPart", "IEEE1722TpConfig", "IEEE1722TpCrfConnection", "IEEE1722TpIidcConnection", "IPSecConfigProps", "IPSecRule", "IPduPort", "IPv6ExtHeaderFilterList", "IPv6ExtHeaderFilterSet", "ISignal", "ISignalGroup", "ISignalIPdu", "ISignalIPduGroup", "ISignalPort", "ISignalToIPduMapping", "ISignalTriggering", "IdsDesign", "IdsMgrCustomTimestampNeeds", "IdsMgrNeeds", "IdsmInstance", "IdsmProperties", "Ieee1722TpEthernetFrame", "ImplementationDataType", "ImplementationDataTypeElement", "ImplementationProps", "ImpositionTime", "IndicatorStatusNeeds", "InitEvent", "InternalTriggerOccurredEvent", "InternalTriggeringPoint", "InterpolationRoutineMappingSet", "J1939Cluster", "J1939ControllerApplication", "J1939DcmDm19Support", "J1939DcmIPdu", "J1939NmCluster", "J1939NmNode", "J1939RmIncomingRequestServiceNeeds", "J1939RmOutgoingRequestServiceNeeds", "J1939SharedAddressCluster", "J1939TpConfig", "J1939TpNode", "Keyword", "KeywordSet", "LatencyTimingConstraint", "LifeCycleInfoSet", "LifeCycleState", "LifeCycleStateDefinitionGroup", "LinCluster", "LinCommunicationConnector", "LinEventTriggeredFrame", "LinFrameTriggering", "LinMaster", "LinPhysicalChannel", "LinScheduleTable", "LinSlave", "LinSlaveConfigIdent", "LinSporadicFrame", "LinTpConfig", "LinTpNode", "LinUnconditionalFrame", "Linker", "LogAndTraceMessageCollectionSet", "MacMulticastGroup", "MacSecGlobalKayProps", "MacSecKayParticipant", "MacSecParticipantSet", "McDataInstance", "McFunction", "McGroup", "MeasuredExecutionTime", "MeasuredHeapUsage", "MeasuredStackUsage", "MemorySection", "ModeAccessPointIdent", "ModeDeclaration", "ModeDeclarationGroup", "ModeDeclarationGroupPrototype", "ModeDeclarationMapping", "ModeDeclarationMappingSet", "ModeInterfaceMapping", "ModeSwitchInterface", "ModeSwitchPoint", "ModeSwitchedAckEvent", "ModeTransition", "MultilanguageReferrable", "MultiplexedIPdu", "NPdu", "NetworkEndpoint", "NmConfig", "NmEcu", "NmPdu", "NvBlockDescriptor", "NvBlockNeeds", "NvBlockSwComponentType", "NvDataInterface", "ObdControlServiceNeeds", "ObdInfoServiceNeeds", "ObdMonitorServiceNeeds", "ObdPidServiceNeeds", "ObdRatioDenominatorNeeds", "ObdRatioServiceNeeds", "OffsetTimingConstraint", "OperationInvokedEvent", "OsTaskExecutionEvent", "OsTaskProxy", "PPortPrototype", "PRPortPrototype", "ParameterAccess", "ParameterDataPrototype", "ParameterInterface", "ParameterSwComponentType", "PassThroughSwConnector", "PduActivationRoutingGroup", "PduToFrameMapping", "PduTriggering", "PdurIPduGroup", "PerInstanceMemory", "PeriodicEventTriggering", "PhysicalDimension", "PhysicalDimensionMappingSet", "PncMappingIdent", "PortElementToCommunicationResourceMapping", "PortGroup", "PortInterfaceMappingSet", "PortPrototypeBlueprint", "PostBuildVariantCriterion", "PostBuildVariantCriterionValueSet", "PredefinedVariant", "PrimitiveAttributeTailoring", "ProvidedServiceInstance", "RPortPrototype", "RapidPrototypingScenario", "ReferenceTailoring", "ResourceConsumption", "RootSwCompositionPrototype", "RoughEstimateHeapUsage", "RoughEstimateOfExecutionTime", "RoughEstimateStackUsage", "RptComponent", "RptContainer", "RptExecutableEntity", "RptExecutableEntityEvent", "RptExecutionContext", "RptProfile", "RptServicePoint", "RteEventInCompositionSeparation", "RteEventInCompositionToOsTaskProxyMapping", "RteEventInSystemSeparation", "RteEventInSystemToOsTaskProxyMapping", "RunnableEntity", "RunnableEntityGroup", "RuntimeError", "SOMEIPTransformationProps", "Sdg", "SdgAggregationWithVariation", "SdgCaption", "SdgClass", "SdgDef", "SdgForeignReference", "SdgForeignReferenceWithVariation", "SdgPrimitiveAttribute", "SdgPrimitiveAttributeWithVariation", "SdgTailoring", "SecOcCryptoServiceMapping", "SectionNamePrefix", "SecureCommunicationAuthenticationProps", "SecureCommunicationFreshnessProps", "SecureCommunicationPropsSet", "SecureOnBoardCommunicationNeeds", "SecuredIPdu", "SecurityEventAggregationFilter", "SecurityEventContextMappingApplication", "SecurityEventContextMappingBswModule", "SecurityEventContextMappingCommConnector", "SecurityEventContextMappingFunctionalCluster", "SecurityEventContextProps", "SecurityEventDefinition", "SecurityEventFilterChain", "SecurityEventOneEveryNFilter", "SecurityEventStateFilter", "SenderReceiverInterface", "SensorActuatorSwComponentType", "ServiceInstanceCollectionSet", "ServiceProxySwComponentType", "ServiceSwComponentType", "SignalServiceTranslationElementProps", "SignalServiceTranslationEventProps", "SignalServiceTranslationProps", "SignalServiceTranslationPropsSet", "SingleLanguageReferrable", "SoAdRoutingGroup", "SoConIPduIdentifier", "SocketAddress", "SocketConnectionBundle", "SocketConnectionIpduIdentifierSet", "SomeipSdClientServiceInstanceConfig", "SomeipSdServerEventGroupTimingConfig", "SomeipSdServerServiceInstanceConfig", "SomeipTpChannel", "SomeipTpConfig", "SpecificationDocumentScope", "SporadicEventTriggering", "StaticSocketConnection", "Std", "StructuredReq", "SupervisedEntityCheckpointNeeds", "SupervisedEntityNeeds", "SwAddrMethod", "SwAxisType", "SwBaseType", "SwGenericAxisParamType", "SwRecordLayout", "SwServiceArg", "SwSystemconst", "SwSystemconstantValueSet", "SwcBswMapping", "SwcImplementation", "SwcInternalBehavior", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "SwcServiceDependency", "SwcTiming", "SwcToApplicationPartitionMapping", "SwcToEcuMapping", "SwcToImplMapping", "SwitchAsynchronousTrafficShaperGroupEntry", "SwitchFlowMeteringEntry", "SwitchStreamFilterActionDestPortModification", "SwitchStreamFilterEntry", "SwitchStreamFilterRule", "SwitchStreamGateEntry", "SwitchStreamIdentification", "SymbolProps", "SyncTimeBaseMgrUserNeeds", "SynchronizationPointConstraint", "SynchronousServerCallPoint", "System", "SystemMapping", "SystemSignal", "SystemSignalGroup", "SystemSignalGroupToCommunicationResourceMapping", "SystemSignalToCommunicationResourceMapping", "SystemTiming", "TDCpSoftwareClusterMapping", "TDCpSoftwareClusterMappingSet", "TDCpSoftwareClusterResourceMapping", "TDEventBswInternalBehavior", "TDEventBswModeDeclaration", "TDEventBswModule", "TDEventComplex", "TDEventFrClusterCycleStart", "TDEventFrame", "TDEventFrameEthernet", "TDEventIPdu", "TDEventISignal", "TDEventModeDeclaration", "TDEventOperation", "TDEventSLLETPort", "TDEventSwcInternalBehavior", "TDEventSwcInternalBehaviorReference", "TDEventTTCanCycleStart", "TDEventTrigger", "TDEventVariableDataPrototype", "TDEventVfbReference", "TDLETZoneClock", "TcpOptionFilterList", "TcpOptionFilterSet", "TimeSyncServerConfiguration", "TimingClockSyncAccuracy", "TimingCondition", "TimingDescriptionEventChain", "TimingEvent", "TimingExtensionResource", "TimingModeInstance", "TlsCryptoCipherSuite", "TlsCryptoCipherSuiteProps", "TlsCryptoServiceMapping", "TlvDataIdDefinitionSet", "Topic1", "TpAddress", "TpConnectionIdent", "TraceableText", "TransformationPropsSet", "TransformationTechnology", "TransformerHardErrorEvent", "TransientFault", "Trigger", "TriggerInterface", "TriggerInterfaceMapping", "TtcanCluster", "TtcanCommunicationConnector", "TtcanCommunicationController", "TtcanPhysicalChannel", "UdpNmCluster", "UdpNmNode", "Unit", "UnitGroup", "UserDefinedCluster", "UserDefinedCommunicationConnector", "UserDefinedCommunicationController", "UserDefinedEthernetFrame", "UserDefinedGlobalTimeMaster", "UserDefinedGlobalTimeSlave", "UserDefinedIPdu", "UserDefinedPdu", "UserDefinedTransformationProps", "V2xDataManagerNeeds", "V2xFacUserNeeds", "V2xMUserNeeds", "VariableAccess", "VariableDataPrototype", "VariationPointProxy", "VendorSpecificServiceNeeds", "VfbTiming", "ViewMap", "ViewMapSet", "VlanConfig", "WaitPoint", "WorstCaseHeapUsage", "WorstCaseStackUsage", "Xdoc", "Xfile", "XrefTarget"]),
-        "SDXF": ("_POLYMORPHIC", "sdxf", ["ARPackage", "AclObjectSet", "AclOperation", "AclPermission", "AclRole", "AgeConstraint", "AggregationTailoring", "AliasNameSet", "AnalyzedExecutionTime", "AppOsTaskProxyToEcuTaskProxyMapping", "ApplicationArrayDataType", "ApplicationArrayElement", "ApplicationEndpoint", "ApplicationError", "ApplicationPartition", "ApplicationPartitionToEcuPartitionMapping", "ApplicationPrimitiveDataType", "ApplicationRecordDataType", "ApplicationRecordElement", "ApplicationSwComponentType", "ArbitraryEventTriggering", "ArgumentDataPrototype", "AssemblySwConnector", "AsynchronousServerCallPoint", "AsynchronousServerCallResultPoint", "AsynchronousServerCallReturnsEvent", "AtpDefinition", "AutosarOperationArgumentInstance", "AutosarVariableInstance", "BackgroundEvent", "BinaryManifestItem", "BinaryManifestItemDefinition", "BinaryManifestMetaDataField", "BinaryManifestProvideResource", "BinaryManifestRequireResource", "BinaryManifestResourceDefinition", "BlockState", "BlueprintMappingSet", "BswAsynchronousServerCallPoint", "BswAsynchronousServerCallResultPoint", "BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswCalledEntity", "BswCompositionTiming", "BswDataReceivedEvent", "BswDirectCallPoint", "BswDistinguishedPartition", "BswEntryRelationshipSet", "BswExternalTriggerOccurredEvent", "BswImplementation", "BswInternalBehavior", "BswInternalTriggerOccurredEvent", "BswInternalTriggeringPoint", "BswInterruptEntity", "BswInterruptEvent", "BswMgrNeeds", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswModuleCallPoint", "BswModuleClientServerEntry", "BswModuleDependency", "BswModuleDescription", "BswModuleEntry", "BswModuleTiming", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswSchedulableEntity", "BswSchedulerNamePrefix", "BswServiceDependencyIdent", "BswTimingEvent", "BswVariableAccess", "BuildAction", "BuildActionEnvironment", "BuildActionManifest", "BulkNvDataDescriptor", "BurstPatternEventTriggering", "BusMirrorChannelMappingCan", "BusMirrorChannelMappingFlexray", "BusMirrorChannelMappingIp", "CalibrationParameterValueSet", "CanCluster", "CanCommunicationConnector", "CanCommunicationController", "CanFrame", "CanFrameTriggering", "CanNmCluster", "CanNmNode", "CanPhysicalChannel", "CanTpAddress", "CanTpChannel", "CanTpConfig", "CanTpNode", "Caption", "Chapter", "ClassContentConditional", "ClientIdDefinition", "ClientIdDefinitionSet", "ClientServerInterface", "ClientServerInterfaceMapping", "ClientServerInterfaceToBswModuleEntryBlueprintMapping", "ClientServerOperation", "Code", "Collection", "ComManagementMapping", "ComMgrUserNeeds", "Compiler", "ComplexDeviceDriverSwComponentType", "CompositionSwComponentType", "CompuMethod", "ConcreteClassTailoring", "ConcretePatternEventTriggering", "ConsistencyNeeds", "ConsistencyNeedsBlueprintSet", "ConstantSpecification", "ConstantSpecificationMappingSet", "ConstraintTailoring", "ConsumedEventGroup", "ConsumedProvidedServiceInstanceGroup", "ConsumedServiceInstance", "ContainerIPdu", "CouplingElement", "CouplingElementSwitchDetails", "CouplingPort", "CouplingPortFifo", "CouplingPortScheduler", "CouplingPortShaper", "CouplingPortTrafficClassAssignment", "CpSoftwareCluster", "CpSoftwareClusterBinaryManifestDescriptor", "CpSoftwareClusterCommunicationResource", "CpSoftwareClusterMappingSet", "CpSoftwareClusterResourcePool", "CpSoftwareClusterResourceToApplicationPartitionMapping", "CpSoftwareClusterServiceResource", "CpSoftwareClusterToApplicationPartitionMapping", "CpSoftwareClusterToEcuInstanceMapping", "CpSoftwareClusterToResourceMapping", "CpSwClusterResourceToDiagDataElemMapping", "CpSwClusterResourceToDiagFunctionIdMapping", "CpSwClusterToDiagEventMapping", "CpSwClusterToDiagRoutineSubfunctionMapping", "CryptoEllipticCurveProps", "CryptoKeyManagementNeeds", "CryptoServiceCertificate", "CryptoServiceJobNeeds", "CryptoServiceKey", "CryptoServiceNeeds", "CryptoServicePrimitive", "CryptoServiceQueue", "CryptoSignatureScheme", "DataConstr", "DataExchangePoint", "DataPrototypeGroup", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataTransformationSet", "DataTypeMappingSet", "DataWriteCompletedEvent", "DcmIPdu", "DdsCpConfig", "DdsCpConsumedServiceInstance", "DdsCpDomain", "DdsCpPartition", "DdsCpProvidedServiceInstance", "DdsCpQosProfile", "DdsCpTopic", "DefItem", "DelegationSwConnector", "DependencyOnArtifact", "DevelopmentError", "DiagEventDebounceCounterBased", "DiagEventDebounceMonitorInternal", "DiagnosticAccessPermission", "DiagnosticAging", "DiagnosticAuthRole", "DiagnosticAuthTransmitCertificate", "DiagnosticAuthTransmitCertificateEvaluation", "DiagnosticAuthTransmitCertificateMapping", "DiagnosticAuthenticationClass", "DiagnosticAuthenticationConfiguration", "DiagnosticClearDiagnosticInformation", "DiagnosticClearDiagnosticInformationClass", "DiagnosticClearResetEmissionRelatedInfo", "DiagnosticClearResetEmissionRelatedInfoClass", "DiagnosticComControl", "DiagnosticComControlClass", "DiagnosticCommunicationManagerNeeds", "DiagnosticComponentNeeds", "DiagnosticConnectedIndicator", "DiagnosticConnection", "DiagnosticContributionSet", "DiagnosticControlDTCSetting", "DiagnosticControlDTCSettingClass", "DiagnosticControlNeeds", "DiagnosticCustomServiceClass", "DiagnosticCustomServiceInstance", "DiagnosticDataElement", "DiagnosticDataIdentifier", "DiagnosticDataIdentifierSet", "DiagnosticDataTransfer", "DiagnosticDataTransferClass", "DiagnosticDeAuthentication", "DiagnosticDebounceAlgorithmProps", "DiagnosticDemProvidedDataMapping", "DiagnosticDynamicDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifierClass", "DiagnosticEcuInstanceProps", "DiagnosticEcuReset", "DiagnosticEcuResetClass", "DiagnosticEnableCondition", "DiagnosticEnableConditionGroup", "DiagnosticEnableConditionNeeds", "DiagnosticEnableConditionPortMapping", "DiagnosticEnvBswModeElement", "DiagnosticEnvModeElement", "DiagnosticEnvSwcModeElement", "DiagnosticEnvironmentalCondition", "DiagnosticEvent", "DiagnosticEventInfoNeeds", "DiagnosticEventManagerNeeds", "DiagnosticEventNeeds", "DiagnosticEventPortMapping", "DiagnosticEventToDebounceAlgorithmMapping", "DiagnosticEventToEnableConditionGroupMapping", "DiagnosticEventToOperationCycleMapping", "DiagnosticEventToSecurityEventMapping", "DiagnosticEventToStorageConditionGroupMapping", "DiagnosticEventToTroubleCodeJ1939Mapping", "DiagnosticEventToTroubleCodeUdsMapping", "DiagnosticExtendedDataRecord", "DiagnosticFimAliasEvent", "DiagnosticFimAliasEventGroup", "DiagnosticFimAliasEventGroupMapping", "DiagnosticFimAliasEventMapping", "DiagnosticFimEventGroup", "DiagnosticFimFunctionMapping", "DiagnosticFreezeFrame", "DiagnosticFunctionIdentifier", "DiagnosticFunctionIdentifierInhibit", "DiagnosticFunctionInhibitSource", "DiagnosticIOControl", "DiagnosticIndicator", "DiagnosticInfoType", "DiagnosticInhibitSourceEventMapping", "DiagnosticIoControlClass", "DiagnosticIoControlNeeds", "DiagnosticIumpr", "DiagnosticIumprDenominatorGroup", "DiagnosticIumprGroup", "DiagnosticIumprToFunctionIdentifierMapping", "DiagnosticJ1939ExpandedFreezeFrame", "DiagnosticJ1939FreezeFrame", "DiagnosticJ1939Node", "DiagnosticJ1939Spn", "DiagnosticJ1939SpnMapping", "DiagnosticJ1939SwMapping", "DiagnosticMasterToSlaveEventMapping", "DiagnosticMeasurementIdentifier", "DiagnosticMemoryDestinationPrimary", "DiagnosticMemoryDestinationUserDefined", "DiagnosticMemoryIdentifier", "DiagnosticOperationCycle", "DiagnosticOperationCycleNeeds", "DiagnosticOperationCyclePortMapping", "DiagnosticParameterElement", "DiagnosticParameterIdent", "DiagnosticParameterIdentifier", "DiagnosticPowertrainFreezeFrame", "DiagnosticProofOfOwnership", "DiagnosticProtocol", "DiagnosticReadDTCInformation", "DiagnosticReadDTCInformationClass", "DiagnosticReadDataByIdentifier", "DiagnosticReadDataByIdentifierClass", "DiagnosticReadDataByPeriodicID", "DiagnosticReadDataByPeriodicIDClass", "DiagnosticReadMemoryByAddress", "DiagnosticReadMemoryByAddressClass", "DiagnosticReadScalingDataByIdentifier", "DiagnosticReadScalingDataByIdentifierClass", "DiagnosticRequestControlOfOnBoardDevice", "DiagnosticRequestControlOfOnBoardDeviceClass", "DiagnosticRequestCurrentPowertrainData", "DiagnosticRequestCurrentPowertrainDataClass", "DiagnosticRequestDownload", "DiagnosticRequestDownloadClass", "DiagnosticRequestEmissionRelatedDTC", "DiagnosticRequestEmissionRelatedDTCClass", "DiagnosticRequestEmissionRelatedDTCPermanentStatus", "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass", "DiagnosticRequestFileTransfer", "DiagnosticRequestFileTransferClass", "DiagnosticRequestFileTransferNeeds", "DiagnosticRequestOnBoardMonitoringTestResults", "DiagnosticRequestOnBoardMonitoringTestResultsClass", "DiagnosticRequestPowertrainFreezeFrameData", "DiagnosticRequestPowertrainFreezeFrameDataClass", "DiagnosticRequestRoutineResults", "DiagnosticRequestUpload", "DiagnosticRequestUploadClass", "DiagnosticRequestVehicleInfo", "DiagnosticRequestVehicleInfoClass", "DiagnosticResponseOnEvent", "DiagnosticResponseOnEventClass", "DiagnosticRoutine", "DiagnosticRoutineControl", "DiagnosticRoutineControlClass", "DiagnosticRoutineNeeds", "DiagnosticSecureCodingMapping", "DiagnosticSecurityAccess", "DiagnosticSecurityAccessClass", "DiagnosticSecurityEventReportingModeMapping", "DiagnosticSecurityLevel", "DiagnosticServiceDataMapping", "DiagnosticServiceSwMapping", "DiagnosticServiceTable", "DiagnosticSession", "DiagnosticSessionControl", "DiagnosticSessionControlClass", "DiagnosticStartRoutine", "DiagnosticStopRoutine", "DiagnosticStorageCondition", "DiagnosticStorageConditionGroup", "DiagnosticStorageConditionNeeds", "DiagnosticStorageConditionPortMapping", "DiagnosticTestResult", "DiagnosticTestRoutineIdentifier", "DiagnosticTransferExit", "DiagnosticTransferExitClass", "DiagnosticTroubleCodeGroup", "DiagnosticTroubleCodeJ1939", "DiagnosticTroubleCodeObd", "DiagnosticTroubleCodeProps", "DiagnosticTroubleCodeUds", "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping", "DiagnosticUploadDownloadNeeds", "DiagnosticValueNeeds", "DiagnosticVerifyCertificateBidirectional", "DiagnosticWriteDataByIdentifierClass", "DiagnosticWriteMemoryByAddressClass", "DiagnosticsCommunicationSecurityNeeds", "DltApplication", "DltArgument", "DltContext", "DltEcu", "DltLogChannel", "DltMessage", "DltUserNeeds", "DoIpActivationLineNeeds", "DoIpGidNeeds", "DoIpGidSynchronizationNeeds", "DoIpInterface", "DoIpLogicAddress", "DoIpLogicTargetAddressProps", "DoIpLogicTesterAddressProps", "DoIpPowerModeStatusNeeds", "DoIpRoutingActivation", "DoIpRoutingActivationAuthenticationNeeds", "DoIpRoutingActivationConfirmationNeeds", "DoIpTpConfig", "DocumentElementScope", "Documentation", "DocumentationContext", "DtcStatusChangeNotificationNeeds", "E2EProfileCompatibilityProps", "ECUMapping", "EOCEventRef", "EOCExecutableEntityRef", "EOCExecutableEntityRefGroup", "EcuAbstractionSwComponentType", "EcuInstance", "EcuPartition", "EcuStateMgrUserNeeds", "EcuTiming", "EcucAddInfoParamDef", "EcucBooleanParamDef", "EcucChoiceContainerDef", "EcucChoiceReferenceDef", "EcucContainerValue", "EcucDefinitionCollection", "EcucDestinationUriDef", "EcucDestinationUriDefSet", "EcucEnumerationLiteralDef", "EcucEnumerationParamDef", "EcucFloatParamDef", "EcucForeignReferenceDef", "EcucFunctionNameDef", "EcucInstanceReferenceDef", "EcucIntegerParamDef", "EcucLinkerSymbolDef", "EcucModuleConfigurationValues", "EcucModuleDef", "EcucMultilineStringParamDef", "EcucParamConfContainerDef", "EcucQuery", "EcucReferenceDef", "EcucStringParamDef", "EcucUriReferenceDef", "EcucValidationCondition", "EcucValueCollection", "EndToEndProtection", "EndToEndProtectionSet", "EnumerationMappingTable", "ErrorTracerNeeds", "EthIpProps", "EthTcpIpIcmpProps", "EthTcpIpProps", "EthTpConfig", "EthernetCluster", "EthernetCommunicationConnector", "EthernetCommunicationController", "EthernetFrameTriggering", "EthernetPhysicalChannel", "EthernetPriorityRegeneration", "EthernetWakeupSleepOnDatalineConfig", "EthernetWakeupSleepOnDatalineConfigSet", "EvaluatedVariantSet", "EventHandler", "ExclusiveArea", "ExclusiveAreaNestingOrder", "ExecutableEntityActivationReason", "ExecutionOrderConstraint", "ExecutionTimeConstraint", "ExternalTriggerOccurredEvent", "ExternalTriggeringPointIdent", "FMAttributeDef", "FMFeature", "FMFeatureMap", "FMFeatureMapAssertion", "FMFeatureMapCondition", "FMFeatureMapElement", "FMFeatureModel", "FMFeatureRelation", "FMFeatureRestriction", "FMFeatureSelection", "FMFeatureSelectionSet", "FirewallRule", "FlatInstanceDescriptor", "FlatMap", "FlexrayArTpConfig", "FlexrayArTpNode", "FlexrayCluster", "FlexrayCommunicationConnector", "FlexrayCommunicationController", "FlexrayFrame", "FlexrayFrameTriggering", "FlexrayNmCluster", "FlexrayNmNode", "FlexrayPhysicalChannel", "FlexrayTpConfig", "FlexrayTpConnectionControl", "FlexrayTpNode", "FlexrayTpPduPool", "FramePort", "FunctionInhibitionAvailabilityNeeds", "FunctionInhibitionNeeds", "Gateway", "GeneralPurposeConnection", "GeneralPurposeIPdu", "GeneralPurposePdu", "GenericEthernetFrame", "GlobalSupervisionNeeds", "GlobalTimeCanMaster", "GlobalTimeCanSlave", "GlobalTimeDomain", "GlobalTimeEthMaster", "GlobalTimeEthSlave", "GlobalTimeFrMaster", "GlobalTimeFrSlave", "GlobalTimeGateway", "HardwareTestNeeds", "HwAttributeDef", "HwAttributeLiteralDef", "HwCategory", "HwDescriptionEntity", "HwElement", "HwPin", "HwPinGroup", "HwType", "IEEE1722TpAafConnection", "IEEE1722TpAcfCan", "IEEE1722TpAcfCanPart", "IEEE1722TpAcfConnection", "IEEE1722TpAcfLin", "IEEE1722TpAcfLinPart", "IEEE1722TpConfig", "IEEE1722TpCrfConnection", "IEEE1722TpIidcConnection", "IPSecConfigProps", "IPSecRule", "IPduPort", "IPv6ExtHeaderFilterList", "IPv6ExtHeaderFilterSet", "ISignal", "ISignalGroup", "ISignalIPdu", "ISignalIPduGroup", "ISignalPort", "ISignalToIPduMapping", "ISignalTriggering", "IdsDesign", "IdsMgrCustomTimestampNeeds", "IdsMgrNeeds", "IdsmInstance", "IdsmProperties", "Ieee1722TpEthernetFrame", "ImplementationDataType", "ImplementationDataTypeElement", "ImplementationProps", "ImpositionTime", "IndicatorStatusNeeds", "InitEvent", "InternalTriggerOccurredEvent", "InternalTriggeringPoint", "InterpolationRoutineMappingSet", "J1939Cluster", "J1939ControllerApplication", "J1939DcmDm19Support", "J1939DcmIPdu", "J1939NmCluster", "J1939NmNode", "J1939RmIncomingRequestServiceNeeds", "J1939RmOutgoingRequestServiceNeeds", "J1939SharedAddressCluster", "J1939TpConfig", "J1939TpNode", "Keyword", "KeywordSet", "LatencyTimingConstraint", "LifeCycleInfoSet", "LifeCycleState", "LifeCycleStateDefinitionGroup", "LinCluster", "LinCommunicationConnector", "LinEventTriggeredFrame", "LinFrameTriggering", "LinMaster", "LinPhysicalChannel", "LinScheduleTable", "LinSlave", "LinSlaveConfigIdent", "LinSporadicFrame", "LinTpConfig", "LinTpNode", "LinUnconditionalFrame", "Linker", "LogAndTraceMessageCollectionSet", "MacMulticastGroup", "MacSecGlobalKayProps", "MacSecKayParticipant", "MacSecParticipantSet", "McDataInstance", "McFunction", "McGroup", "MeasuredExecutionTime", "MeasuredHeapUsage", "MeasuredStackUsage", "MemorySection", "ModeAccessPointIdent", "ModeDeclaration", "ModeDeclarationGroup", "ModeDeclarationGroupPrototype", "ModeDeclarationMapping", "ModeDeclarationMappingSet", "ModeInterfaceMapping", "ModeSwitchInterface", "ModeSwitchPoint", "ModeSwitchedAckEvent", "ModeTransition", "MultilanguageReferrable", "MultiplexedIPdu", "NPdu", "NetworkEndpoint", "NmConfig", "NmEcu", "NmPdu", "NvBlockDescriptor", "NvBlockNeeds", "NvBlockSwComponentType", "NvDataInterface", "ObdControlServiceNeeds", "ObdInfoServiceNeeds", "ObdMonitorServiceNeeds", "ObdPidServiceNeeds", "ObdRatioDenominatorNeeds", "ObdRatioServiceNeeds", "OffsetTimingConstraint", "OperationInvokedEvent", "OsTaskExecutionEvent", "OsTaskProxy", "PPortPrototype", "PRPortPrototype", "ParameterAccess", "ParameterDataPrototype", "ParameterInterface", "ParameterSwComponentType", "PassThroughSwConnector", "PduActivationRoutingGroup", "PduToFrameMapping", "PduTriggering", "PdurIPduGroup", "PerInstanceMemory", "PeriodicEventTriggering", "PhysicalDimension", "PhysicalDimensionMappingSet", "PncMappingIdent", "PortElementToCommunicationResourceMapping", "PortGroup", "PortInterfaceMappingSet", "PortPrototypeBlueprint", "PostBuildVariantCriterion", "PostBuildVariantCriterionValueSet", "PredefinedVariant", "PrimitiveAttributeTailoring", "ProvidedServiceInstance", "RPortPrototype", "RapidPrototypingScenario", "ReferenceTailoring", "ResourceConsumption", "RootSwCompositionPrototype", "RoughEstimateHeapUsage", "RoughEstimateOfExecutionTime", "RoughEstimateStackUsage", "RptComponent", "RptContainer", "RptExecutableEntity", "RptExecutableEntityEvent", "RptExecutionContext", "RptProfile", "RptServicePoint", "RteEventInCompositionSeparation", "RteEventInCompositionToOsTaskProxyMapping", "RteEventInSystemSeparation", "RteEventInSystemToOsTaskProxyMapping", "RunnableEntity", "RunnableEntityGroup", "RuntimeError", "SOMEIPTransformationProps", "Sdg", "SdgAggregationWithVariation", "SdgCaption", "SdgClass", "SdgDef", "SdgForeignReference", "SdgForeignReferenceWithVariation", "SdgPrimitiveAttribute", "SdgPrimitiveAttributeWithVariation", "SdgTailoring", "SecOcCryptoServiceMapping", "SectionNamePrefix", "SecureCommunicationAuthenticationProps", "SecureCommunicationFreshnessProps", "SecureCommunicationPropsSet", "SecureOnBoardCommunicationNeeds", "SecuredIPdu", "SecurityEventAggregationFilter", "SecurityEventContextMappingApplication", "SecurityEventContextMappingBswModule", "SecurityEventContextMappingCommConnector", "SecurityEventContextMappingFunctionalCluster", "SecurityEventContextProps", "SecurityEventDefinition", "SecurityEventFilterChain", "SecurityEventOneEveryNFilter", "SecurityEventStateFilter", "SenderReceiverInterface", "SensorActuatorSwComponentType", "ServiceInstanceCollectionSet", "ServiceProxySwComponentType", "ServiceSwComponentType", "SignalServiceTranslationElementProps", "SignalServiceTranslationEventProps", "SignalServiceTranslationProps", "SignalServiceTranslationPropsSet", "SingleLanguageReferrable", "SoAdRoutingGroup", "SoConIPduIdentifier", "SocketAddress", "SocketConnectionBundle", "SocketConnectionIpduIdentifierSet", "SomeipSdClientServiceInstanceConfig", "SomeipSdServerEventGroupTimingConfig", "SomeipSdServerServiceInstanceConfig", "SomeipTpChannel", "SomeipTpConfig", "SpecificationDocumentScope", "SporadicEventTriggering", "StaticSocketConnection", "Std", "StructuredReq", "SupervisedEntityCheckpointNeeds", "SupervisedEntityNeeds", "SwAddrMethod", "SwAxisType", "SwBaseType", "SwGenericAxisParamType", "SwRecordLayout", "SwServiceArg", "SwSystemconst", "SwSystemconstantValueSet", "SwcBswMapping", "SwcImplementation", "SwcInternalBehavior", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "SwcServiceDependency", "SwcTiming", "SwcToApplicationPartitionMapping", "SwcToEcuMapping", "SwcToImplMapping", "SwitchAsynchronousTrafficShaperGroupEntry", "SwitchFlowMeteringEntry", "SwitchStreamFilterActionDestPortModification", "SwitchStreamFilterEntry", "SwitchStreamFilterRule", "SwitchStreamGateEntry", "SwitchStreamIdentification", "SymbolProps", "SyncTimeBaseMgrUserNeeds", "SynchronizationPointConstraint", "SynchronousServerCallPoint", "System", "SystemMapping", "SystemSignal", "SystemSignalGroup", "SystemSignalGroupToCommunicationResourceMapping", "SystemSignalToCommunicationResourceMapping", "SystemTiming", "TDCpSoftwareClusterMapping", "TDCpSoftwareClusterMappingSet", "TDCpSoftwareClusterResourceMapping", "TDEventBswInternalBehavior", "TDEventBswModeDeclaration", "TDEventBswModule", "TDEventComplex", "TDEventFrClusterCycleStart", "TDEventFrame", "TDEventFrameEthernet", "TDEventIPdu", "TDEventISignal", "TDEventModeDeclaration", "TDEventOperation", "TDEventSLLETPort", "TDEventSwcInternalBehavior", "TDEventSwcInternalBehaviorReference", "TDEventTTCanCycleStart", "TDEventTrigger", "TDEventVariableDataPrototype", "TDEventVfbReference", "TDLETZoneClock", "TcpOptionFilterList", "TcpOptionFilterSet", "TimeSyncServerConfiguration", "TimingClockSyncAccuracy", "TimingCondition", "TimingDescriptionEventChain", "TimingEvent", "TimingExtensionResource", "TimingModeInstance", "TlsCryptoCipherSuite", "TlsCryptoCipherSuiteProps", "TlsCryptoServiceMapping", "TlvDataIdDefinitionSet", "Topic1", "TpAddress", "TpConnectionIdent", "TraceableText", "TransformationPropsSet", "TransformationTechnology", "TransformerHardErrorEvent", "TransientFault", "Trigger", "TriggerInterface", "TriggerInterfaceMapping", "TtcanCluster", "TtcanCommunicationConnector", "TtcanCommunicationController", "TtcanPhysicalChannel", "UdpNmCluster", "UdpNmNode", "Unit", "UnitGroup", "UserDefinedCluster", "UserDefinedCommunicationConnector", "UserDefinedCommunicationController", "UserDefinedEthernetFrame", "UserDefinedGlobalTimeMaster", "UserDefinedGlobalTimeSlave", "UserDefinedIPdu", "UserDefinedPdu", "UserDefinedTransformationProps", "V2xDataManagerNeeds", "V2xFacUserNeeds", "V2xMUserNeeds", "VariableAccess", "VariableDataPrototype", "VariationPointProxy", "VendorSpecificServiceNeeds", "VfbTiming", "ViewMap", "ViewMapSet", "VlanConfig", "WaitPoint", "WorstCaseHeapUsage", "WorstCaseStackUsage", "Xdoc", "Xfile", "XrefTarget"]),
-    }
 
+    # Primary attribute for atp_mixed content
+    # SdgContents uses @atp_mixed decorator, so its children serialize directly
+    sdg_contents_type: Optional["SdgContents"]
 
     def __init__(self) -> None:
         """Initialize Sdg."""
         super().__init__()
         self._gid: NameToken = None
         self.sdg_caption: Optional[SdgCaption] = None
+        # Legacy single-value attributes
         self.sd: Optional[Sd] = None
         self.sdf: Optional[Sdf] = None
         self.sdg: Optional[Sdg] = None
         self.sdx: Optional[Referrable] = None
         self.sdxf: Optional[Referrable] = None
+        # Primary atp_mixed container
+        self.sdg_contents_type: Optional[SdgContents] = None
+
     @property
     @xml_attribute
     def gid(self) -> NameToken:
@@ -86,27 +106,22 @@ class Sdg(ARObject):
         """Set gid XML attribute."""
         self._gid = value
 
-
     def serialize(self) -> ET.Element:
         """Serialize Sdg to XML element.
+
+        The atp_mixed pattern means that SdgContents children serialize
+        directly under the SDG element without a wrapper.
 
         Returns:
             xml.etree.ElementTree.Element representing this object
         """
-        # Use pre-computed _XML_TAG constant
         elem = ET.Element(self._XML_TAG)
 
         # First, call parent's serialize to handle inherited attributes
         parent_elem = super(Sdg, self).serialize()
-
-        # Copy all attributes from parent element
         elem.attrib.update(parent_elem.attrib)
-
-        # Copy text from parent element
         if parent_elem.text:
             elem.text = parent_elem.text
-
-        # Copy all children from parent element
         for child in parent_elem:
             elem.append(child)
 
@@ -118,7 +133,6 @@ class Sdg(ARObject):
         if self.sdg_caption is not None:
             serialized = SerializationHelper.serialize_item(self.sdg_caption, "SdgCaption")
             if serialized is not None:
-                # Wrap with correct tag
                 wrapped = ET.Element("SDG-CAPTION")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
@@ -128,75 +142,75 @@ class Sdg(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sd
-        if self.sd is not None:
-            serialized = SerializationHelper.serialize_item(self.sd, "Sd")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SD")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+        # Serialize sdg_contents_type (atp_mixed pattern)
+        # When SdgContents is set, its children serialize directly under SDG
+        if self.sdg_contents_type is not None:
+            # Serialize the SdgContents and append its children directly
+            serialized = self.sdg_contents_type.serialize()
+            # For atp_mixed, append children directly, not the wrapper element
+            for child in serialized:
+                elem.append(child)
+        else:
+            # Fallback to legacy single-value attributes for backward compatibility
+            if self.sd is not None:
+                serialized = SerializationHelper.serialize_item(self.sd, "Sd")
+                if serialized is not None:
+                    wrapped = ET.Element("SD")
+                    if hasattr(serialized, 'attrib'):
+                        wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                    for child in serialized:
+                        wrapped.append(child)
+                    elem.append(wrapped)
 
-        # Serialize sdf
-        if self.sdf is not None:
-            serialized = SerializationHelper.serialize_item(self.sdf, "Sdf")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SDF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+            if self.sdf is not None:
+                serialized = SerializationHelper.serialize_item(self.sdf, "Sdf")
+                if serialized is not None:
+                    wrapped = ET.Element("SDF")
+                    if hasattr(serialized, 'attrib'):
+                        wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                    for child in serialized:
+                        wrapped.append(child)
+                    elem.append(wrapped)
 
-        # Serialize sdg
-        if self.sdg is not None:
-            serialized = SerializationHelper.serialize_item(self.sdg, "Sdg")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SDG")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+            if self.sdg is not None:
+                serialized = SerializationHelper.serialize_item(self.sdg, "Sdg")
+                if serialized is not None:
+                    wrapped = ET.Element("SDG")
+                    if hasattr(serialized, 'attrib'):
+                        wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                    for child in serialized:
+                        wrapped.append(child)
+                    elem.append(wrapped)
 
-        # Serialize sdx
-        if self.sdx is not None:
-            serialized = SerializationHelper.serialize_item(self.sdx, "Referrable")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SDX")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+            if self.sdx is not None:
+                serialized = SerializationHelper.serialize_item(self.sdx, "Referrable")
+                if serialized is not None:
+                    wrapped = ET.Element("SDX")
+                    if hasattr(serialized, 'attrib'):
+                        wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                    for child in serialized:
+                        wrapped.append(child)
+                    elem.append(wrapped)
 
-        # Serialize sdxf
-        if self.sdxf is not None:
-            serialized = SerializationHelper.serialize_item(self.sdxf, "Referrable")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("SDXF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+            if self.sdxf is not None:
+                serialized = SerializationHelper.serialize_item(self.sdxf, "Referrable")
+                if serialized is not None:
+                    wrapped = ET.Element("SDXF")
+                    if hasattr(serialized, 'attrib'):
+                        wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                    for child in serialized:
+                        wrapped.append(child)
+                    elem.append(wrapped)
 
         return elem
 
@@ -204,12 +218,17 @@ class Sdg(ARObject):
     def deserialize(cls, element: ET.Element) -> "Sdg":
         """Deserialize XML element to Sdg object.
 
+        Collects all SD/SDF/SDG/SDX/SDXF children into SdgContents for
+        proper handling of multiple children of the same type.
+
         Args:
             element: XML element to deserialize from
 
         Returns:
             Deserialized Sdg object
         """
+        from armodel2.models.M2.MSR.AsamHdo.SpecialData.sdg_contents import SdgContents
+
         # First, call parent's deserialize to handle inherited attributes
         obj = super(Sdg, cls).deserialize(element)
 
@@ -217,3415 +236,188 @@ class Sdg(ARObject):
         if "GID" in element.attrib:
             obj.gid = element.attrib["GID"]
 
-        # Single-pass deserialization with if-elif-else chain
+        # Collect SD/SDF/SDG/SDX/SDXF children for atp_mixed handling
+        sd_children: List[ET.Element] = []
+        sdf_children: List[ET.Element] = []
+        sdg_children: List[ET.Element] = []
+        sdx_children: List[ET.Element] = []
+        sdxf_children: List[ET.Element] = []
+
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "SDG-CAPTION":
                 setattr(obj, "sdg_caption", SerializationHelper.deserialize_by_tag(child, "SdgCaption"))
             elif tag == "SD":
-                setattr(obj, "sd", SerializationHelper.deserialize_by_tag(child, "Sd"))
+                sd_children.append(child)
             elif tag == "SDF":
-                setattr(obj, "sdf", SerializationHelper.deserialize_by_tag(child, "Sdf"))
+                sdf_children.append(child)
             elif tag == "SDG":
-                setattr(obj, "sdg", SerializationHelper.deserialize_by_tag(child, "Sdg"))
+                sdg_children.append(child)
             elif tag == "SDX":
-                # Check first child element for concrete type
-                if len(child) > 0:
-                    concrete_tag = child[0].tag.split(ns_split, 1)[1] if child[0].tag.startswith("{") else child[0].tag
-                    if concrete_tag == "AR-PACKAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ARPackage"))
-                    elif concrete_tag == "ACL-OBJECT-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AclObjectSet"))
-                    elif concrete_tag == "ACL-OPERATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AclOperation"))
-                    elif concrete_tag == "ACL-PERMISSION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AclPermission"))
-                    elif concrete_tag == "ACL-ROLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AclRole"))
-                    elif concrete_tag == "AGE-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AgeConstraint"))
-                    elif concrete_tag == "AGGREGATION-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AggregationTailoring"))
-                    elif concrete_tag == "ALIAS-NAME-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AliasNameSet"))
-                    elif concrete_tag == "ANALYZED-EXECUTION-TIME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AnalyzedExecutionTime"))
-                    elif concrete_tag == "APP-OS-TASK-PROXY-TO-ECU-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AppOsTaskProxyToEcuTaskProxyMapping"))
-                    elif concrete_tag == "APPLICATION-ARRAY-DATA-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationArrayDataType"))
-                    elif concrete_tag == "APPLICATION-ARRAY-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationArrayElement"))
-                    elif concrete_tag == "APPLICATION-ENDPOINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationEndpoint"))
-                    elif concrete_tag == "APPLICATION-ERROR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationError"))
-                    elif concrete_tag == "APPLICATION-PARTITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPartition"))
-                    elif concrete_tag == "APPLICATION-PARTITION-TO-ECU-PARTITION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPartitionToEcuPartitionMapping"))
-                    elif concrete_tag == "APPLICATION-PRIMITIVE-DATA-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPrimitiveDataType"))
-                    elif concrete_tag == "APPLICATION-RECORD-DATA-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationRecordDataType"))
-                    elif concrete_tag == "APPLICATION-RECORD-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationRecordElement"))
-                    elif concrete_tag == "APPLICATION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ApplicationSwComponentType"))
-                    elif concrete_tag == "ARBITRARY-EVENT-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ArbitraryEventTriggering"))
-                    elif concrete_tag == "ARGUMENT-DATA-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ArgumentDataPrototype"))
-                    elif concrete_tag == "ASSEMBLY-SW-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AssemblySwConnector"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallPoint"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-RESULT-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallResultPoint"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallReturnsEvent"))
-                    elif concrete_tag == "ATP-DEFINITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AtpDefinition"))
-                    elif concrete_tag == "AUTOSAR-OPERATION-ARGUMENT-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AutosarOperationArgumentInstance"))
-                    elif concrete_tag == "AUTOSAR-VARIABLE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "AutosarVariableInstance"))
-                    elif concrete_tag == "BACKGROUND-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BackgroundEvent"))
-                    elif concrete_tag == "BINARY-MANIFEST-ITEM":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestItem"))
-                    elif concrete_tag == "BINARY-MANIFEST-ITEM-DEFINITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestItemDefinition"))
-                    elif concrete_tag == "BINARY-MANIFEST-META-DATA-FIELD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestMetaDataField"))
-                    elif concrete_tag == "BINARY-MANIFEST-PROVIDE-RESOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestProvideResource"))
-                    elif concrete_tag == "BINARY-MANIFEST-REQUIRE-RESOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestRequireResource"))
-                    elif concrete_tag == "BINARY-MANIFEST-RESOURCE-DEFINITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestResourceDefinition"))
-                    elif concrete_tag == "BLOCK-STATE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BlockState"))
-                    elif concrete_tag == "BLUEPRINT-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BlueprintMappingSet"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallPoint"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-RESULT-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallResultPoint"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallReturnsEvent"))
-                    elif concrete_tag == "BSW-BACKGROUND-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswBackgroundEvent"))
-                    elif concrete_tag == "BSW-CALLED-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswCalledEntity"))
-                    elif concrete_tag == "BSW-COMPOSITION-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswCompositionTiming"))
-                    elif concrete_tag == "BSW-DATA-RECEIVED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswDataReceivedEvent"))
-                    elif concrete_tag == "BSW-DIRECT-CALL-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswDirectCallPoint"))
-                    elif concrete_tag == "BSW-DISTINGUISHED-PARTITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswDistinguishedPartition"))
-                    elif concrete_tag == "BSW-ENTRY-RELATIONSHIP-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswEntryRelationshipSet"))
-                    elif concrete_tag == "BSW-EXTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswExternalTriggerOccurredEvent"))
-                    elif concrete_tag == "BSW-IMPLEMENTATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswImplementation"))
-                    elif concrete_tag == "BSW-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswInternalBehavior"))
-                    elif concrete_tag == "BSW-INTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswInternalTriggerOccurredEvent"))
-                    elif concrete_tag == "BSW-INTERNAL-TRIGGERING-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswInternalTriggeringPoint"))
-                    elif concrete_tag == "BSW-INTERRUPT-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswInterruptEntity"))
-                    elif concrete_tag == "BSW-INTERRUPT-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswInterruptEvent"))
-                    elif concrete_tag == "BSW-MGR-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswMgrNeeds"))
-                    elif concrete_tag == "BSW-MODE-MANAGER-ERROR-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModeManagerErrorEvent"))
-                    elif concrete_tag == "BSW-MODE-SWITCH-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModeSwitchEvent"))
-                    elif concrete_tag == "BSW-MODE-SWITCHED-ACK-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModeSwitchedAckEvent"))
-                    elif concrete_tag == "BSW-MODULE-CALL-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleCallPoint"))
-                    elif concrete_tag == "BSW-MODULE-CLIENT-SERVER-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleClientServerEntry"))
-                    elif concrete_tag == "BSW-MODULE-DEPENDENCY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleDependency"))
-                    elif concrete_tag == "BSW-MODULE-DESCRIPTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleDescription"))
-                    elif concrete_tag == "BSW-MODULE-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleEntry"))
-                    elif concrete_tag == "BSW-MODULE-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswModuleTiming"))
-                    elif concrete_tag == "BSW-OPERATION-INVOKED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswOperationInvokedEvent"))
-                    elif concrete_tag == "BSW-OS-TASK-EXECUTION-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswOsTaskExecutionEvent"))
-                    elif concrete_tag == "BSW-SCHEDULABLE-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswSchedulableEntity"))
-                    elif concrete_tag == "BSW-SCHEDULER-NAME-PREFIX":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswSchedulerNamePrefix"))
-                    elif concrete_tag == "BSW-SERVICE-DEPENDENCY-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswServiceDependencyIdent"))
-                    elif concrete_tag == "BSW-TIMING-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswTimingEvent"))
-                    elif concrete_tag == "BSW-VARIABLE-ACCESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BswVariableAccess"))
-                    elif concrete_tag == "BUILD-ACTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BuildAction"))
-                    elif concrete_tag == "BUILD-ACTION-ENVIRONMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BuildActionEnvironment"))
-                    elif concrete_tag == "BUILD-ACTION-MANIFEST":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BuildActionManifest"))
-                    elif concrete_tag == "BULK-NV-DATA-DESCRIPTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BulkNvDataDescriptor"))
-                    elif concrete_tag == "BURST-PATTERN-EVENT-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BurstPatternEventTriggering"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-CAN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingCan"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-FLEXRAY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingFlexray"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-IP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingIp"))
-                    elif concrete_tag == "CALIBRATION-PARAMETER-VALUE-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CalibrationParameterValueSet"))
-                    elif concrete_tag == "CAN-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanCluster"))
-                    elif concrete_tag == "CAN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanCommunicationConnector"))
-                    elif concrete_tag == "CAN-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanCommunicationController"))
-                    elif concrete_tag == "CAN-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanFrame"))
-                    elif concrete_tag == "CAN-FRAME-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanFrameTriggering"))
-                    elif concrete_tag == "CAN-NM-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanNmCluster"))
-                    elif concrete_tag == "CAN-NM-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanNmNode"))
-                    elif concrete_tag == "CAN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanPhysicalChannel"))
-                    elif concrete_tag == "CAN-TP-ADDRESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanTpAddress"))
-                    elif concrete_tag == "CAN-TP-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanTpChannel"))
-                    elif concrete_tag == "CAN-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanTpConfig"))
-                    elif concrete_tag == "CAN-TP-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CanTpNode"))
-                    elif concrete_tag == "CAPTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Caption"))
-                    elif concrete_tag == "CHAPTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Chapter"))
-                    elif concrete_tag == "CLASS-CONTENT-CONDITIONAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClassContentConditional"))
-                    elif concrete_tag == "CLIENT-ID-DEFINITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientIdDefinition"))
-                    elif concrete_tag == "CLIENT-ID-DEFINITION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientIdDefinitionSet"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterface"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterfaceMapping"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE-TO-BSW-MODULE-ENTRY-BLUEPRINT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterfaceToBswModuleEntryBlueprintMapping"))
-                    elif concrete_tag == "CLIENT-SERVER-OPERATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ClientServerOperation"))
-                    elif concrete_tag == "CODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Code"))
-                    elif concrete_tag == "COLLECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Collection"))
-                    elif concrete_tag == "COM-MANAGEMENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ComManagementMapping"))
-                    elif concrete_tag == "COM-MGR-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ComMgrUserNeeds"))
-                    elif concrete_tag == "COMPILER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Compiler"))
-                    elif concrete_tag == "COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ComplexDeviceDriverSwComponentType"))
-                    elif concrete_tag == "COMPOSITION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CompositionSwComponentType"))
-                    elif concrete_tag == "COMPU-METHOD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CompuMethod"))
-                    elif concrete_tag == "CONCRETE-CLASS-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConcreteClassTailoring"))
-                    elif concrete_tag == "CONCRETE-PATTERN-EVENT-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConcretePatternEventTriggering"))
-                    elif concrete_tag == "CONSISTENCY-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConsistencyNeeds"))
-                    elif concrete_tag == "CONSISTENCY-NEEDS-BLUEPRINT-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConsistencyNeedsBlueprintSet"))
-                    elif concrete_tag == "CONSTANT-SPECIFICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConstantSpecification"))
-                    elif concrete_tag == "CONSTANT-SPECIFICATION-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConstantSpecificationMappingSet"))
-                    elif concrete_tag == "CONSTRAINT-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConstraintTailoring"))
-                    elif concrete_tag == "CONSUMED-EVENT-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConsumedEventGroup"))
-                    elif concrete_tag == "CONSUMED-PROVIDED-SERVICE-INSTANCE-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConsumedProvidedServiceInstanceGroup"))
-                    elif concrete_tag == "CONSUMED-SERVICE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ConsumedServiceInstance"))
-                    elif concrete_tag == "CONTAINER-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ContainerIPdu"))
-                    elif concrete_tag == "COUPLING-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingElement"))
-                    elif concrete_tag == "COUPLING-ELEMENT-SWITCH-DETAILS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingElementSwitchDetails"))
-                    elif concrete_tag == "COUPLING-PORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingPort"))
-                    elif concrete_tag == "COUPLING-PORT-FIFO":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortFifo"))
-                    elif concrete_tag == "COUPLING-PORT-SCHEDULER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortScheduler"))
-                    elif concrete_tag == "COUPLING-PORT-SHAPER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortShaper"))
-                    elif concrete_tag == "COUPLING-PORT-TRAFFIC-CLASS-ASSIGNMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortTrafficClassAssignment"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareCluster"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-BINARY-MANIFEST-DESCRIPTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterBinaryManifestDescriptor"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-COMMUNICATION-RESOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterCommunicationResource"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterMappingSet"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-RESOURCE-POOL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterResourcePool"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-RESOURCE-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterResourceToApplicationPartitionMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-SERVICE-RESOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterServiceResource"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToApplicationPartitionMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-ECU-INSTANCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToEcuInstanceMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-RESOURCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToResourceMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-RESOURCE-TO-DIAG-DATA-ELEM-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterResourceToDiagDataElemMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-RESOURCE-TO-DIAG-FUNCTION-ID-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterResourceToDiagFunctionIdMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-TO-DIAG-EVENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterToDiagEventMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-TO-DIAG-ROUTINE-SUBFUNCTION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterToDiagRoutineSubfunctionMapping"))
-                    elif concrete_tag == "CRYPTO-ELLIPTIC-CURVE-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoEllipticCurveProps"))
-                    elif concrete_tag == "CRYPTO-KEY-MANAGEMENT-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoKeyManagementNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-CERTIFICATE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceCertificate"))
-                    elif concrete_tag == "CRYPTO-SERVICE-JOB-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceJobNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-KEY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceKey"))
-                    elif concrete_tag == "CRYPTO-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-PRIMITIVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServicePrimitive"))
-                    elif concrete_tag == "CRYPTO-SERVICE-QUEUE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceQueue"))
-                    elif concrete_tag == "CRYPTO-SIGNATURE-SCHEME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "CryptoSignatureScheme"))
-                    elif concrete_tag == "DATA-CONSTR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataConstr"))
-                    elif concrete_tag == "DATA-EXCHANGE-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataExchangePoint"))
-                    elif concrete_tag == "DATA-PROTOTYPE-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataPrototypeGroup"))
-                    elif concrete_tag == "DATA-RECEIVE-ERROR-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataReceiveErrorEvent"))
-                    elif concrete_tag == "DATA-RECEIVED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataReceivedEvent"))
-                    elif concrete_tag == "DATA-SEND-COMPLETED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataSendCompletedEvent"))
-                    elif concrete_tag == "DATA-TRANSFORMATION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataTransformationSet"))
-                    elif concrete_tag == "DATA-TYPE-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataTypeMappingSet"))
-                    elif concrete_tag == "DATA-WRITE-COMPLETED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DataWriteCompletedEvent"))
-                    elif concrete_tag == "DCM-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DcmIPdu"))
-                    elif concrete_tag == "DDS-CP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpConfig"))
-                    elif concrete_tag == "DDS-CP-CONSUMED-SERVICE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpConsumedServiceInstance"))
-                    elif concrete_tag == "DDS-CP-DOMAIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpDomain"))
-                    elif concrete_tag == "DDS-CP-PARTITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpPartition"))
-                    elif concrete_tag == "DDS-CP-PROVIDED-SERVICE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpProvidedServiceInstance"))
-                    elif concrete_tag == "DDS-CP-QOS-PROFILE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpQosProfile"))
-                    elif concrete_tag == "DDS-CP-TOPIC":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DdsCpTopic"))
-                    elif concrete_tag == "DEF-ITEM":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DefItem"))
-                    elif concrete_tag == "DELEGATION-SW-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DelegationSwConnector"))
-                    elif concrete_tag == "DEPENDENCY-ON-ARTIFACT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DependencyOnArtifact"))
-                    elif concrete_tag == "DEVELOPMENT-ERROR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DevelopmentError"))
-                    elif concrete_tag == "DIAG-EVENT-DEBOUNCE-COUNTER-BASED":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagEventDebounceCounterBased"))
-                    elif concrete_tag == "DIAG-EVENT-DEBOUNCE-MONITOR-INTERNAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagEventDebounceMonitorInternal"))
-                    elif concrete_tag == "DIAGNOSTIC-ACCESS-PERMISSION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAccessPermission"))
-                    elif concrete_tag == "DIAGNOSTIC-AGING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAging"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-ROLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthRole"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificate"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE-EVALUATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificateEvaluation"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificateMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTHENTICATION-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthenticationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTHENTICATION-CONFIGURATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthenticationConfiguration"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-DIAGNOSTIC-INFORMATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearDiagnosticInformation"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-DIAGNOSTIC-INFORMATION-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearDiagnosticInformationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-RESET-EMISSION-RELATED-INFO":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearResetEmissionRelatedInfo"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-RESET-EMISSION-RELATED-INFO-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearResetEmissionRelatedInfoClass"))
-                    elif concrete_tag == "DIAGNOSTIC-COM-CONTROL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComControl"))
-                    elif concrete_tag == "DIAGNOSTIC-COM-CONTROL-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-COMMUNICATION-MANAGER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCommunicationManagerNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-COMPONENT-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComponentNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-CONNECTED-INDICATOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticConnectedIndicator"))
-                    elif concrete_tag == "DIAGNOSTIC-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticConnection"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTRIBUTION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticContributionSet"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-D-T-C-SETTING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlDTCSetting"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-D-T-C-SETTING-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlDTCSettingClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-CUSTOM-SERVICE-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCustomServiceClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CUSTOM-SERVICE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCustomServiceInstance"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataElement"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-IDENTIFIER-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataIdentifierSet"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-TRANSFER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataTransfer"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-TRANSFER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataTransferClass"))
-                    elif concrete_tag == "DIAGNOSTIC-DE-AUTHENTICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDeAuthentication"))
-                    elif concrete_tag == "DIAGNOSTIC-DEBOUNCE-ALGORITHM-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDebounceAlgorithmProps"))
-                    elif concrete_tag == "DIAGNOSTIC-DEM-PROVIDED-DATA-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDemProvidedDataMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMIC-DATA-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMICALLY-DEFINE-DATA-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicallyDefineDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMICALLY-DEFINE-DATA-IDENTIFIER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicallyDefineDataIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-INSTANCE-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuInstanceProps"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-RESET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuReset"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-RESET-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuResetClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-PORT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-BSW-MODE-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvBswModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-MODE-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-SWC-MODE-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvSwcModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENVIRONMENTAL-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvironmentalCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-INFO-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventInfoNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-MANAGER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventManagerNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-PORT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-DEBOUNCE-ALGORITHM-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToDebounceAlgorithmMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-ENABLE-CONDITION-GROUP-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToEnableConditionGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-OPERATION-CYCLE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToOperationCycleMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-SECURITY-EVENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToSecurityEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-STORAGE-CONDITION-GROUP-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToStorageConditionGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-TROUBLE-CODE-J1939-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToTroubleCodeJ1939Mapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-TROUBLE-CODE-UDS-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToTroubleCodeUdsMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EXTENDED-DATA-RECORD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticExtendedDataRecord"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-GROUP-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-EVENT-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimEventGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-FUNCTION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimFunctionMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FREEZE-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-IDENTIFIER-INHIBIT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionIdentifierInhibit"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-INHIBIT-SOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionInhibitSource"))
-                    elif concrete_tag == "DIAGNOSTIC-I-O-CONTROL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIOControl"))
-                    elif concrete_tag == "DIAGNOSTIC-INDICATOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIndicator"))
-                    elif concrete_tag == "DIAGNOSTIC-INFO-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticInfoType"))
-                    elif concrete_tag == "DIAGNOSTIC-INHIBIT-SOURCE-EVENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticInhibitSourceEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-IO-CONTROL-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIoControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-IO-CONTROL-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIoControlNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumpr"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-DENOMINATOR-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprDenominatorGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-TO-FUNCTION-IDENTIFIER-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprToFunctionIdentifierMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-EXPANDED-FREEZE-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939ExpandedFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-FREEZE-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939FreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939Node"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SPN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939Spn"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SPN-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939SpnMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SW-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939SwMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-MASTER-TO-SLAVE-EVENT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMasterToSlaveEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-MEASUREMENT-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMeasurementIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-DESTINATION-PRIMARY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryDestinationPrimary"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-DESTINATION-USER-DEFINED":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryDestinationUserDefined"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCycle"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCycleNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE-PORT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCyclePortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterElement"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterIdent"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-POWERTRAIN-FREEZE-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticPowertrainFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-PROOF-OF-OWNERSHIP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticProofOfOwnership"))
-                    elif concrete_tag == "DIAGNOSTIC-PROTOCOL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticProtocol"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-D-T-C-INFORMATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDTCInformation"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-D-T-C-INFORMATION-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDTCInformationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-PERIODIC-ID":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByPeriodicID"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-PERIODIC-ID-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByPeriodicIDClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-MEMORY-BY-ADDRESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadMemoryByAddress"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-MEMORY-BY-ADDRESS-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadMemoryByAddressClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-SCALING-DATA-BY-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadScalingDataByIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-SCALING-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadScalingDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CONTROL-OF-ON-BOARD-DEVICE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestControlOfOnBoardDevice"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CONTROL-OF-ON-BOARD-DEVICE-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestControlOfOnBoardDeviceClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CURRENT-POWERTRAIN-DATA":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestCurrentPowertrainData"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CURRENT-POWERTRAIN-DATA-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestCurrentPowertrainDataClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-DOWNLOAD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestDownload"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-DOWNLOAD-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestDownloadClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTC"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-PERMANENT-STATUS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCPermanentStatus"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-PERMANENT-STATUS-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransfer"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransferClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransferNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ON-BOARD-MONITORING-TEST-RESULTS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestOnBoardMonitoringTestResults"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ON-BOARD-MONITORING-TEST-RESULTS-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestOnBoardMonitoringTestResultsClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-POWERTRAIN-FREEZE-FRAME-DATA":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestPowertrainFreezeFrameData"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-POWERTRAIN-FREEZE-FRAME-DATA-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestPowertrainFreezeFrameDataClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ROUTINE-RESULTS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestRoutineResults"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-UPLOAD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestUpload"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-UPLOAD-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestUploadClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-VEHICLE-INFO":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestVehicleInfo"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-VEHICLE-INFO-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestVehicleInfoClass"))
-                    elif concrete_tag == "DIAGNOSTIC-RESPONSE-ON-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticResponseOnEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-RESPONSE-ON-EVENT-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticResponseOnEventClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-CONTROL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineControl"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-CONTROL-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURE-CODING-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecureCodingMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-ACCESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityAccess"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-ACCESS-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityAccessClass"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-EVENT-REPORTING-MODE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityEventReportingModeMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-LEVEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityLevel"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-DATA-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceDataMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-SW-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceSwMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-TABLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceTable"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSession"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION-CONTROL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSessionControl"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION-CONTROL-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSessionControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-START-ROUTINE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStartRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-STOP-ROUTINE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStopRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-PORT-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-TEST-RESULT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTestResult"))
-                    elif concrete_tag == "DIAGNOSTIC-TEST-ROUTINE-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTestRoutineIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-TRANSFER-EXIT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTransferExit"))
-                    elif concrete_tag == "DIAGNOSTIC-TRANSFER-EXIT-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTransferExitClass"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-J1939":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeJ1939"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-OBD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeObd"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeProps"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-UDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeUds"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-UDS-TO-TROUBLE-CODE-OBD-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-UPLOAD-DOWNLOAD-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticUploadDownloadNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-VALUE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticValueNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-VERIFY-CERTIFICATE-BIDIRECTIONAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticVerifyCertificateBidirectional"))
-                    elif concrete_tag == "DIAGNOSTIC-WRITE-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticWriteDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-WRITE-MEMORY-BY-ADDRESS-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticWriteMemoryByAddressClass"))
-                    elif concrete_tag == "DIAGNOSTICS-COMMUNICATION-SECURITY-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticsCommunicationSecurityNeeds"))
-                    elif concrete_tag == "DLT-APPLICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltApplication"))
-                    elif concrete_tag == "DLT-ARGUMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltArgument"))
-                    elif concrete_tag == "DLT-CONTEXT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltContext"))
-                    elif concrete_tag == "DLT-ECU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltEcu"))
-                    elif concrete_tag == "DLT-LOG-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltLogChannel"))
-                    elif concrete_tag == "DLT-MESSAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltMessage"))
-                    elif concrete_tag == "DLT-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DltUserNeeds"))
-                    elif concrete_tag == "DO-IP-ACTIVATION-LINE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpActivationLineNeeds"))
-                    elif concrete_tag == "DO-IP-GID-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpGidNeeds"))
-                    elif concrete_tag == "DO-IP-GID-SYNCHRONIZATION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpGidSynchronizationNeeds"))
-                    elif concrete_tag == "DO-IP-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpInterface"))
-                    elif concrete_tag == "DO-IP-LOGIC-ADDRESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicAddress"))
-                    elif concrete_tag == "DO-IP-LOGIC-TARGET-ADDRESS-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicTargetAddressProps"))
-                    elif concrete_tag == "DO-IP-LOGIC-TESTER-ADDRESS-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicTesterAddressProps"))
-                    elif concrete_tag == "DO-IP-POWER-MODE-STATUS-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpPowerModeStatusNeeds"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivation"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION-AUTHENTICATION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivationAuthenticationNeeds"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION-CONFIRMATION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivationConfirmationNeeds"))
-                    elif concrete_tag == "DO-IP-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DoIpTpConfig"))
-                    elif concrete_tag == "DOCUMENT-ELEMENT-SCOPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DocumentElementScope"))
-                    elif concrete_tag == "DOCUMENTATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Documentation"))
-                    elif concrete_tag == "DOCUMENTATION-CONTEXT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DocumentationContext"))
-                    elif concrete_tag == "DTC-STATUS-CHANGE-NOTIFICATION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "DtcStatusChangeNotificationNeeds"))
-                    elif concrete_tag == "E2-E-PROFILE-COMPATIBILITY-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "E2EProfileCompatibilityProps"))
-                    elif concrete_tag == "E-C-U-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ECUMapping"))
-                    elif concrete_tag == "E-O-C-EVENT-REF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EOCEventRef"))
-                    elif concrete_tag == "E-O-C-EXECUTABLE-ENTITY-REF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EOCExecutableEntityRef"))
-                    elif concrete_tag == "E-O-C-EXECUTABLE-ENTITY-REF-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EOCExecutableEntityRefGroup"))
-                    elif concrete_tag == "ECU-ABSTRACTION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcuAbstractionSwComponentType"))
-                    elif concrete_tag == "ECU-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcuInstance"))
-                    elif concrete_tag == "ECU-PARTITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcuPartition"))
-                    elif concrete_tag == "ECU-STATE-MGR-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcuStateMgrUserNeeds"))
-                    elif concrete_tag == "ECU-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcuTiming"))
-                    elif concrete_tag == "ECUC-ADD-INFO-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucAddInfoParamDef"))
-                    elif concrete_tag == "ECUC-BOOLEAN-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucBooleanParamDef"))
-                    elif concrete_tag == "ECUC-CHOICE-CONTAINER-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucChoiceContainerDef"))
-                    elif concrete_tag == "ECUC-CHOICE-REFERENCE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucChoiceReferenceDef"))
-                    elif concrete_tag == "ECUC-CONTAINER-VALUE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucContainerValue"))
-                    elif concrete_tag == "ECUC-DEFINITION-COLLECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucDefinitionCollection"))
-                    elif concrete_tag == "ECUC-DESTINATION-URI-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucDestinationUriDef"))
-                    elif concrete_tag == "ECUC-DESTINATION-URI-DEF-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucDestinationUriDefSet"))
-                    elif concrete_tag == "ECUC-ENUMERATION-LITERAL-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucEnumerationLiteralDef"))
-                    elif concrete_tag == "ECUC-ENUMERATION-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucEnumerationParamDef"))
-                    elif concrete_tag == "ECUC-FLOAT-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucFloatParamDef"))
-                    elif concrete_tag == "ECUC-FOREIGN-REFERENCE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucForeignReferenceDef"))
-                    elif concrete_tag == "ECUC-FUNCTION-NAME-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucFunctionNameDef"))
-                    elif concrete_tag == "ECUC-INSTANCE-REFERENCE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucInstanceReferenceDef"))
-                    elif concrete_tag == "ECUC-INTEGER-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucIntegerParamDef"))
-                    elif concrete_tag == "ECUC-LINKER-SYMBOL-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucLinkerSymbolDef"))
-                    elif concrete_tag == "ECUC-MODULE-CONFIGURATION-VALUES":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucModuleConfigurationValues"))
-                    elif concrete_tag == "ECUC-MODULE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucModuleDef"))
-                    elif concrete_tag == "ECUC-MULTILINE-STRING-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucMultilineStringParamDef"))
-                    elif concrete_tag == "ECUC-PARAM-CONF-CONTAINER-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucParamConfContainerDef"))
-                    elif concrete_tag == "ECUC-QUERY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucQuery"))
-                    elif concrete_tag == "ECUC-REFERENCE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucReferenceDef"))
-                    elif concrete_tag == "ECUC-STRING-PARAM-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucStringParamDef"))
-                    elif concrete_tag == "ECUC-URI-REFERENCE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucUriReferenceDef"))
-                    elif concrete_tag == "ECUC-VALIDATION-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucValidationCondition"))
-                    elif concrete_tag == "ECUC-VALUE-COLLECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EcucValueCollection"))
-                    elif concrete_tag == "END-TO-END-PROTECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EndToEndProtection"))
-                    elif concrete_tag == "END-TO-END-PROTECTION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EndToEndProtectionSet"))
-                    elif concrete_tag == "ENUMERATION-MAPPING-TABLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EnumerationMappingTable"))
-                    elif concrete_tag == "ERROR-TRACER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ErrorTracerNeeds"))
-                    elif concrete_tag == "ETH-IP-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthIpProps"))
-                    elif concrete_tag == "ETH-TCP-IP-ICMP-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthTcpIpIcmpProps"))
-                    elif concrete_tag == "ETH-TCP-IP-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthTcpIpProps"))
-                    elif concrete_tag == "ETH-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthTpConfig"))
-                    elif concrete_tag == "ETHERNET-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetCluster"))
-                    elif concrete_tag == "ETHERNET-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetCommunicationConnector"))
-                    elif concrete_tag == "ETHERNET-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetCommunicationController"))
-                    elif concrete_tag == "ETHERNET-FRAME-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetFrameTriggering"))
-                    elif concrete_tag == "ETHERNET-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetPhysicalChannel"))
-                    elif concrete_tag == "ETHERNET-PRIORITY-REGENERATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetPriorityRegeneration"))
-                    elif concrete_tag == "ETHERNET-WAKEUP-SLEEP-ON-DATALINE-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetWakeupSleepOnDatalineConfig"))
-                    elif concrete_tag == "ETHERNET-WAKEUP-SLEEP-ON-DATALINE-CONFIG-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EthernetWakeupSleepOnDatalineConfigSet"))
-                    elif concrete_tag == "EVALUATED-VARIANT-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EvaluatedVariantSet"))
-                    elif concrete_tag == "EVENT-HANDLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "EventHandler"))
-                    elif concrete_tag == "EXCLUSIVE-AREA":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExclusiveArea"))
-                    elif concrete_tag == "EXCLUSIVE-AREA-NESTING-ORDER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExclusiveAreaNestingOrder"))
-                    elif concrete_tag == "EXECUTABLE-ENTITY-ACTIVATION-REASON":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExecutableEntityActivationReason"))
-                    elif concrete_tag == "EXECUTION-ORDER-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExecutionOrderConstraint"))
-                    elif concrete_tag == "EXECUTION-TIME-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExecutionTimeConstraint"))
-                    elif concrete_tag == "EXTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExternalTriggerOccurredEvent"))
-                    elif concrete_tag == "EXTERNAL-TRIGGERING-POINT-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ExternalTriggeringPointIdent"))
-                    elif concrete_tag == "F-M-ATTRIBUTE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMAttributeDef"))
-                    elif concrete_tag == "F-M-FEATURE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeature"))
-                    elif concrete_tag == "F-M-FEATURE-MAP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMap"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-ASSERTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapAssertion"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapCondition"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapElement"))
-                    elif concrete_tag == "F-M-FEATURE-MODEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureModel"))
-                    elif concrete_tag == "F-M-FEATURE-RELATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureRelation"))
-                    elif concrete_tag == "F-M-FEATURE-RESTRICTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureRestriction"))
-                    elif concrete_tag == "F-M-FEATURE-SELECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureSelection"))
-                    elif concrete_tag == "F-M-FEATURE-SELECTION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureSelectionSet"))
-                    elif concrete_tag == "FIREWALL-RULE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FirewallRule"))
-                    elif concrete_tag == "FLAT-INSTANCE-DESCRIPTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlatInstanceDescriptor"))
-                    elif concrete_tag == "FLAT-MAP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlatMap"))
-                    elif concrete_tag == "FLEXRAY-AR-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayArTpConfig"))
-                    elif concrete_tag == "FLEXRAY-AR-TP-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayArTpNode"))
-                    elif concrete_tag == "FLEXRAY-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCluster"))
-                    elif concrete_tag == "FLEXRAY-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCommunicationConnector"))
-                    elif concrete_tag == "FLEXRAY-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCommunicationController"))
-                    elif concrete_tag == "FLEXRAY-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayFrame"))
-                    elif concrete_tag == "FLEXRAY-FRAME-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayFrameTriggering"))
-                    elif concrete_tag == "FLEXRAY-NM-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayNmCluster"))
-                    elif concrete_tag == "FLEXRAY-NM-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayNmNode"))
-                    elif concrete_tag == "FLEXRAY-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayPhysicalChannel"))
-                    elif concrete_tag == "FLEXRAY-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpConfig"))
-                    elif concrete_tag == "FLEXRAY-TP-CONNECTION-CONTROL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpConnectionControl"))
-                    elif concrete_tag == "FLEXRAY-TP-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpNode"))
-                    elif concrete_tag == "FLEXRAY-TP-PDU-POOL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpPduPool"))
-                    elif concrete_tag == "FRAME-PORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FramePort"))
-                    elif concrete_tag == "FUNCTION-INHIBITION-AVAILABILITY-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FunctionInhibitionAvailabilityNeeds"))
-                    elif concrete_tag == "FUNCTION-INHIBITION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "FunctionInhibitionNeeds"))
-                    elif concrete_tag == "GATEWAY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Gateway"))
-                    elif concrete_tag == "GENERAL-PURPOSE-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposeConnection"))
-                    elif concrete_tag == "GENERAL-PURPOSE-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposeIPdu"))
-                    elif concrete_tag == "GENERAL-PURPOSE-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposePdu"))
-                    elif concrete_tag == "GENERIC-ETHERNET-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GenericEthernetFrame"))
-                    elif concrete_tag == "GLOBAL-SUPERVISION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalSupervisionNeeds"))
-                    elif concrete_tag == "GLOBAL-TIME-CAN-MASTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeCanMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-CAN-SLAVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeCanSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-DOMAIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeDomain"))
-                    elif concrete_tag == "GLOBAL-TIME-ETH-MASTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeEthMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-ETH-SLAVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeEthSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-FR-MASTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeFrMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-FR-SLAVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeFrSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-GATEWAY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeGateway"))
-                    elif concrete_tag == "HARDWARE-TEST-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HardwareTestNeeds"))
-                    elif concrete_tag == "HW-ATTRIBUTE-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwAttributeDef"))
-                    elif concrete_tag == "HW-ATTRIBUTE-LITERAL-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwAttributeLiteralDef"))
-                    elif concrete_tag == "HW-CATEGORY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwCategory"))
-                    elif concrete_tag == "HW-DESCRIPTION-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwDescriptionEntity"))
-                    elif concrete_tag == "HW-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwElement"))
-                    elif concrete_tag == "HW-PIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwPin"))
-                    elif concrete_tag == "HW-PIN-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwPinGroup"))
-                    elif concrete_tag == "HW-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "HwType"))
-                    elif concrete_tag == "I-E-E-E1722-TP-AAF-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAafConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CAN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfCan"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CAN-PART":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfCanPart"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-LIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfLin"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-LIN-PART":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfLinPart"))
-                    elif concrete_tag == "I-E-E-E1722-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpConfig"))
-                    elif concrete_tag == "I-E-E-E1722-TP-CRF-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpCrfConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-IIDC-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpIidcConnection"))
-                    elif concrete_tag == "I-P-SEC-CONFIG-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IPSecConfigProps"))
-                    elif concrete_tag == "I-P-SEC-RULE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IPSecRule"))
-                    elif concrete_tag == "I-PDU-PORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IPduPort"))
-                    elif concrete_tag == "I-PV6-EXT-HEADER-FILTER-LIST":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IPv6ExtHeaderFilterList"))
-                    elif concrete_tag == "I-PV6-EXT-HEADER-FILTER-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IPv6ExtHeaderFilterSet"))
-                    elif concrete_tag == "I-SIGNAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignal"))
-                    elif concrete_tag == "I-SIGNAL-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalGroup"))
-                    elif concrete_tag == "I-SIGNAL-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalIPdu"))
-                    elif concrete_tag == "I-SIGNAL-I-PDU-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalIPduGroup"))
-                    elif concrete_tag == "I-SIGNAL-PORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalPort"))
-                    elif concrete_tag == "I-SIGNAL-TO-I-PDU-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalToIPduMapping"))
-                    elif concrete_tag == "I-SIGNAL-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ISignalTriggering"))
-                    elif concrete_tag == "IDS-DESIGN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IdsDesign"))
-                    elif concrete_tag == "IDS-MGR-CUSTOM-TIMESTAMP-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IdsMgrCustomTimestampNeeds"))
-                    elif concrete_tag == "IDS-MGR-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IdsMgrNeeds"))
-                    elif concrete_tag == "IDSM-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IdsmInstance"))
-                    elif concrete_tag == "IDSM-PROPERTIES":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IdsmProperties"))
-                    elif concrete_tag == "IEEE1722-TP-ETHERNET-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Ieee1722TpEthernetFrame"))
-                    elif concrete_tag == "IMPLEMENTATION-DATA-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ImplementationDataType"))
-                    elif concrete_tag == "IMPLEMENTATION-DATA-TYPE-ELEMENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ImplementationDataTypeElement"))
-                    elif concrete_tag == "IMPLEMENTATION-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ImplementationProps"))
-                    elif concrete_tag == "IMPOSITION-TIME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ImpositionTime"))
-                    elif concrete_tag == "INDICATOR-STATUS-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "IndicatorStatusNeeds"))
-                    elif concrete_tag == "INIT-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "InitEvent"))
-                    elif concrete_tag == "INTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "InternalTriggerOccurredEvent"))
-                    elif concrete_tag == "INTERNAL-TRIGGERING-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "InternalTriggeringPoint"))
-                    elif concrete_tag == "INTERPOLATION-ROUTINE-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "InterpolationRoutineMappingSet"))
-                    elif concrete_tag == "J1939-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939Cluster"))
-                    elif concrete_tag == "J1939-CONTROLLER-APPLICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939ControllerApplication"))
-                    elif concrete_tag == "J1939-DCM-DM19-SUPPORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939DcmDm19Support"))
-                    elif concrete_tag == "J1939-DCM-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939DcmIPdu"))
-                    elif concrete_tag == "J1939-NM-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939NmCluster"))
-                    elif concrete_tag == "J1939-NM-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939NmNode"))
-                    elif concrete_tag == "J1939-RM-INCOMING-REQUEST-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939RmIncomingRequestServiceNeeds"))
-                    elif concrete_tag == "J1939-RM-OUTGOING-REQUEST-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939RmOutgoingRequestServiceNeeds"))
-                    elif concrete_tag == "J1939-SHARED-ADDRESS-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939SharedAddressCluster"))
-                    elif concrete_tag == "J1939-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939TpConfig"))
-                    elif concrete_tag == "J1939-TP-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "J1939TpNode"))
-                    elif concrete_tag == "KEYWORD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Keyword"))
-                    elif concrete_tag == "KEYWORD-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "KeywordSet"))
-                    elif concrete_tag == "LATENCY-TIMING-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LatencyTimingConstraint"))
-                    elif concrete_tag == "LIFE-CYCLE-INFO-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleInfoSet"))
-                    elif concrete_tag == "LIFE-CYCLE-STATE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleState"))
-                    elif concrete_tag == "LIFE-CYCLE-STATE-DEFINITION-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleStateDefinitionGroup"))
-                    elif concrete_tag == "LIN-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinCluster"))
-                    elif concrete_tag == "LIN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinCommunicationConnector"))
-                    elif concrete_tag == "LIN-EVENT-TRIGGERED-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinEventTriggeredFrame"))
-                    elif concrete_tag == "LIN-FRAME-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinFrameTriggering"))
-                    elif concrete_tag == "LIN-MASTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinMaster"))
-                    elif concrete_tag == "LIN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinPhysicalChannel"))
-                    elif concrete_tag == "LIN-SCHEDULE-TABLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinScheduleTable"))
-                    elif concrete_tag == "LIN-SLAVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinSlave"))
-                    elif concrete_tag == "LIN-SLAVE-CONFIG-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinSlaveConfigIdent"))
-                    elif concrete_tag == "LIN-SPORADIC-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinSporadicFrame"))
-                    elif concrete_tag == "LIN-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinTpConfig"))
-                    elif concrete_tag == "LIN-TP-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinTpNode"))
-                    elif concrete_tag == "LIN-UNCONDITIONAL-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LinUnconditionalFrame"))
-                    elif concrete_tag == "LINKER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Linker"))
-                    elif concrete_tag == "LOG-AND-TRACE-MESSAGE-COLLECTION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "LogAndTraceMessageCollectionSet"))
-                    elif concrete_tag == "MAC-MULTICAST-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MacMulticastGroup"))
-                    elif concrete_tag == "MAC-SEC-GLOBAL-KAY-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MacSecGlobalKayProps"))
-                    elif concrete_tag == "MAC-SEC-KAY-PARTICIPANT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MacSecKayParticipant"))
-                    elif concrete_tag == "MAC-SEC-PARTICIPANT-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MacSecParticipantSet"))
-                    elif concrete_tag == "MC-DATA-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "McDataInstance"))
-                    elif concrete_tag == "MC-FUNCTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "McFunction"))
-                    elif concrete_tag == "MC-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "McGroup"))
-                    elif concrete_tag == "MEASURED-EXECUTION-TIME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MeasuredExecutionTime"))
-                    elif concrete_tag == "MEASURED-HEAP-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MeasuredHeapUsage"))
-                    elif concrete_tag == "MEASURED-STACK-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MeasuredStackUsage"))
-                    elif concrete_tag == "MEMORY-SECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MemorySection"))
-                    elif concrete_tag == "MODE-ACCESS-POINT-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeAccessPointIdent"))
-                    elif concrete_tag == "MODE-DECLARATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclaration"))
-                    elif concrete_tag == "MODE-DECLARATION-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationGroup"))
-                    elif concrete_tag == "MODE-DECLARATION-GROUP-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationGroupPrototype"))
-                    elif concrete_tag == "MODE-DECLARATION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationMapping"))
-                    elif concrete_tag == "MODE-DECLARATION-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationMappingSet"))
-                    elif concrete_tag == "MODE-INTERFACE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeInterfaceMapping"))
-                    elif concrete_tag == "MODE-SWITCH-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchInterface"))
-                    elif concrete_tag == "MODE-SWITCH-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchPoint"))
-                    elif concrete_tag == "MODE-SWITCHED-ACK-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchedAckEvent"))
-                    elif concrete_tag == "MODE-TRANSITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ModeTransition"))
-                    elif concrete_tag == "MULTILANGUAGE-REFERRABLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MultilanguageReferrable"))
-                    elif concrete_tag == "MULTIPLEXED-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "MultiplexedIPdu"))
-                    elif concrete_tag == "N-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NPdu"))
-                    elif concrete_tag == "NETWORK-ENDPOINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NetworkEndpoint"))
-                    elif concrete_tag == "NM-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NmConfig"))
-                    elif concrete_tag == "NM-ECU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NmEcu"))
-                    elif concrete_tag == "NM-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NmPdu"))
-                    elif concrete_tag == "NV-BLOCK-DESCRIPTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NvBlockDescriptor"))
-                    elif concrete_tag == "NV-BLOCK-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NvBlockNeeds"))
-                    elif concrete_tag == "NV-BLOCK-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NvBlockSwComponentType"))
-                    elif concrete_tag == "NV-DATA-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "NvDataInterface"))
-                    elif concrete_tag == "OBD-CONTROL-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdControlServiceNeeds"))
-                    elif concrete_tag == "OBD-INFO-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdInfoServiceNeeds"))
-                    elif concrete_tag == "OBD-MONITOR-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdMonitorServiceNeeds"))
-                    elif concrete_tag == "OBD-PID-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdPidServiceNeeds"))
-                    elif concrete_tag == "OBD-RATIO-DENOMINATOR-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdRatioDenominatorNeeds"))
-                    elif concrete_tag == "OBD-RATIO-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ObdRatioServiceNeeds"))
-                    elif concrete_tag == "OFFSET-TIMING-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "OffsetTimingConstraint"))
-                    elif concrete_tag == "OPERATION-INVOKED-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "OperationInvokedEvent"))
-                    elif concrete_tag == "OS-TASK-EXECUTION-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "OsTaskExecutionEvent"))
-                    elif concrete_tag == "OS-TASK-PROXY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "OsTaskProxy"))
-                    elif concrete_tag == "P-PORT-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PPortPrototype"))
-                    elif concrete_tag == "P-R-PORT-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PRPortPrototype"))
-                    elif concrete_tag == "PARAMETER-ACCESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ParameterAccess"))
-                    elif concrete_tag == "PARAMETER-DATA-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ParameterDataPrototype"))
-                    elif concrete_tag == "PARAMETER-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ParameterInterface"))
-                    elif concrete_tag == "PARAMETER-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ParameterSwComponentType"))
-                    elif concrete_tag == "PASS-THROUGH-SW-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PassThroughSwConnector"))
-                    elif concrete_tag == "PDU-ACTIVATION-ROUTING-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PduActivationRoutingGroup"))
-                    elif concrete_tag == "PDU-TO-FRAME-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PduToFrameMapping"))
-                    elif concrete_tag == "PDU-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PduTriggering"))
-                    elif concrete_tag == "PDUR-I-PDU-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PdurIPduGroup"))
-                    elif concrete_tag == "PER-INSTANCE-MEMORY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PerInstanceMemory"))
-                    elif concrete_tag == "PERIODIC-EVENT-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PeriodicEventTriggering"))
-                    elif concrete_tag == "PHYSICAL-DIMENSION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PhysicalDimension"))
-                    elif concrete_tag == "PHYSICAL-DIMENSION-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PhysicalDimensionMappingSet"))
-                    elif concrete_tag == "PNC-MAPPING-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PncMappingIdent"))
-                    elif concrete_tag == "PORT-ELEMENT-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PortElementToCommunicationResourceMapping"))
-                    elif concrete_tag == "PORT-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PortGroup"))
-                    elif concrete_tag == "PORT-INTERFACE-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PortInterfaceMappingSet"))
-                    elif concrete_tag == "PORT-PROTOTYPE-BLUEPRINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PortPrototypeBlueprint"))
-                    elif concrete_tag == "POST-BUILD-VARIANT-CRITERION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PostBuildVariantCriterion"))
-                    elif concrete_tag == "POST-BUILD-VARIANT-CRITERION-VALUE-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PostBuildVariantCriterionValueSet"))
-                    elif concrete_tag == "PREDEFINED-VARIANT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PredefinedVariant"))
-                    elif concrete_tag == "PRIMITIVE-ATTRIBUTE-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "PrimitiveAttributeTailoring"))
-                    elif concrete_tag == "PROVIDED-SERVICE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ProvidedServiceInstance"))
-                    elif concrete_tag == "R-PORT-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RPortPrototype"))
-                    elif concrete_tag == "RAPID-PROTOTYPING-SCENARIO":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RapidPrototypingScenario"))
-                    elif concrete_tag == "REFERENCE-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ReferenceTailoring"))
-                    elif concrete_tag == "RESOURCE-CONSUMPTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ResourceConsumption"))
-                    elif concrete_tag == "ROOT-SW-COMPOSITION-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RootSwCompositionPrototype"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-HEAP-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateHeapUsage"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-OF-EXECUTION-TIME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateOfExecutionTime"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-STACK-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateStackUsage"))
-                    elif concrete_tag == "RPT-COMPONENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptComponent"))
-                    elif concrete_tag == "RPT-CONTAINER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptContainer"))
-                    elif concrete_tag == "RPT-EXECUTABLE-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptExecutableEntity"))
-                    elif concrete_tag == "RPT-EXECUTABLE-ENTITY-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptExecutableEntityEvent"))
-                    elif concrete_tag == "RPT-EXECUTION-CONTEXT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptExecutionContext"))
-                    elif concrete_tag == "RPT-PROFILE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptProfile"))
-                    elif concrete_tag == "RPT-SERVICE-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RptServicePoint"))
-                    elif concrete_tag == "RTE-EVENT-IN-COMPOSITION-SEPARATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RteEventInCompositionSeparation"))
-                    elif concrete_tag == "RTE-EVENT-IN-COMPOSITION-TO-OS-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RteEventInCompositionToOsTaskProxyMapping"))
-                    elif concrete_tag == "RTE-EVENT-IN-SYSTEM-SEPARATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RteEventInSystemSeparation"))
-                    elif concrete_tag == "RTE-EVENT-IN-SYSTEM-TO-OS-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RteEventInSystemToOsTaskProxyMapping"))
-                    elif concrete_tag == "RUNNABLE-ENTITY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RunnableEntity"))
-                    elif concrete_tag == "RUNNABLE-ENTITY-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RunnableEntityGroup"))
-                    elif concrete_tag == "RUNTIME-ERROR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "RuntimeError"))
-                    elif concrete_tag == "S-O-M-E-I-P-TRANSFORMATION-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SOMEIPTransformationProps"))
-                    elif concrete_tag == "SDG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Sdg"))
-                    elif concrete_tag == "SDG-AGGREGATION-WITH-VARIATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgAggregationWithVariation"))
-                    elif concrete_tag == "SDG-CAPTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgCaption"))
-                    elif concrete_tag == "SDG-CLASS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgClass"))
-                    elif concrete_tag == "SDG-DEF":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgDef"))
-                    elif concrete_tag == "SDG-FOREIGN-REFERENCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgForeignReference"))
-                    elif concrete_tag == "SDG-FOREIGN-REFERENCE-WITH-VARIATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgForeignReferenceWithVariation"))
-                    elif concrete_tag == "SDG-PRIMITIVE-ATTRIBUTE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgPrimitiveAttribute"))
-                    elif concrete_tag == "SDG-PRIMITIVE-ATTRIBUTE-WITH-VARIATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgPrimitiveAttributeWithVariation"))
-                    elif concrete_tag == "SDG-TAILORING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SdgTailoring"))
-                    elif concrete_tag == "SEC-OC-CRYPTO-SERVICE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecOcCryptoServiceMapping"))
-                    elif concrete_tag == "SECTION-NAME-PREFIX":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SectionNamePrefix"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-AUTHENTICATION-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationAuthenticationProps"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-FRESHNESS-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationFreshnessProps"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-PROPS-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationPropsSet"))
-                    elif concrete_tag == "SECURE-ON-BOARD-COMMUNICATION-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecureOnBoardCommunicationNeeds"))
-                    elif concrete_tag == "SECURED-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecuredIPdu"))
-                    elif concrete_tag == "SECURITY-EVENT-AGGREGATION-FILTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventAggregationFilter"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-APPLICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingApplication"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-BSW-MODULE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingBswModule"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-COMM-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingCommConnector"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-FUNCTIONAL-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingFunctionalCluster"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextProps"))
-                    elif concrete_tag == "SECURITY-EVENT-DEFINITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventDefinition"))
-                    elif concrete_tag == "SECURITY-EVENT-FILTER-CHAIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventFilterChain"))
-                    elif concrete_tag == "SECURITY-EVENT-ONE-EVERY-N-FILTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventOneEveryNFilter"))
-                    elif concrete_tag == "SECURITY-EVENT-STATE-FILTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventStateFilter"))
-                    elif concrete_tag == "SENDER-RECEIVER-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SenderReceiverInterface"))
-                    elif concrete_tag == "SENSOR-ACTUATOR-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SensorActuatorSwComponentType"))
-                    elif concrete_tag == "SERVICE-INSTANCE-COLLECTION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ServiceInstanceCollectionSet"))
-                    elif concrete_tag == "SERVICE-PROXY-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ServiceProxySwComponentType"))
-                    elif concrete_tag == "SERVICE-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ServiceSwComponentType"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-ELEMENT-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationElementProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-EVENT-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationEventProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-PROPS-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationPropsSet"))
-                    elif concrete_tag == "SINGLE-LANGUAGE-REFERRABLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SingleLanguageReferrable"))
-                    elif concrete_tag == "SO-AD-ROUTING-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SoAdRoutingGroup"))
-                    elif concrete_tag == "SO-CON-I-PDU-IDENTIFIER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SoConIPduIdentifier"))
-                    elif concrete_tag == "SOCKET-ADDRESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SocketAddress"))
-                    elif concrete_tag == "SOCKET-CONNECTION-BUNDLE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SocketConnectionBundle"))
-                    elif concrete_tag == "SOCKET-CONNECTION-IPDU-IDENTIFIER-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SocketConnectionIpduIdentifierSet"))
-                    elif concrete_tag == "SOMEIP-SD-CLIENT-SERVICE-INSTANCE-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdClientServiceInstanceConfig"))
-                    elif concrete_tag == "SOMEIP-SD-SERVER-EVENT-GROUP-TIMING-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdServerEventGroupTimingConfig"))
-                    elif concrete_tag == "SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdServerServiceInstanceConfig"))
-                    elif concrete_tag == "SOMEIP-TP-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SomeipTpChannel"))
-                    elif concrete_tag == "SOMEIP-TP-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SomeipTpConfig"))
-                    elif concrete_tag == "SPECIFICATION-DOCUMENT-SCOPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SpecificationDocumentScope"))
-                    elif concrete_tag == "SPORADIC-EVENT-TRIGGERING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SporadicEventTriggering"))
-                    elif concrete_tag == "STATIC-SOCKET-CONNECTION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "StaticSocketConnection"))
-                    elif concrete_tag == "STD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Std"))
-                    elif concrete_tag == "STRUCTURED-REQ":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "StructuredReq"))
-                    elif concrete_tag == "SUPERVISED-ENTITY-CHECKPOINT-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SupervisedEntityCheckpointNeeds"))
-                    elif concrete_tag == "SUPERVISED-ENTITY-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SupervisedEntityNeeds"))
-                    elif concrete_tag == "SW-ADDR-METHOD":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwAddrMethod"))
-                    elif concrete_tag == "SW-AXIS-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwAxisType"))
-                    elif concrete_tag == "SW-BASE-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwBaseType"))
-                    elif concrete_tag == "SW-GENERIC-AXIS-PARAM-TYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwGenericAxisParamType"))
-                    elif concrete_tag == "SW-RECORD-LAYOUT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwRecordLayout"))
-                    elif concrete_tag == "SW-SERVICE-ARG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwServiceArg"))
-                    elif concrete_tag == "SW-SYSTEMCONST":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwSystemconst"))
-                    elif concrete_tag == "SW-SYSTEMCONSTANT-VALUE-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwSystemconstantValueSet"))
-                    elif concrete_tag == "SWC-BSW-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcBswMapping"))
-                    elif concrete_tag == "SWC-IMPLEMENTATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcImplementation"))
-                    elif concrete_tag == "SWC-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcInternalBehavior"))
-                    elif concrete_tag == "SWC-MODE-MANAGER-ERROR-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcModeManagerErrorEvent"))
-                    elif concrete_tag == "SWC-MODE-SWITCH-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcModeSwitchEvent"))
-                    elif concrete_tag == "SWC-SERVICE-DEPENDENCY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcServiceDependency"))
-                    elif concrete_tag == "SWC-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcTiming"))
-                    elif concrete_tag == "SWC-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcToApplicationPartitionMapping"))
-                    elif concrete_tag == "SWC-TO-ECU-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcToEcuMapping"))
-                    elif concrete_tag == "SWC-TO-IMPL-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwcToImplMapping"))
-                    elif concrete_tag == "SWITCH-ASYNCHRONOUS-TRAFFIC-SHAPER-GROUP-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchAsynchronousTrafficShaperGroupEntry"))
-                    elif concrete_tag == "SWITCH-FLOW-METERING-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchFlowMeteringEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-ACTION-DEST-PORT-MODIFICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterActionDestPortModification"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-RULE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterRule"))
-                    elif concrete_tag == "SWITCH-STREAM-GATE-ENTRY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamGateEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-IDENTIFICATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamIdentification"))
-                    elif concrete_tag == "SYMBOL-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SymbolProps"))
-                    elif concrete_tag == "SYNC-TIME-BASE-MGR-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SyncTimeBaseMgrUserNeeds"))
-                    elif concrete_tag == "SYNCHRONIZATION-POINT-CONSTRAINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SynchronizationPointConstraint"))
-                    elif concrete_tag == "SYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SynchronousServerCallPoint"))
-                    elif concrete_tag == "SYSTEM":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "System"))
-                    elif concrete_tag == "SYSTEM-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemMapping"))
-                    elif concrete_tag == "SYSTEM-SIGNAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemSignal"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalGroup"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-GROUP-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalGroupToCommunicationResourceMapping"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalToCommunicationResourceMapping"))
-                    elif concrete_tag == "SYSTEM-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "SystemTiming"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterMapping"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-MAPPING-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterMappingSet"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-RESOURCE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterResourceMapping"))
-                    elif concrete_tag == "T-D-EVENT-BSW-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswInternalBehavior"))
-                    elif concrete_tag == "T-D-EVENT-BSW-MODE-DECLARATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswModeDeclaration"))
-                    elif concrete_tag == "T-D-EVENT-BSW-MODULE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswModule"))
-                    elif concrete_tag == "T-D-EVENT-COMPLEX":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventComplex"))
-                    elif concrete_tag == "T-D-EVENT-FR-CLUSTER-CYCLE-START":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrClusterCycleStart"))
-                    elif concrete_tag == "T-D-EVENT-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrame"))
-                    elif concrete_tag == "T-D-EVENT-FRAME-ETHERNET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrameEthernet"))
-                    elif concrete_tag == "T-D-EVENT-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventIPdu"))
-                    elif concrete_tag == "T-D-EVENT-I-SIGNAL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventISignal"))
-                    elif concrete_tag == "T-D-EVENT-MODE-DECLARATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventModeDeclaration"))
-                    elif concrete_tag == "T-D-EVENT-OPERATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventOperation"))
-                    elif concrete_tag == "T-D-EVENT-S-L-L-E-T-PORT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventSLLETPort"))
-                    elif concrete_tag == "T-D-EVENT-SWC-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventSwcInternalBehavior"))
-                    elif concrete_tag == "T-D-EVENT-SWC-INTERNAL-BEHAVIOR-REFERENCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventSwcInternalBehaviorReference"))
-                    elif concrete_tag == "T-D-EVENT-T-T-CAN-CYCLE-START":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventTTCanCycleStart"))
-                    elif concrete_tag == "T-D-EVENT-TRIGGER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventTrigger"))
-                    elif concrete_tag == "T-D-EVENT-VARIABLE-DATA-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventVariableDataPrototype"))
-                    elif concrete_tag == "T-D-EVENT-VFB-REFERENCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDEventVfbReference"))
-                    elif concrete_tag == "T-D-L-E-T-ZONE-CLOCK":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TDLETZoneClock"))
-                    elif concrete_tag == "TCP-OPTION-FILTER-LIST":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TcpOptionFilterList"))
-                    elif concrete_tag == "TCP-OPTION-FILTER-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TcpOptionFilterSet"))
-                    elif concrete_tag == "TIME-SYNC-SERVER-CONFIGURATION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimeSyncServerConfiguration"))
-                    elif concrete_tag == "TIMING-CLOCK-SYNC-ACCURACY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingClockSyncAccuracy"))
-                    elif concrete_tag == "TIMING-CONDITION":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingCondition"))
-                    elif concrete_tag == "TIMING-DESCRIPTION-EVENT-CHAIN":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingDescriptionEventChain"))
-                    elif concrete_tag == "TIMING-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingEvent"))
-                    elif concrete_tag == "TIMING-EXTENSION-RESOURCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingExtensionResource"))
-                    elif concrete_tag == "TIMING-MODE-INSTANCE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TimingModeInstance"))
-                    elif concrete_tag == "TLS-CRYPTO-CIPHER-SUITE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoCipherSuite"))
-                    elif concrete_tag == "TLS-CRYPTO-CIPHER-SUITE-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoCipherSuiteProps"))
-                    elif concrete_tag == "TLS-CRYPTO-SERVICE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoServiceMapping"))
-                    elif concrete_tag == "TLV-DATA-ID-DEFINITION-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TlvDataIdDefinitionSet"))
-                    elif concrete_tag == "TOPIC1":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Topic1"))
-                    elif concrete_tag == "TP-ADDRESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TpAddress"))
-                    elif concrete_tag == "TP-CONNECTION-IDENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TpConnectionIdent"))
-                    elif concrete_tag == "TRACEABLE-TEXT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TraceableText"))
-                    elif concrete_tag == "TRANSFORMATION-PROPS-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TransformationPropsSet"))
-                    elif concrete_tag == "TRANSFORMATION-TECHNOLOGY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TransformationTechnology"))
-                    elif concrete_tag == "TRANSFORMER-HARD-ERROR-EVENT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TransformerHardErrorEvent"))
-                    elif concrete_tag == "TRANSIENT-FAULT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TransientFault"))
-                    elif concrete_tag == "TRIGGER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Trigger"))
-                    elif concrete_tag == "TRIGGER-INTERFACE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TriggerInterface"))
-                    elif concrete_tag == "TRIGGER-INTERFACE-MAPPING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TriggerInterfaceMapping"))
-                    elif concrete_tag == "TTCAN-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TtcanCluster"))
-                    elif concrete_tag == "TTCAN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TtcanCommunicationConnector"))
-                    elif concrete_tag == "TTCAN-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TtcanCommunicationController"))
-                    elif concrete_tag == "TTCAN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "TtcanPhysicalChannel"))
-                    elif concrete_tag == "UDP-NM-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UdpNmCluster"))
-                    elif concrete_tag == "UDP-NM-NODE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UdpNmNode"))
-                    elif concrete_tag == "UNIT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Unit"))
-                    elif concrete_tag == "UNIT-GROUP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UnitGroup"))
-                    elif concrete_tag == "USER-DEFINED-CLUSTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCluster"))
-                    elif concrete_tag == "USER-DEFINED-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCommunicationConnector"))
-                    elif concrete_tag == "USER-DEFINED-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCommunicationController"))
-                    elif concrete_tag == "USER-DEFINED-ETHERNET-FRAME":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedEthernetFrame"))
-                    elif concrete_tag == "USER-DEFINED-GLOBAL-TIME-MASTER":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedGlobalTimeMaster"))
-                    elif concrete_tag == "USER-DEFINED-GLOBAL-TIME-SLAVE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedGlobalTimeSlave"))
-                    elif concrete_tag == "USER-DEFINED-I-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedIPdu"))
-                    elif concrete_tag == "USER-DEFINED-PDU":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedPdu"))
-                    elif concrete_tag == "USER-DEFINED-TRANSFORMATION-PROPS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedTransformationProps"))
-                    elif concrete_tag == "V2X-DATA-MANAGER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "V2xDataManagerNeeds"))
-                    elif concrete_tag == "V2X-FAC-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "V2xFacUserNeeds"))
-                    elif concrete_tag == "V2X-M-USER-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "V2xMUserNeeds"))
-                    elif concrete_tag == "VARIABLE-ACCESS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VariableAccess"))
-                    elif concrete_tag == "VARIABLE-DATA-PROTOTYPE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VariableDataPrototype"))
-                    elif concrete_tag == "VARIATION-POINT-PROXY":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VariationPointProxy"))
-                    elif concrete_tag == "VENDOR-SPECIFIC-SERVICE-NEEDS":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VendorSpecificServiceNeeds"))
-                    elif concrete_tag == "VFB-TIMING":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VfbTiming"))
-                    elif concrete_tag == "VIEW-MAP":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ViewMap"))
-                    elif concrete_tag == "VIEW-MAP-SET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "ViewMapSet"))
-                    elif concrete_tag == "VLAN-CONFIG":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "VlanConfig"))
-                    elif concrete_tag == "WAIT-POINT":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "WaitPoint"))
-                    elif concrete_tag == "WORST-CASE-HEAP-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "WorstCaseHeapUsage"))
-                    elif concrete_tag == "WORST-CASE-STACK-USAGE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "WorstCaseStackUsage"))
-                    elif concrete_tag == "XDOC":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Xdoc"))
-                    elif concrete_tag == "XFILE":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "Xfile"))
-                    elif concrete_tag == "XREF-TARGET":
-                        setattr(obj, "sdx", SerializationHelper.deserialize_by_tag(child[0], "XrefTarget"))
+                sdx_children.append(child)
             elif tag == "SDXF":
-                # Check first child element for concrete type
-                if len(child) > 0:
-                    concrete_tag = child[0].tag.split(ns_split, 1)[1] if child[0].tag.startswith("{") else child[0].tag
-                    if concrete_tag == "AR-PACKAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ARPackage"))
-                    elif concrete_tag == "ACL-OBJECT-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AclObjectSet"))
-                    elif concrete_tag == "ACL-OPERATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AclOperation"))
-                    elif concrete_tag == "ACL-PERMISSION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AclPermission"))
-                    elif concrete_tag == "ACL-ROLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AclRole"))
-                    elif concrete_tag == "AGE-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AgeConstraint"))
-                    elif concrete_tag == "AGGREGATION-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AggregationTailoring"))
-                    elif concrete_tag == "ALIAS-NAME-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AliasNameSet"))
-                    elif concrete_tag == "ANALYZED-EXECUTION-TIME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AnalyzedExecutionTime"))
-                    elif concrete_tag == "APP-OS-TASK-PROXY-TO-ECU-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AppOsTaskProxyToEcuTaskProxyMapping"))
-                    elif concrete_tag == "APPLICATION-ARRAY-DATA-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationArrayDataType"))
-                    elif concrete_tag == "APPLICATION-ARRAY-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationArrayElement"))
-                    elif concrete_tag == "APPLICATION-ENDPOINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationEndpoint"))
-                    elif concrete_tag == "APPLICATION-ERROR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationError"))
-                    elif concrete_tag == "APPLICATION-PARTITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPartition"))
-                    elif concrete_tag == "APPLICATION-PARTITION-TO-ECU-PARTITION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPartitionToEcuPartitionMapping"))
-                    elif concrete_tag == "APPLICATION-PRIMITIVE-DATA-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationPrimitiveDataType"))
-                    elif concrete_tag == "APPLICATION-RECORD-DATA-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationRecordDataType"))
-                    elif concrete_tag == "APPLICATION-RECORD-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationRecordElement"))
-                    elif concrete_tag == "APPLICATION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ApplicationSwComponentType"))
-                    elif concrete_tag == "ARBITRARY-EVENT-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ArbitraryEventTriggering"))
-                    elif concrete_tag == "ARGUMENT-DATA-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ArgumentDataPrototype"))
-                    elif concrete_tag == "ASSEMBLY-SW-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AssemblySwConnector"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallPoint"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-RESULT-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallResultPoint"))
-                    elif concrete_tag == "ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AsynchronousServerCallReturnsEvent"))
-                    elif concrete_tag == "ATP-DEFINITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AtpDefinition"))
-                    elif concrete_tag == "AUTOSAR-OPERATION-ARGUMENT-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AutosarOperationArgumentInstance"))
-                    elif concrete_tag == "AUTOSAR-VARIABLE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "AutosarVariableInstance"))
-                    elif concrete_tag == "BACKGROUND-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BackgroundEvent"))
-                    elif concrete_tag == "BINARY-MANIFEST-ITEM":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestItem"))
-                    elif concrete_tag == "BINARY-MANIFEST-ITEM-DEFINITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestItemDefinition"))
-                    elif concrete_tag == "BINARY-MANIFEST-META-DATA-FIELD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestMetaDataField"))
-                    elif concrete_tag == "BINARY-MANIFEST-PROVIDE-RESOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestProvideResource"))
-                    elif concrete_tag == "BINARY-MANIFEST-REQUIRE-RESOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestRequireResource"))
-                    elif concrete_tag == "BINARY-MANIFEST-RESOURCE-DEFINITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BinaryManifestResourceDefinition"))
-                    elif concrete_tag == "BLOCK-STATE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BlockState"))
-                    elif concrete_tag == "BLUEPRINT-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BlueprintMappingSet"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallPoint"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-RESULT-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallResultPoint"))
-                    elif concrete_tag == "BSW-ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswAsynchronousServerCallReturnsEvent"))
-                    elif concrete_tag == "BSW-BACKGROUND-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswBackgroundEvent"))
-                    elif concrete_tag == "BSW-CALLED-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswCalledEntity"))
-                    elif concrete_tag == "BSW-COMPOSITION-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswCompositionTiming"))
-                    elif concrete_tag == "BSW-DATA-RECEIVED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswDataReceivedEvent"))
-                    elif concrete_tag == "BSW-DIRECT-CALL-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswDirectCallPoint"))
-                    elif concrete_tag == "BSW-DISTINGUISHED-PARTITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswDistinguishedPartition"))
-                    elif concrete_tag == "BSW-ENTRY-RELATIONSHIP-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswEntryRelationshipSet"))
-                    elif concrete_tag == "BSW-EXTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswExternalTriggerOccurredEvent"))
-                    elif concrete_tag == "BSW-IMPLEMENTATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswImplementation"))
-                    elif concrete_tag == "BSW-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswInternalBehavior"))
-                    elif concrete_tag == "BSW-INTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswInternalTriggerOccurredEvent"))
-                    elif concrete_tag == "BSW-INTERNAL-TRIGGERING-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswInternalTriggeringPoint"))
-                    elif concrete_tag == "BSW-INTERRUPT-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswInterruptEntity"))
-                    elif concrete_tag == "BSW-INTERRUPT-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswInterruptEvent"))
-                    elif concrete_tag == "BSW-MGR-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswMgrNeeds"))
-                    elif concrete_tag == "BSW-MODE-MANAGER-ERROR-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModeManagerErrorEvent"))
-                    elif concrete_tag == "BSW-MODE-SWITCH-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModeSwitchEvent"))
-                    elif concrete_tag == "BSW-MODE-SWITCHED-ACK-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModeSwitchedAckEvent"))
-                    elif concrete_tag == "BSW-MODULE-CALL-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleCallPoint"))
-                    elif concrete_tag == "BSW-MODULE-CLIENT-SERVER-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleClientServerEntry"))
-                    elif concrete_tag == "BSW-MODULE-DEPENDENCY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleDependency"))
-                    elif concrete_tag == "BSW-MODULE-DESCRIPTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleDescription"))
-                    elif concrete_tag == "BSW-MODULE-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleEntry"))
-                    elif concrete_tag == "BSW-MODULE-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswModuleTiming"))
-                    elif concrete_tag == "BSW-OPERATION-INVOKED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswOperationInvokedEvent"))
-                    elif concrete_tag == "BSW-OS-TASK-EXECUTION-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswOsTaskExecutionEvent"))
-                    elif concrete_tag == "BSW-SCHEDULABLE-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswSchedulableEntity"))
-                    elif concrete_tag == "BSW-SCHEDULER-NAME-PREFIX":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswSchedulerNamePrefix"))
-                    elif concrete_tag == "BSW-SERVICE-DEPENDENCY-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswServiceDependencyIdent"))
-                    elif concrete_tag == "BSW-TIMING-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswTimingEvent"))
-                    elif concrete_tag == "BSW-VARIABLE-ACCESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BswVariableAccess"))
-                    elif concrete_tag == "BUILD-ACTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BuildAction"))
-                    elif concrete_tag == "BUILD-ACTION-ENVIRONMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BuildActionEnvironment"))
-                    elif concrete_tag == "BUILD-ACTION-MANIFEST":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BuildActionManifest"))
-                    elif concrete_tag == "BULK-NV-DATA-DESCRIPTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BulkNvDataDescriptor"))
-                    elif concrete_tag == "BURST-PATTERN-EVENT-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BurstPatternEventTriggering"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-CAN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingCan"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-FLEXRAY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingFlexray"))
-                    elif concrete_tag == "BUS-MIRROR-CHANNEL-MAPPING-IP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "BusMirrorChannelMappingIp"))
-                    elif concrete_tag == "CALIBRATION-PARAMETER-VALUE-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CalibrationParameterValueSet"))
-                    elif concrete_tag == "CAN-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanCluster"))
-                    elif concrete_tag == "CAN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanCommunicationConnector"))
-                    elif concrete_tag == "CAN-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanCommunicationController"))
-                    elif concrete_tag == "CAN-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanFrame"))
-                    elif concrete_tag == "CAN-FRAME-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanFrameTriggering"))
-                    elif concrete_tag == "CAN-NM-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanNmCluster"))
-                    elif concrete_tag == "CAN-NM-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanNmNode"))
-                    elif concrete_tag == "CAN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanPhysicalChannel"))
-                    elif concrete_tag == "CAN-TP-ADDRESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanTpAddress"))
-                    elif concrete_tag == "CAN-TP-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanTpChannel"))
-                    elif concrete_tag == "CAN-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanTpConfig"))
-                    elif concrete_tag == "CAN-TP-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CanTpNode"))
-                    elif concrete_tag == "CAPTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Caption"))
-                    elif concrete_tag == "CHAPTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Chapter"))
-                    elif concrete_tag == "CLASS-CONTENT-CONDITIONAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClassContentConditional"))
-                    elif concrete_tag == "CLIENT-ID-DEFINITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientIdDefinition"))
-                    elif concrete_tag == "CLIENT-ID-DEFINITION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientIdDefinitionSet"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterface"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterfaceMapping"))
-                    elif concrete_tag == "CLIENT-SERVER-INTERFACE-TO-BSW-MODULE-ENTRY-BLUEPRINT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientServerInterfaceToBswModuleEntryBlueprintMapping"))
-                    elif concrete_tag == "CLIENT-SERVER-OPERATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ClientServerOperation"))
-                    elif concrete_tag == "CODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Code"))
-                    elif concrete_tag == "COLLECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Collection"))
-                    elif concrete_tag == "COM-MANAGEMENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ComManagementMapping"))
-                    elif concrete_tag == "COM-MGR-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ComMgrUserNeeds"))
-                    elif concrete_tag == "COMPILER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Compiler"))
-                    elif concrete_tag == "COMPLEX-DEVICE-DRIVER-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ComplexDeviceDriverSwComponentType"))
-                    elif concrete_tag == "COMPOSITION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CompositionSwComponentType"))
-                    elif concrete_tag == "COMPU-METHOD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CompuMethod"))
-                    elif concrete_tag == "CONCRETE-CLASS-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConcreteClassTailoring"))
-                    elif concrete_tag == "CONCRETE-PATTERN-EVENT-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConcretePatternEventTriggering"))
-                    elif concrete_tag == "CONSISTENCY-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConsistencyNeeds"))
-                    elif concrete_tag == "CONSISTENCY-NEEDS-BLUEPRINT-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConsistencyNeedsBlueprintSet"))
-                    elif concrete_tag == "CONSTANT-SPECIFICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConstantSpecification"))
-                    elif concrete_tag == "CONSTANT-SPECIFICATION-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConstantSpecificationMappingSet"))
-                    elif concrete_tag == "CONSTRAINT-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConstraintTailoring"))
-                    elif concrete_tag == "CONSUMED-EVENT-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConsumedEventGroup"))
-                    elif concrete_tag == "CONSUMED-PROVIDED-SERVICE-INSTANCE-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConsumedProvidedServiceInstanceGroup"))
-                    elif concrete_tag == "CONSUMED-SERVICE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ConsumedServiceInstance"))
-                    elif concrete_tag == "CONTAINER-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ContainerIPdu"))
-                    elif concrete_tag == "COUPLING-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingElement"))
-                    elif concrete_tag == "COUPLING-ELEMENT-SWITCH-DETAILS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingElementSwitchDetails"))
-                    elif concrete_tag == "COUPLING-PORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingPort"))
-                    elif concrete_tag == "COUPLING-PORT-FIFO":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortFifo"))
-                    elif concrete_tag == "COUPLING-PORT-SCHEDULER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortScheduler"))
-                    elif concrete_tag == "COUPLING-PORT-SHAPER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortShaper"))
-                    elif concrete_tag == "COUPLING-PORT-TRAFFIC-CLASS-ASSIGNMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CouplingPortTrafficClassAssignment"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareCluster"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-BINARY-MANIFEST-DESCRIPTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterBinaryManifestDescriptor"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-COMMUNICATION-RESOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterCommunicationResource"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterMappingSet"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-RESOURCE-POOL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterResourcePool"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-RESOURCE-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterResourceToApplicationPartitionMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-SERVICE-RESOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterServiceResource"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToApplicationPartitionMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-ECU-INSTANCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToEcuInstanceMapping"))
-                    elif concrete_tag == "CP-SOFTWARE-CLUSTER-TO-RESOURCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSoftwareClusterToResourceMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-RESOURCE-TO-DIAG-DATA-ELEM-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterResourceToDiagDataElemMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-RESOURCE-TO-DIAG-FUNCTION-ID-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterResourceToDiagFunctionIdMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-TO-DIAG-EVENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterToDiagEventMapping"))
-                    elif concrete_tag == "CP-SW-CLUSTER-TO-DIAG-ROUTINE-SUBFUNCTION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CpSwClusterToDiagRoutineSubfunctionMapping"))
-                    elif concrete_tag == "CRYPTO-ELLIPTIC-CURVE-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoEllipticCurveProps"))
-                    elif concrete_tag == "CRYPTO-KEY-MANAGEMENT-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoKeyManagementNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-CERTIFICATE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceCertificate"))
-                    elif concrete_tag == "CRYPTO-SERVICE-JOB-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceJobNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-KEY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceKey"))
-                    elif concrete_tag == "CRYPTO-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceNeeds"))
-                    elif concrete_tag == "CRYPTO-SERVICE-PRIMITIVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServicePrimitive"))
-                    elif concrete_tag == "CRYPTO-SERVICE-QUEUE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoServiceQueue"))
-                    elif concrete_tag == "CRYPTO-SIGNATURE-SCHEME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "CryptoSignatureScheme"))
-                    elif concrete_tag == "DATA-CONSTR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataConstr"))
-                    elif concrete_tag == "DATA-EXCHANGE-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataExchangePoint"))
-                    elif concrete_tag == "DATA-PROTOTYPE-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataPrototypeGroup"))
-                    elif concrete_tag == "DATA-RECEIVE-ERROR-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataReceiveErrorEvent"))
-                    elif concrete_tag == "DATA-RECEIVED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataReceivedEvent"))
-                    elif concrete_tag == "DATA-SEND-COMPLETED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataSendCompletedEvent"))
-                    elif concrete_tag == "DATA-TRANSFORMATION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataTransformationSet"))
-                    elif concrete_tag == "DATA-TYPE-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataTypeMappingSet"))
-                    elif concrete_tag == "DATA-WRITE-COMPLETED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DataWriteCompletedEvent"))
-                    elif concrete_tag == "DCM-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DcmIPdu"))
-                    elif concrete_tag == "DDS-CP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpConfig"))
-                    elif concrete_tag == "DDS-CP-CONSUMED-SERVICE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpConsumedServiceInstance"))
-                    elif concrete_tag == "DDS-CP-DOMAIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpDomain"))
-                    elif concrete_tag == "DDS-CP-PARTITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpPartition"))
-                    elif concrete_tag == "DDS-CP-PROVIDED-SERVICE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpProvidedServiceInstance"))
-                    elif concrete_tag == "DDS-CP-QOS-PROFILE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpQosProfile"))
-                    elif concrete_tag == "DDS-CP-TOPIC":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DdsCpTopic"))
-                    elif concrete_tag == "DEF-ITEM":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DefItem"))
-                    elif concrete_tag == "DELEGATION-SW-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DelegationSwConnector"))
-                    elif concrete_tag == "DEPENDENCY-ON-ARTIFACT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DependencyOnArtifact"))
-                    elif concrete_tag == "DEVELOPMENT-ERROR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DevelopmentError"))
-                    elif concrete_tag == "DIAG-EVENT-DEBOUNCE-COUNTER-BASED":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagEventDebounceCounterBased"))
-                    elif concrete_tag == "DIAG-EVENT-DEBOUNCE-MONITOR-INTERNAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagEventDebounceMonitorInternal"))
-                    elif concrete_tag == "DIAGNOSTIC-ACCESS-PERMISSION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAccessPermission"))
-                    elif concrete_tag == "DIAGNOSTIC-AGING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAging"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-ROLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthRole"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificate"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE-EVALUATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificateEvaluation"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTH-TRANSMIT-CERTIFICATE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthTransmitCertificateMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTHENTICATION-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthenticationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-AUTHENTICATION-CONFIGURATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticAuthenticationConfiguration"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-DIAGNOSTIC-INFORMATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearDiagnosticInformation"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-DIAGNOSTIC-INFORMATION-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearDiagnosticInformationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-RESET-EMISSION-RELATED-INFO":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearResetEmissionRelatedInfo"))
-                    elif concrete_tag == "DIAGNOSTIC-CLEAR-RESET-EMISSION-RELATED-INFO-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticClearResetEmissionRelatedInfoClass"))
-                    elif concrete_tag == "DIAGNOSTIC-COM-CONTROL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComControl"))
-                    elif concrete_tag == "DIAGNOSTIC-COM-CONTROL-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-COMMUNICATION-MANAGER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCommunicationManagerNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-COMPONENT-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticComponentNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-CONNECTED-INDICATOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticConnectedIndicator"))
-                    elif concrete_tag == "DIAGNOSTIC-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticConnection"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTRIBUTION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticContributionSet"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-D-T-C-SETTING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlDTCSetting"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-D-T-C-SETTING-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlDTCSettingClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CONTROL-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticControlNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-CUSTOM-SERVICE-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCustomServiceClass"))
-                    elif concrete_tag == "DIAGNOSTIC-CUSTOM-SERVICE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticCustomServiceInstance"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataElement"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-IDENTIFIER-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataIdentifierSet"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-TRANSFER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataTransfer"))
-                    elif concrete_tag == "DIAGNOSTIC-DATA-TRANSFER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDataTransferClass"))
-                    elif concrete_tag == "DIAGNOSTIC-DE-AUTHENTICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDeAuthentication"))
-                    elif concrete_tag == "DIAGNOSTIC-DEBOUNCE-ALGORITHM-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDebounceAlgorithmProps"))
-                    elif concrete_tag == "DIAGNOSTIC-DEM-PROVIDED-DATA-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDemProvidedDataMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMIC-DATA-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMICALLY-DEFINE-DATA-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicallyDefineDataIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-DYNAMICALLY-DEFINE-DATA-IDENTIFIER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticDynamicallyDefineDataIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-INSTANCE-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuInstanceProps"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-RESET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuReset"))
-                    elif concrete_tag == "DIAGNOSTIC-ECU-RESET-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEcuResetClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-ENABLE-CONDITION-PORT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnableConditionPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-BSW-MODE-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvBswModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-MODE-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENV-SWC-MODE-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvSwcModeElement"))
-                    elif concrete_tag == "DIAGNOSTIC-ENVIRONMENTAL-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEnvironmentalCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-INFO-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventInfoNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-MANAGER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventManagerNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-PORT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-DEBOUNCE-ALGORITHM-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToDebounceAlgorithmMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-ENABLE-CONDITION-GROUP-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToEnableConditionGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-OPERATION-CYCLE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToOperationCycleMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-SECURITY-EVENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToSecurityEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-STORAGE-CONDITION-GROUP-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToStorageConditionGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-TROUBLE-CODE-J1939-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToTroubleCodeJ1939Mapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EVENT-TO-TROUBLE-CODE-UDS-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticEventToTroubleCodeUdsMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-EXTENDED-DATA-RECORD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticExtendedDataRecord"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-GROUP-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventGroupMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-ALIAS-EVENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimAliasEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-EVENT-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimEventGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-FIM-FUNCTION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFimFunctionMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-FREEZE-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-IDENTIFIER-INHIBIT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionIdentifierInhibit"))
-                    elif concrete_tag == "DIAGNOSTIC-FUNCTION-INHIBIT-SOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticFunctionInhibitSource"))
-                    elif concrete_tag == "DIAGNOSTIC-I-O-CONTROL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIOControl"))
-                    elif concrete_tag == "DIAGNOSTIC-INDICATOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIndicator"))
-                    elif concrete_tag == "DIAGNOSTIC-INFO-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticInfoType"))
-                    elif concrete_tag == "DIAGNOSTIC-INHIBIT-SOURCE-EVENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticInhibitSourceEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-IO-CONTROL-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIoControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-IO-CONTROL-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIoControlNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumpr"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-DENOMINATOR-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprDenominatorGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-IUMPR-TO-FUNCTION-IDENTIFIER-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticIumprToFunctionIdentifierMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-EXPANDED-FREEZE-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939ExpandedFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-FREEZE-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939FreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939Node"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SPN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939Spn"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SPN-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939SpnMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-J1939-SW-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticJ1939SwMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-MASTER-TO-SLAVE-EVENT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMasterToSlaveEventMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-MEASUREMENT-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMeasurementIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-DESTINATION-PRIMARY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryDestinationPrimary"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-DESTINATION-USER-DEFINED":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryDestinationUserDefined"))
-                    elif concrete_tag == "DIAGNOSTIC-MEMORY-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticMemoryIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCycle"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCycleNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-OPERATION-CYCLE-PORT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticOperationCyclePortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterElement"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterIdent"))
-                    elif concrete_tag == "DIAGNOSTIC-PARAMETER-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticParameterIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-POWERTRAIN-FREEZE-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticPowertrainFreezeFrame"))
-                    elif concrete_tag == "DIAGNOSTIC-PROOF-OF-OWNERSHIP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticProofOfOwnership"))
-                    elif concrete_tag == "DIAGNOSTIC-PROTOCOL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticProtocol"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-D-T-C-INFORMATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDTCInformation"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-D-T-C-INFORMATION-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDTCInformationClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-PERIODIC-ID":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByPeriodicID"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-DATA-BY-PERIODIC-ID-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadDataByPeriodicIDClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-MEMORY-BY-ADDRESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadMemoryByAddress"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-MEMORY-BY-ADDRESS-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadMemoryByAddressClass"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-SCALING-DATA-BY-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadScalingDataByIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-READ-SCALING-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticReadScalingDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CONTROL-OF-ON-BOARD-DEVICE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestControlOfOnBoardDevice"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CONTROL-OF-ON-BOARD-DEVICE-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestControlOfOnBoardDeviceClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CURRENT-POWERTRAIN-DATA":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestCurrentPowertrainData"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-CURRENT-POWERTRAIN-DATA-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestCurrentPowertrainDataClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-DOWNLOAD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestDownload"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-DOWNLOAD-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestDownloadClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTC"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-PERMANENT-STATUS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCPermanentStatus"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-EMISSION-RELATED-D-T-C-PERMANENT-STATUS-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransfer"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransferClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-FILE-TRANSFER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestFileTransferNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ON-BOARD-MONITORING-TEST-RESULTS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestOnBoardMonitoringTestResults"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ON-BOARD-MONITORING-TEST-RESULTS-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestOnBoardMonitoringTestResultsClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-POWERTRAIN-FREEZE-FRAME-DATA":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestPowertrainFreezeFrameData"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-POWERTRAIN-FREEZE-FRAME-DATA-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestPowertrainFreezeFrameDataClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-ROUTINE-RESULTS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestRoutineResults"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-UPLOAD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestUpload"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-UPLOAD-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestUploadClass"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-VEHICLE-INFO":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestVehicleInfo"))
-                    elif concrete_tag == "DIAGNOSTIC-REQUEST-VEHICLE-INFO-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRequestVehicleInfoClass"))
-                    elif concrete_tag == "DIAGNOSTIC-RESPONSE-ON-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticResponseOnEvent"))
-                    elif concrete_tag == "DIAGNOSTIC-RESPONSE-ON-EVENT-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticResponseOnEventClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-CONTROL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineControl"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-CONTROL-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-ROUTINE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticRoutineNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURE-CODING-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecureCodingMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-ACCESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityAccess"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-ACCESS-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityAccessClass"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-EVENT-REPORTING-MODE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityEventReportingModeMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SECURITY-LEVEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSecurityLevel"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-DATA-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceDataMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-SW-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceSwMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-SERVICE-TABLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticServiceTable"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSession"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION-CONTROL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSessionControl"))
-                    elif concrete_tag == "DIAGNOSTIC-SESSION-CONTROL-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticSessionControlClass"))
-                    elif concrete_tag == "DIAGNOSTIC-START-ROUTINE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStartRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-STOP-ROUTINE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStopRoutine"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageCondition"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-STORAGE-CONDITION-PORT-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticStorageConditionPortMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-TEST-RESULT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTestResult"))
-                    elif concrete_tag == "DIAGNOSTIC-TEST-ROUTINE-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTestRoutineIdentifier"))
-                    elif concrete_tag == "DIAGNOSTIC-TRANSFER-EXIT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTransferExit"))
-                    elif concrete_tag == "DIAGNOSTIC-TRANSFER-EXIT-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTransferExitClass"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeGroup"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-J1939":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeJ1939"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-OBD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeObd"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeProps"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-UDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeUds"))
-                    elif concrete_tag == "DIAGNOSTIC-TROUBLE-CODE-UDS-TO-TROUBLE-CODE-OBD-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping"))
-                    elif concrete_tag == "DIAGNOSTIC-UPLOAD-DOWNLOAD-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticUploadDownloadNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-VALUE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticValueNeeds"))
-                    elif concrete_tag == "DIAGNOSTIC-VERIFY-CERTIFICATE-BIDIRECTIONAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticVerifyCertificateBidirectional"))
-                    elif concrete_tag == "DIAGNOSTIC-WRITE-DATA-BY-IDENTIFIER-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticWriteDataByIdentifierClass"))
-                    elif concrete_tag == "DIAGNOSTIC-WRITE-MEMORY-BY-ADDRESS-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticWriteMemoryByAddressClass"))
-                    elif concrete_tag == "DIAGNOSTICS-COMMUNICATION-SECURITY-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DiagnosticsCommunicationSecurityNeeds"))
-                    elif concrete_tag == "DLT-APPLICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltApplication"))
-                    elif concrete_tag == "DLT-ARGUMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltArgument"))
-                    elif concrete_tag == "DLT-CONTEXT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltContext"))
-                    elif concrete_tag == "DLT-ECU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltEcu"))
-                    elif concrete_tag == "DLT-LOG-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltLogChannel"))
-                    elif concrete_tag == "DLT-MESSAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltMessage"))
-                    elif concrete_tag == "DLT-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DltUserNeeds"))
-                    elif concrete_tag == "DO-IP-ACTIVATION-LINE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpActivationLineNeeds"))
-                    elif concrete_tag == "DO-IP-GID-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpGidNeeds"))
-                    elif concrete_tag == "DO-IP-GID-SYNCHRONIZATION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpGidSynchronizationNeeds"))
-                    elif concrete_tag == "DO-IP-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpInterface"))
-                    elif concrete_tag == "DO-IP-LOGIC-ADDRESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicAddress"))
-                    elif concrete_tag == "DO-IP-LOGIC-TARGET-ADDRESS-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicTargetAddressProps"))
-                    elif concrete_tag == "DO-IP-LOGIC-TESTER-ADDRESS-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpLogicTesterAddressProps"))
-                    elif concrete_tag == "DO-IP-POWER-MODE-STATUS-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpPowerModeStatusNeeds"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivation"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION-AUTHENTICATION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivationAuthenticationNeeds"))
-                    elif concrete_tag == "DO-IP-ROUTING-ACTIVATION-CONFIRMATION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpRoutingActivationConfirmationNeeds"))
-                    elif concrete_tag == "DO-IP-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DoIpTpConfig"))
-                    elif concrete_tag == "DOCUMENT-ELEMENT-SCOPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DocumentElementScope"))
-                    elif concrete_tag == "DOCUMENTATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Documentation"))
-                    elif concrete_tag == "DOCUMENTATION-CONTEXT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DocumentationContext"))
-                    elif concrete_tag == "DTC-STATUS-CHANGE-NOTIFICATION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "DtcStatusChangeNotificationNeeds"))
-                    elif concrete_tag == "E2-E-PROFILE-COMPATIBILITY-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "E2EProfileCompatibilityProps"))
-                    elif concrete_tag == "E-C-U-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ECUMapping"))
-                    elif concrete_tag == "E-O-C-EVENT-REF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EOCEventRef"))
-                    elif concrete_tag == "E-O-C-EXECUTABLE-ENTITY-REF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EOCExecutableEntityRef"))
-                    elif concrete_tag == "E-O-C-EXECUTABLE-ENTITY-REF-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EOCExecutableEntityRefGroup"))
-                    elif concrete_tag == "ECU-ABSTRACTION-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcuAbstractionSwComponentType"))
-                    elif concrete_tag == "ECU-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcuInstance"))
-                    elif concrete_tag == "ECU-PARTITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcuPartition"))
-                    elif concrete_tag == "ECU-STATE-MGR-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcuStateMgrUserNeeds"))
-                    elif concrete_tag == "ECU-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcuTiming"))
-                    elif concrete_tag == "ECUC-ADD-INFO-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucAddInfoParamDef"))
-                    elif concrete_tag == "ECUC-BOOLEAN-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucBooleanParamDef"))
-                    elif concrete_tag == "ECUC-CHOICE-CONTAINER-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucChoiceContainerDef"))
-                    elif concrete_tag == "ECUC-CHOICE-REFERENCE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucChoiceReferenceDef"))
-                    elif concrete_tag == "ECUC-CONTAINER-VALUE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucContainerValue"))
-                    elif concrete_tag == "ECUC-DEFINITION-COLLECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucDefinitionCollection"))
-                    elif concrete_tag == "ECUC-DESTINATION-URI-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucDestinationUriDef"))
-                    elif concrete_tag == "ECUC-DESTINATION-URI-DEF-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucDestinationUriDefSet"))
-                    elif concrete_tag == "ECUC-ENUMERATION-LITERAL-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucEnumerationLiteralDef"))
-                    elif concrete_tag == "ECUC-ENUMERATION-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucEnumerationParamDef"))
-                    elif concrete_tag == "ECUC-FLOAT-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucFloatParamDef"))
-                    elif concrete_tag == "ECUC-FOREIGN-REFERENCE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucForeignReferenceDef"))
-                    elif concrete_tag == "ECUC-FUNCTION-NAME-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucFunctionNameDef"))
-                    elif concrete_tag == "ECUC-INSTANCE-REFERENCE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucInstanceReferenceDef"))
-                    elif concrete_tag == "ECUC-INTEGER-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucIntegerParamDef"))
-                    elif concrete_tag == "ECUC-LINKER-SYMBOL-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucLinkerSymbolDef"))
-                    elif concrete_tag == "ECUC-MODULE-CONFIGURATION-VALUES":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucModuleConfigurationValues"))
-                    elif concrete_tag == "ECUC-MODULE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucModuleDef"))
-                    elif concrete_tag == "ECUC-MULTILINE-STRING-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucMultilineStringParamDef"))
-                    elif concrete_tag == "ECUC-PARAM-CONF-CONTAINER-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucParamConfContainerDef"))
-                    elif concrete_tag == "ECUC-QUERY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucQuery"))
-                    elif concrete_tag == "ECUC-REFERENCE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucReferenceDef"))
-                    elif concrete_tag == "ECUC-STRING-PARAM-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucStringParamDef"))
-                    elif concrete_tag == "ECUC-URI-REFERENCE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucUriReferenceDef"))
-                    elif concrete_tag == "ECUC-VALIDATION-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucValidationCondition"))
-                    elif concrete_tag == "ECUC-VALUE-COLLECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EcucValueCollection"))
-                    elif concrete_tag == "END-TO-END-PROTECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EndToEndProtection"))
-                    elif concrete_tag == "END-TO-END-PROTECTION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EndToEndProtectionSet"))
-                    elif concrete_tag == "ENUMERATION-MAPPING-TABLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EnumerationMappingTable"))
-                    elif concrete_tag == "ERROR-TRACER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ErrorTracerNeeds"))
-                    elif concrete_tag == "ETH-IP-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthIpProps"))
-                    elif concrete_tag == "ETH-TCP-IP-ICMP-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthTcpIpIcmpProps"))
-                    elif concrete_tag == "ETH-TCP-IP-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthTcpIpProps"))
-                    elif concrete_tag == "ETH-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthTpConfig"))
-                    elif concrete_tag == "ETHERNET-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetCluster"))
-                    elif concrete_tag == "ETHERNET-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetCommunicationConnector"))
-                    elif concrete_tag == "ETHERNET-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetCommunicationController"))
-                    elif concrete_tag == "ETHERNET-FRAME-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetFrameTriggering"))
-                    elif concrete_tag == "ETHERNET-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetPhysicalChannel"))
-                    elif concrete_tag == "ETHERNET-PRIORITY-REGENERATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetPriorityRegeneration"))
-                    elif concrete_tag == "ETHERNET-WAKEUP-SLEEP-ON-DATALINE-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetWakeupSleepOnDatalineConfig"))
-                    elif concrete_tag == "ETHERNET-WAKEUP-SLEEP-ON-DATALINE-CONFIG-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EthernetWakeupSleepOnDatalineConfigSet"))
-                    elif concrete_tag == "EVALUATED-VARIANT-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EvaluatedVariantSet"))
-                    elif concrete_tag == "EVENT-HANDLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "EventHandler"))
-                    elif concrete_tag == "EXCLUSIVE-AREA":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExclusiveArea"))
-                    elif concrete_tag == "EXCLUSIVE-AREA-NESTING-ORDER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExclusiveAreaNestingOrder"))
-                    elif concrete_tag == "EXECUTABLE-ENTITY-ACTIVATION-REASON":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExecutableEntityActivationReason"))
-                    elif concrete_tag == "EXECUTION-ORDER-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExecutionOrderConstraint"))
-                    elif concrete_tag == "EXECUTION-TIME-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExecutionTimeConstraint"))
-                    elif concrete_tag == "EXTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExternalTriggerOccurredEvent"))
-                    elif concrete_tag == "EXTERNAL-TRIGGERING-POINT-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ExternalTriggeringPointIdent"))
-                    elif concrete_tag == "F-M-ATTRIBUTE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMAttributeDef"))
-                    elif concrete_tag == "F-M-FEATURE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeature"))
-                    elif concrete_tag == "F-M-FEATURE-MAP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMap"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-ASSERTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapAssertion"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapCondition"))
-                    elif concrete_tag == "F-M-FEATURE-MAP-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureMapElement"))
-                    elif concrete_tag == "F-M-FEATURE-MODEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureModel"))
-                    elif concrete_tag == "F-M-FEATURE-RELATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureRelation"))
-                    elif concrete_tag == "F-M-FEATURE-RESTRICTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureRestriction"))
-                    elif concrete_tag == "F-M-FEATURE-SELECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureSelection"))
-                    elif concrete_tag == "F-M-FEATURE-SELECTION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FMFeatureSelectionSet"))
-                    elif concrete_tag == "FIREWALL-RULE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FirewallRule"))
-                    elif concrete_tag == "FLAT-INSTANCE-DESCRIPTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlatInstanceDescriptor"))
-                    elif concrete_tag == "FLAT-MAP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlatMap"))
-                    elif concrete_tag == "FLEXRAY-AR-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayArTpConfig"))
-                    elif concrete_tag == "FLEXRAY-AR-TP-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayArTpNode"))
-                    elif concrete_tag == "FLEXRAY-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCluster"))
-                    elif concrete_tag == "FLEXRAY-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCommunicationConnector"))
-                    elif concrete_tag == "FLEXRAY-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayCommunicationController"))
-                    elif concrete_tag == "FLEXRAY-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayFrame"))
-                    elif concrete_tag == "FLEXRAY-FRAME-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayFrameTriggering"))
-                    elif concrete_tag == "FLEXRAY-NM-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayNmCluster"))
-                    elif concrete_tag == "FLEXRAY-NM-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayNmNode"))
-                    elif concrete_tag == "FLEXRAY-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayPhysicalChannel"))
-                    elif concrete_tag == "FLEXRAY-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpConfig"))
-                    elif concrete_tag == "FLEXRAY-TP-CONNECTION-CONTROL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpConnectionControl"))
-                    elif concrete_tag == "FLEXRAY-TP-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpNode"))
-                    elif concrete_tag == "FLEXRAY-TP-PDU-POOL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FlexrayTpPduPool"))
-                    elif concrete_tag == "FRAME-PORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FramePort"))
-                    elif concrete_tag == "FUNCTION-INHIBITION-AVAILABILITY-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FunctionInhibitionAvailabilityNeeds"))
-                    elif concrete_tag == "FUNCTION-INHIBITION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "FunctionInhibitionNeeds"))
-                    elif concrete_tag == "GATEWAY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Gateway"))
-                    elif concrete_tag == "GENERAL-PURPOSE-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposeConnection"))
-                    elif concrete_tag == "GENERAL-PURPOSE-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposeIPdu"))
-                    elif concrete_tag == "GENERAL-PURPOSE-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GeneralPurposePdu"))
-                    elif concrete_tag == "GENERIC-ETHERNET-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GenericEthernetFrame"))
-                    elif concrete_tag == "GLOBAL-SUPERVISION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalSupervisionNeeds"))
-                    elif concrete_tag == "GLOBAL-TIME-CAN-MASTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeCanMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-CAN-SLAVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeCanSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-DOMAIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeDomain"))
-                    elif concrete_tag == "GLOBAL-TIME-ETH-MASTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeEthMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-ETH-SLAVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeEthSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-FR-MASTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeFrMaster"))
-                    elif concrete_tag == "GLOBAL-TIME-FR-SLAVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeFrSlave"))
-                    elif concrete_tag == "GLOBAL-TIME-GATEWAY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "GlobalTimeGateway"))
-                    elif concrete_tag == "HARDWARE-TEST-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HardwareTestNeeds"))
-                    elif concrete_tag == "HW-ATTRIBUTE-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwAttributeDef"))
-                    elif concrete_tag == "HW-ATTRIBUTE-LITERAL-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwAttributeLiteralDef"))
-                    elif concrete_tag == "HW-CATEGORY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwCategory"))
-                    elif concrete_tag == "HW-DESCRIPTION-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwDescriptionEntity"))
-                    elif concrete_tag == "HW-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwElement"))
-                    elif concrete_tag == "HW-PIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwPin"))
-                    elif concrete_tag == "HW-PIN-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwPinGroup"))
-                    elif concrete_tag == "HW-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "HwType"))
-                    elif concrete_tag == "I-E-E-E1722-TP-AAF-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAafConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CAN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfCan"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CAN-PART":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfCanPart"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-LIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfLin"))
-                    elif concrete_tag == "I-E-E-E1722-TP-ACF-LIN-PART":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpAcfLinPart"))
-                    elif concrete_tag == "I-E-E-E1722-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpConfig"))
-                    elif concrete_tag == "I-E-E-E1722-TP-CRF-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpCrfConnection"))
-                    elif concrete_tag == "I-E-E-E1722-TP-IIDC-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IEEE1722TpIidcConnection"))
-                    elif concrete_tag == "I-P-SEC-CONFIG-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IPSecConfigProps"))
-                    elif concrete_tag == "I-P-SEC-RULE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IPSecRule"))
-                    elif concrete_tag == "I-PDU-PORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IPduPort"))
-                    elif concrete_tag == "I-PV6-EXT-HEADER-FILTER-LIST":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IPv6ExtHeaderFilterList"))
-                    elif concrete_tag == "I-PV6-EXT-HEADER-FILTER-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IPv6ExtHeaderFilterSet"))
-                    elif concrete_tag == "I-SIGNAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignal"))
-                    elif concrete_tag == "I-SIGNAL-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalGroup"))
-                    elif concrete_tag == "I-SIGNAL-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalIPdu"))
-                    elif concrete_tag == "I-SIGNAL-I-PDU-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalIPduGroup"))
-                    elif concrete_tag == "I-SIGNAL-PORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalPort"))
-                    elif concrete_tag == "I-SIGNAL-TO-I-PDU-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalToIPduMapping"))
-                    elif concrete_tag == "I-SIGNAL-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ISignalTriggering"))
-                    elif concrete_tag == "IDS-DESIGN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IdsDesign"))
-                    elif concrete_tag == "IDS-MGR-CUSTOM-TIMESTAMP-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IdsMgrCustomTimestampNeeds"))
-                    elif concrete_tag == "IDS-MGR-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IdsMgrNeeds"))
-                    elif concrete_tag == "IDSM-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IdsmInstance"))
-                    elif concrete_tag == "IDSM-PROPERTIES":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IdsmProperties"))
-                    elif concrete_tag == "IEEE1722-TP-ETHERNET-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Ieee1722TpEthernetFrame"))
-                    elif concrete_tag == "IMPLEMENTATION-DATA-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ImplementationDataType"))
-                    elif concrete_tag == "IMPLEMENTATION-DATA-TYPE-ELEMENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ImplementationDataTypeElement"))
-                    elif concrete_tag == "IMPLEMENTATION-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ImplementationProps"))
-                    elif concrete_tag == "IMPOSITION-TIME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ImpositionTime"))
-                    elif concrete_tag == "INDICATOR-STATUS-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "IndicatorStatusNeeds"))
-                    elif concrete_tag == "INIT-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "InitEvent"))
-                    elif concrete_tag == "INTERNAL-TRIGGER-OCCURRED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "InternalTriggerOccurredEvent"))
-                    elif concrete_tag == "INTERNAL-TRIGGERING-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "InternalTriggeringPoint"))
-                    elif concrete_tag == "INTERPOLATION-ROUTINE-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "InterpolationRoutineMappingSet"))
-                    elif concrete_tag == "J1939-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939Cluster"))
-                    elif concrete_tag == "J1939-CONTROLLER-APPLICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939ControllerApplication"))
-                    elif concrete_tag == "J1939-DCM-DM19-SUPPORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939DcmDm19Support"))
-                    elif concrete_tag == "J1939-DCM-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939DcmIPdu"))
-                    elif concrete_tag == "J1939-NM-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939NmCluster"))
-                    elif concrete_tag == "J1939-NM-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939NmNode"))
-                    elif concrete_tag == "J1939-RM-INCOMING-REQUEST-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939RmIncomingRequestServiceNeeds"))
-                    elif concrete_tag == "J1939-RM-OUTGOING-REQUEST-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939RmOutgoingRequestServiceNeeds"))
-                    elif concrete_tag == "J1939-SHARED-ADDRESS-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939SharedAddressCluster"))
-                    elif concrete_tag == "J1939-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939TpConfig"))
-                    elif concrete_tag == "J1939-TP-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "J1939TpNode"))
-                    elif concrete_tag == "KEYWORD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Keyword"))
-                    elif concrete_tag == "KEYWORD-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "KeywordSet"))
-                    elif concrete_tag == "LATENCY-TIMING-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LatencyTimingConstraint"))
-                    elif concrete_tag == "LIFE-CYCLE-INFO-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleInfoSet"))
-                    elif concrete_tag == "LIFE-CYCLE-STATE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleState"))
-                    elif concrete_tag == "LIFE-CYCLE-STATE-DEFINITION-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LifeCycleStateDefinitionGroup"))
-                    elif concrete_tag == "LIN-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinCluster"))
-                    elif concrete_tag == "LIN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinCommunicationConnector"))
-                    elif concrete_tag == "LIN-EVENT-TRIGGERED-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinEventTriggeredFrame"))
-                    elif concrete_tag == "LIN-FRAME-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinFrameTriggering"))
-                    elif concrete_tag == "LIN-MASTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinMaster"))
-                    elif concrete_tag == "LIN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinPhysicalChannel"))
-                    elif concrete_tag == "LIN-SCHEDULE-TABLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinScheduleTable"))
-                    elif concrete_tag == "LIN-SLAVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinSlave"))
-                    elif concrete_tag == "LIN-SLAVE-CONFIG-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinSlaveConfigIdent"))
-                    elif concrete_tag == "LIN-SPORADIC-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinSporadicFrame"))
-                    elif concrete_tag == "LIN-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinTpConfig"))
-                    elif concrete_tag == "LIN-TP-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinTpNode"))
-                    elif concrete_tag == "LIN-UNCONDITIONAL-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LinUnconditionalFrame"))
-                    elif concrete_tag == "LINKER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Linker"))
-                    elif concrete_tag == "LOG-AND-TRACE-MESSAGE-COLLECTION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "LogAndTraceMessageCollectionSet"))
-                    elif concrete_tag == "MAC-MULTICAST-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MacMulticastGroup"))
-                    elif concrete_tag == "MAC-SEC-GLOBAL-KAY-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MacSecGlobalKayProps"))
-                    elif concrete_tag == "MAC-SEC-KAY-PARTICIPANT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MacSecKayParticipant"))
-                    elif concrete_tag == "MAC-SEC-PARTICIPANT-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MacSecParticipantSet"))
-                    elif concrete_tag == "MC-DATA-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "McDataInstance"))
-                    elif concrete_tag == "MC-FUNCTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "McFunction"))
-                    elif concrete_tag == "MC-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "McGroup"))
-                    elif concrete_tag == "MEASURED-EXECUTION-TIME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MeasuredExecutionTime"))
-                    elif concrete_tag == "MEASURED-HEAP-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MeasuredHeapUsage"))
-                    elif concrete_tag == "MEASURED-STACK-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MeasuredStackUsage"))
-                    elif concrete_tag == "MEMORY-SECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MemorySection"))
-                    elif concrete_tag == "MODE-ACCESS-POINT-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeAccessPointIdent"))
-                    elif concrete_tag == "MODE-DECLARATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclaration"))
-                    elif concrete_tag == "MODE-DECLARATION-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationGroup"))
-                    elif concrete_tag == "MODE-DECLARATION-GROUP-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationGroupPrototype"))
-                    elif concrete_tag == "MODE-DECLARATION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationMapping"))
-                    elif concrete_tag == "MODE-DECLARATION-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeDeclarationMappingSet"))
-                    elif concrete_tag == "MODE-INTERFACE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeInterfaceMapping"))
-                    elif concrete_tag == "MODE-SWITCH-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchInterface"))
-                    elif concrete_tag == "MODE-SWITCH-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchPoint"))
-                    elif concrete_tag == "MODE-SWITCHED-ACK-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeSwitchedAckEvent"))
-                    elif concrete_tag == "MODE-TRANSITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ModeTransition"))
-                    elif concrete_tag == "MULTILANGUAGE-REFERRABLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MultilanguageReferrable"))
-                    elif concrete_tag == "MULTIPLEXED-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "MultiplexedIPdu"))
-                    elif concrete_tag == "N-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NPdu"))
-                    elif concrete_tag == "NETWORK-ENDPOINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NetworkEndpoint"))
-                    elif concrete_tag == "NM-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NmConfig"))
-                    elif concrete_tag == "NM-ECU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NmEcu"))
-                    elif concrete_tag == "NM-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NmPdu"))
-                    elif concrete_tag == "NV-BLOCK-DESCRIPTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NvBlockDescriptor"))
-                    elif concrete_tag == "NV-BLOCK-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NvBlockNeeds"))
-                    elif concrete_tag == "NV-BLOCK-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NvBlockSwComponentType"))
-                    elif concrete_tag == "NV-DATA-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "NvDataInterface"))
-                    elif concrete_tag == "OBD-CONTROL-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdControlServiceNeeds"))
-                    elif concrete_tag == "OBD-INFO-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdInfoServiceNeeds"))
-                    elif concrete_tag == "OBD-MONITOR-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdMonitorServiceNeeds"))
-                    elif concrete_tag == "OBD-PID-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdPidServiceNeeds"))
-                    elif concrete_tag == "OBD-RATIO-DENOMINATOR-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdRatioDenominatorNeeds"))
-                    elif concrete_tag == "OBD-RATIO-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ObdRatioServiceNeeds"))
-                    elif concrete_tag == "OFFSET-TIMING-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "OffsetTimingConstraint"))
-                    elif concrete_tag == "OPERATION-INVOKED-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "OperationInvokedEvent"))
-                    elif concrete_tag == "OS-TASK-EXECUTION-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "OsTaskExecutionEvent"))
-                    elif concrete_tag == "OS-TASK-PROXY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "OsTaskProxy"))
-                    elif concrete_tag == "P-PORT-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PPortPrototype"))
-                    elif concrete_tag == "P-R-PORT-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PRPortPrototype"))
-                    elif concrete_tag == "PARAMETER-ACCESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ParameterAccess"))
-                    elif concrete_tag == "PARAMETER-DATA-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ParameterDataPrototype"))
-                    elif concrete_tag == "PARAMETER-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ParameterInterface"))
-                    elif concrete_tag == "PARAMETER-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ParameterSwComponentType"))
-                    elif concrete_tag == "PASS-THROUGH-SW-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PassThroughSwConnector"))
-                    elif concrete_tag == "PDU-ACTIVATION-ROUTING-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PduActivationRoutingGroup"))
-                    elif concrete_tag == "PDU-TO-FRAME-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PduToFrameMapping"))
-                    elif concrete_tag == "PDU-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PduTriggering"))
-                    elif concrete_tag == "PDUR-I-PDU-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PdurIPduGroup"))
-                    elif concrete_tag == "PER-INSTANCE-MEMORY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PerInstanceMemory"))
-                    elif concrete_tag == "PERIODIC-EVENT-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PeriodicEventTriggering"))
-                    elif concrete_tag == "PHYSICAL-DIMENSION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PhysicalDimension"))
-                    elif concrete_tag == "PHYSICAL-DIMENSION-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PhysicalDimensionMappingSet"))
-                    elif concrete_tag == "PNC-MAPPING-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PncMappingIdent"))
-                    elif concrete_tag == "PORT-ELEMENT-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PortElementToCommunicationResourceMapping"))
-                    elif concrete_tag == "PORT-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PortGroup"))
-                    elif concrete_tag == "PORT-INTERFACE-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PortInterfaceMappingSet"))
-                    elif concrete_tag == "PORT-PROTOTYPE-BLUEPRINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PortPrototypeBlueprint"))
-                    elif concrete_tag == "POST-BUILD-VARIANT-CRITERION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PostBuildVariantCriterion"))
-                    elif concrete_tag == "POST-BUILD-VARIANT-CRITERION-VALUE-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PostBuildVariantCriterionValueSet"))
-                    elif concrete_tag == "PREDEFINED-VARIANT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PredefinedVariant"))
-                    elif concrete_tag == "PRIMITIVE-ATTRIBUTE-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "PrimitiveAttributeTailoring"))
-                    elif concrete_tag == "PROVIDED-SERVICE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ProvidedServiceInstance"))
-                    elif concrete_tag == "R-PORT-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RPortPrototype"))
-                    elif concrete_tag == "RAPID-PROTOTYPING-SCENARIO":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RapidPrototypingScenario"))
-                    elif concrete_tag == "REFERENCE-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ReferenceTailoring"))
-                    elif concrete_tag == "RESOURCE-CONSUMPTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ResourceConsumption"))
-                    elif concrete_tag == "ROOT-SW-COMPOSITION-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RootSwCompositionPrototype"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-HEAP-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateHeapUsage"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-OF-EXECUTION-TIME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateOfExecutionTime"))
-                    elif concrete_tag == "ROUGH-ESTIMATE-STACK-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RoughEstimateStackUsage"))
-                    elif concrete_tag == "RPT-COMPONENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptComponent"))
-                    elif concrete_tag == "RPT-CONTAINER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptContainer"))
-                    elif concrete_tag == "RPT-EXECUTABLE-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptExecutableEntity"))
-                    elif concrete_tag == "RPT-EXECUTABLE-ENTITY-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptExecutableEntityEvent"))
-                    elif concrete_tag == "RPT-EXECUTION-CONTEXT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptExecutionContext"))
-                    elif concrete_tag == "RPT-PROFILE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptProfile"))
-                    elif concrete_tag == "RPT-SERVICE-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RptServicePoint"))
-                    elif concrete_tag == "RTE-EVENT-IN-COMPOSITION-SEPARATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RteEventInCompositionSeparation"))
-                    elif concrete_tag == "RTE-EVENT-IN-COMPOSITION-TO-OS-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RteEventInCompositionToOsTaskProxyMapping"))
-                    elif concrete_tag == "RTE-EVENT-IN-SYSTEM-SEPARATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RteEventInSystemSeparation"))
-                    elif concrete_tag == "RTE-EVENT-IN-SYSTEM-TO-OS-TASK-PROXY-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RteEventInSystemToOsTaskProxyMapping"))
-                    elif concrete_tag == "RUNNABLE-ENTITY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RunnableEntity"))
-                    elif concrete_tag == "RUNNABLE-ENTITY-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RunnableEntityGroup"))
-                    elif concrete_tag == "RUNTIME-ERROR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "RuntimeError"))
-                    elif concrete_tag == "S-O-M-E-I-P-TRANSFORMATION-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SOMEIPTransformationProps"))
-                    elif concrete_tag == "SDG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Sdg"))
-                    elif concrete_tag == "SDG-AGGREGATION-WITH-VARIATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgAggregationWithVariation"))
-                    elif concrete_tag == "SDG-CAPTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgCaption"))
-                    elif concrete_tag == "SDG-CLASS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgClass"))
-                    elif concrete_tag == "SDG-DEF":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgDef"))
-                    elif concrete_tag == "SDG-FOREIGN-REFERENCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgForeignReference"))
-                    elif concrete_tag == "SDG-FOREIGN-REFERENCE-WITH-VARIATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgForeignReferenceWithVariation"))
-                    elif concrete_tag == "SDG-PRIMITIVE-ATTRIBUTE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgPrimitiveAttribute"))
-                    elif concrete_tag == "SDG-PRIMITIVE-ATTRIBUTE-WITH-VARIATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgPrimitiveAttributeWithVariation"))
-                    elif concrete_tag == "SDG-TAILORING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SdgTailoring"))
-                    elif concrete_tag == "SEC-OC-CRYPTO-SERVICE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecOcCryptoServiceMapping"))
-                    elif concrete_tag == "SECTION-NAME-PREFIX":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SectionNamePrefix"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-AUTHENTICATION-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationAuthenticationProps"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-FRESHNESS-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationFreshnessProps"))
-                    elif concrete_tag == "SECURE-COMMUNICATION-PROPS-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecureCommunicationPropsSet"))
-                    elif concrete_tag == "SECURE-ON-BOARD-COMMUNICATION-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecureOnBoardCommunicationNeeds"))
-                    elif concrete_tag == "SECURED-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecuredIPdu"))
-                    elif concrete_tag == "SECURITY-EVENT-AGGREGATION-FILTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventAggregationFilter"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-APPLICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingApplication"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-BSW-MODULE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingBswModule"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-COMM-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingCommConnector"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-MAPPING-FUNCTIONAL-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextMappingFunctionalCluster"))
-                    elif concrete_tag == "SECURITY-EVENT-CONTEXT-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventContextProps"))
-                    elif concrete_tag == "SECURITY-EVENT-DEFINITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventDefinition"))
-                    elif concrete_tag == "SECURITY-EVENT-FILTER-CHAIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventFilterChain"))
-                    elif concrete_tag == "SECURITY-EVENT-ONE-EVERY-N-FILTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventOneEveryNFilter"))
-                    elif concrete_tag == "SECURITY-EVENT-STATE-FILTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SecurityEventStateFilter"))
-                    elif concrete_tag == "SENDER-RECEIVER-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SenderReceiverInterface"))
-                    elif concrete_tag == "SENSOR-ACTUATOR-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SensorActuatorSwComponentType"))
-                    elif concrete_tag == "SERVICE-INSTANCE-COLLECTION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ServiceInstanceCollectionSet"))
-                    elif concrete_tag == "SERVICE-PROXY-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ServiceProxySwComponentType"))
-                    elif concrete_tag == "SERVICE-SW-COMPONENT-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ServiceSwComponentType"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-ELEMENT-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationElementProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-EVENT-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationEventProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationProps"))
-                    elif concrete_tag == "SIGNAL-SERVICE-TRANSLATION-PROPS-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SignalServiceTranslationPropsSet"))
-                    elif concrete_tag == "SINGLE-LANGUAGE-REFERRABLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SingleLanguageReferrable"))
-                    elif concrete_tag == "SO-AD-ROUTING-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SoAdRoutingGroup"))
-                    elif concrete_tag == "SO-CON-I-PDU-IDENTIFIER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SoConIPduIdentifier"))
-                    elif concrete_tag == "SOCKET-ADDRESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SocketAddress"))
-                    elif concrete_tag == "SOCKET-CONNECTION-BUNDLE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SocketConnectionBundle"))
-                    elif concrete_tag == "SOCKET-CONNECTION-IPDU-IDENTIFIER-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SocketConnectionIpduIdentifierSet"))
-                    elif concrete_tag == "SOMEIP-SD-CLIENT-SERVICE-INSTANCE-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdClientServiceInstanceConfig"))
-                    elif concrete_tag == "SOMEIP-SD-SERVER-EVENT-GROUP-TIMING-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdServerEventGroupTimingConfig"))
-                    elif concrete_tag == "SOMEIP-SD-SERVER-SERVICE-INSTANCE-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SomeipSdServerServiceInstanceConfig"))
-                    elif concrete_tag == "SOMEIP-TP-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SomeipTpChannel"))
-                    elif concrete_tag == "SOMEIP-TP-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SomeipTpConfig"))
-                    elif concrete_tag == "SPECIFICATION-DOCUMENT-SCOPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SpecificationDocumentScope"))
-                    elif concrete_tag == "SPORADIC-EVENT-TRIGGERING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SporadicEventTriggering"))
-                    elif concrete_tag == "STATIC-SOCKET-CONNECTION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "StaticSocketConnection"))
-                    elif concrete_tag == "STD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Std"))
-                    elif concrete_tag == "STRUCTURED-REQ":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "StructuredReq"))
-                    elif concrete_tag == "SUPERVISED-ENTITY-CHECKPOINT-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SupervisedEntityCheckpointNeeds"))
-                    elif concrete_tag == "SUPERVISED-ENTITY-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SupervisedEntityNeeds"))
-                    elif concrete_tag == "SW-ADDR-METHOD":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwAddrMethod"))
-                    elif concrete_tag == "SW-AXIS-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwAxisType"))
-                    elif concrete_tag == "SW-BASE-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwBaseType"))
-                    elif concrete_tag == "SW-GENERIC-AXIS-PARAM-TYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwGenericAxisParamType"))
-                    elif concrete_tag == "SW-RECORD-LAYOUT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwRecordLayout"))
-                    elif concrete_tag == "SW-SERVICE-ARG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwServiceArg"))
-                    elif concrete_tag == "SW-SYSTEMCONST":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwSystemconst"))
-                    elif concrete_tag == "SW-SYSTEMCONSTANT-VALUE-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwSystemconstantValueSet"))
-                    elif concrete_tag == "SWC-BSW-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcBswMapping"))
-                    elif concrete_tag == "SWC-IMPLEMENTATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcImplementation"))
-                    elif concrete_tag == "SWC-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcInternalBehavior"))
-                    elif concrete_tag == "SWC-MODE-MANAGER-ERROR-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcModeManagerErrorEvent"))
-                    elif concrete_tag == "SWC-MODE-SWITCH-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcModeSwitchEvent"))
-                    elif concrete_tag == "SWC-SERVICE-DEPENDENCY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcServiceDependency"))
-                    elif concrete_tag == "SWC-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcTiming"))
-                    elif concrete_tag == "SWC-TO-APPLICATION-PARTITION-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcToApplicationPartitionMapping"))
-                    elif concrete_tag == "SWC-TO-ECU-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcToEcuMapping"))
-                    elif concrete_tag == "SWC-TO-IMPL-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwcToImplMapping"))
-                    elif concrete_tag == "SWITCH-ASYNCHRONOUS-TRAFFIC-SHAPER-GROUP-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchAsynchronousTrafficShaperGroupEntry"))
-                    elif concrete_tag == "SWITCH-FLOW-METERING-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchFlowMeteringEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-ACTION-DEST-PORT-MODIFICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterActionDestPortModification"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-FILTER-RULE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamFilterRule"))
-                    elif concrete_tag == "SWITCH-STREAM-GATE-ENTRY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamGateEntry"))
-                    elif concrete_tag == "SWITCH-STREAM-IDENTIFICATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SwitchStreamIdentification"))
-                    elif concrete_tag == "SYMBOL-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SymbolProps"))
-                    elif concrete_tag == "SYNC-TIME-BASE-MGR-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SyncTimeBaseMgrUserNeeds"))
-                    elif concrete_tag == "SYNCHRONIZATION-POINT-CONSTRAINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SynchronizationPointConstraint"))
-                    elif concrete_tag == "SYNCHRONOUS-SERVER-CALL-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SynchronousServerCallPoint"))
-                    elif concrete_tag == "SYSTEM":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "System"))
-                    elif concrete_tag == "SYSTEM-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemMapping"))
-                    elif concrete_tag == "SYSTEM-SIGNAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemSignal"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalGroup"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-GROUP-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalGroupToCommunicationResourceMapping"))
-                    elif concrete_tag == "SYSTEM-SIGNAL-TO-COMMUNICATION-RESOURCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemSignalToCommunicationResourceMapping"))
-                    elif concrete_tag == "SYSTEM-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "SystemTiming"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterMapping"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-MAPPING-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterMappingSet"))
-                    elif concrete_tag == "T-D-CP-SOFTWARE-CLUSTER-RESOURCE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDCpSoftwareClusterResourceMapping"))
-                    elif concrete_tag == "T-D-EVENT-BSW-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswInternalBehavior"))
-                    elif concrete_tag == "T-D-EVENT-BSW-MODE-DECLARATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswModeDeclaration"))
-                    elif concrete_tag == "T-D-EVENT-BSW-MODULE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventBswModule"))
-                    elif concrete_tag == "T-D-EVENT-COMPLEX":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventComplex"))
-                    elif concrete_tag == "T-D-EVENT-FR-CLUSTER-CYCLE-START":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrClusterCycleStart"))
-                    elif concrete_tag == "T-D-EVENT-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrame"))
-                    elif concrete_tag == "T-D-EVENT-FRAME-ETHERNET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventFrameEthernet"))
-                    elif concrete_tag == "T-D-EVENT-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventIPdu"))
-                    elif concrete_tag == "T-D-EVENT-I-SIGNAL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventISignal"))
-                    elif concrete_tag == "T-D-EVENT-MODE-DECLARATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventModeDeclaration"))
-                    elif concrete_tag == "T-D-EVENT-OPERATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventOperation"))
-                    elif concrete_tag == "T-D-EVENT-S-L-L-E-T-PORT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventSLLETPort"))
-                    elif concrete_tag == "T-D-EVENT-SWC-INTERNAL-BEHAVIOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventSwcInternalBehavior"))
-                    elif concrete_tag == "T-D-EVENT-SWC-INTERNAL-BEHAVIOR-REFERENCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventSwcInternalBehaviorReference"))
-                    elif concrete_tag == "T-D-EVENT-T-T-CAN-CYCLE-START":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventTTCanCycleStart"))
-                    elif concrete_tag == "T-D-EVENT-TRIGGER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventTrigger"))
-                    elif concrete_tag == "T-D-EVENT-VARIABLE-DATA-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventVariableDataPrototype"))
-                    elif concrete_tag == "T-D-EVENT-VFB-REFERENCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDEventVfbReference"))
-                    elif concrete_tag == "T-D-L-E-T-ZONE-CLOCK":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TDLETZoneClock"))
-                    elif concrete_tag == "TCP-OPTION-FILTER-LIST":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TcpOptionFilterList"))
-                    elif concrete_tag == "TCP-OPTION-FILTER-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TcpOptionFilterSet"))
-                    elif concrete_tag == "TIME-SYNC-SERVER-CONFIGURATION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimeSyncServerConfiguration"))
-                    elif concrete_tag == "TIMING-CLOCK-SYNC-ACCURACY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingClockSyncAccuracy"))
-                    elif concrete_tag == "TIMING-CONDITION":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingCondition"))
-                    elif concrete_tag == "TIMING-DESCRIPTION-EVENT-CHAIN":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingDescriptionEventChain"))
-                    elif concrete_tag == "TIMING-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingEvent"))
-                    elif concrete_tag == "TIMING-EXTENSION-RESOURCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingExtensionResource"))
-                    elif concrete_tag == "TIMING-MODE-INSTANCE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TimingModeInstance"))
-                    elif concrete_tag == "TLS-CRYPTO-CIPHER-SUITE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoCipherSuite"))
-                    elif concrete_tag == "TLS-CRYPTO-CIPHER-SUITE-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoCipherSuiteProps"))
-                    elif concrete_tag == "TLS-CRYPTO-SERVICE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TlsCryptoServiceMapping"))
-                    elif concrete_tag == "TLV-DATA-ID-DEFINITION-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TlvDataIdDefinitionSet"))
-                    elif concrete_tag == "TOPIC1":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Topic1"))
-                    elif concrete_tag == "TP-ADDRESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TpAddress"))
-                    elif concrete_tag == "TP-CONNECTION-IDENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TpConnectionIdent"))
-                    elif concrete_tag == "TRACEABLE-TEXT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TraceableText"))
-                    elif concrete_tag == "TRANSFORMATION-PROPS-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TransformationPropsSet"))
-                    elif concrete_tag == "TRANSFORMATION-TECHNOLOGY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TransformationTechnology"))
-                    elif concrete_tag == "TRANSFORMER-HARD-ERROR-EVENT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TransformerHardErrorEvent"))
-                    elif concrete_tag == "TRANSIENT-FAULT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TransientFault"))
-                    elif concrete_tag == "TRIGGER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Trigger"))
-                    elif concrete_tag == "TRIGGER-INTERFACE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TriggerInterface"))
-                    elif concrete_tag == "TRIGGER-INTERFACE-MAPPING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TriggerInterfaceMapping"))
-                    elif concrete_tag == "TTCAN-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TtcanCluster"))
-                    elif concrete_tag == "TTCAN-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TtcanCommunicationConnector"))
-                    elif concrete_tag == "TTCAN-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TtcanCommunicationController"))
-                    elif concrete_tag == "TTCAN-PHYSICAL-CHANNEL":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "TtcanPhysicalChannel"))
-                    elif concrete_tag == "UDP-NM-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UdpNmCluster"))
-                    elif concrete_tag == "UDP-NM-NODE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UdpNmNode"))
-                    elif concrete_tag == "UNIT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Unit"))
-                    elif concrete_tag == "UNIT-GROUP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UnitGroup"))
-                    elif concrete_tag == "USER-DEFINED-CLUSTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCluster"))
-                    elif concrete_tag == "USER-DEFINED-COMMUNICATION-CONNECTOR":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCommunicationConnector"))
-                    elif concrete_tag == "USER-DEFINED-COMMUNICATION-CONTROLLER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedCommunicationController"))
-                    elif concrete_tag == "USER-DEFINED-ETHERNET-FRAME":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedEthernetFrame"))
-                    elif concrete_tag == "USER-DEFINED-GLOBAL-TIME-MASTER":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedGlobalTimeMaster"))
-                    elif concrete_tag == "USER-DEFINED-GLOBAL-TIME-SLAVE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedGlobalTimeSlave"))
-                    elif concrete_tag == "USER-DEFINED-I-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedIPdu"))
-                    elif concrete_tag == "USER-DEFINED-PDU":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedPdu"))
-                    elif concrete_tag == "USER-DEFINED-TRANSFORMATION-PROPS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "UserDefinedTransformationProps"))
-                    elif concrete_tag == "V2X-DATA-MANAGER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "V2xDataManagerNeeds"))
-                    elif concrete_tag == "V2X-FAC-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "V2xFacUserNeeds"))
-                    elif concrete_tag == "V2X-M-USER-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "V2xMUserNeeds"))
-                    elif concrete_tag == "VARIABLE-ACCESS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VariableAccess"))
-                    elif concrete_tag == "VARIABLE-DATA-PROTOTYPE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VariableDataPrototype"))
-                    elif concrete_tag == "VARIATION-POINT-PROXY":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VariationPointProxy"))
-                    elif concrete_tag == "VENDOR-SPECIFIC-SERVICE-NEEDS":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VendorSpecificServiceNeeds"))
-                    elif concrete_tag == "VFB-TIMING":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VfbTiming"))
-                    elif concrete_tag == "VIEW-MAP":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ViewMap"))
-                    elif concrete_tag == "VIEW-MAP-SET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "ViewMapSet"))
-                    elif concrete_tag == "VLAN-CONFIG":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "VlanConfig"))
-                    elif concrete_tag == "WAIT-POINT":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "WaitPoint"))
-                    elif concrete_tag == "WORST-CASE-HEAP-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "WorstCaseHeapUsage"))
-                    elif concrete_tag == "WORST-CASE-STACK-USAGE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "WorstCaseStackUsage"))
-                    elif concrete_tag == "XDOC":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Xdoc"))
-                    elif concrete_tag == "XFILE":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "Xfile"))
-                    elif concrete_tag == "XREF-TARGET":
-                        setattr(obj, "sdxf", SerializationHelper.deserialize_by_tag(child[0], "XrefTarget"))
+                sdxf_children.append(child)
+
+        # If we have any children, create SdgContents to hold them
+        if sd_children or sdf_children or sdg_children or sdx_children or sdxf_children:
+            obj.sdg_contents_type = SdgContents()
+
+            # Deserialize ALL children into SdgContents lists
+            for sd_child in sd_children:
+                obj.sdg_contents_type.sd.append(SerializationHelper.deserialize_by_tag(sd_child, "Sd"))
+            # Also set legacy attribute for backward compatibility (first element)
+            if obj.sdg_contents_type.sd:
+                obj.sd = obj.sdg_contents_type.sd[0]
+
+            for sdf_child in sdf_children:
+                obj.sdg_contents_type.sdf.append(SerializationHelper.deserialize_by_tag(sdf_child, "Sdf"))
+            if obj.sdg_contents_type.sdf:
+                obj.sdf = obj.sdg_contents_type.sdf[0]
+
+            for sdg_child in sdg_children:
+                obj.sdg_contents_type.sdg.append(SerializationHelper.deserialize_by_tag(sdg_child, "Sdg"))
+            if obj.sdg_contents_type.sdg:
+                obj.sdg = obj.sdg_contents_type.sdg[0]
+
+            # For SDX/SDXF: handle polymorphic references
+            for sdx_child in sdx_children:
+                obj.sdg_contents_type.sdx_ref.append(SerializationHelper.deserialize_by_tag(sdx_child, "ARRef"))
+            if obj.sdg_contents_type.sdx_ref:
+                obj.sdx = obj.sdg_contents_type.sdx_ref[0]
+
+            for sdxf_child in sdxf_children:
+                obj.sdg_contents_type.sdxf_ref.append(SerializationHelper.deserialize_by_tag(sdxf_child, "ARRef"))
+            if obj.sdg_contents_type.sdxf_ref:
+                obj.sdxf = obj.sdg_contents_type.sdxf_ref[0]
 
         return obj
 
 
-
 class SdgBuilder(BuilderBase):
-    """Builder for Sdg with fluent API."""
+    """Builder for Sdg objects."""
 
     def __init__(self) -> None:
-        """Initialize builder with defaults."""
-        super().__init__()
-        self._obj: Sdg = Sdg()
+        """Initialize SdgBuilder."""
+        self._instance: Optional[Sdg] = None
 
+    def _get_instance(self) -> Sdg:
+        """Get or create the Sdg instance."""
+        if self._instance is None:
+            self._instance = Sdg()
+        return self._instance
 
-    def with_gid(self, value: NameToken) -> "SdgBuilder":
-        """Set gid attribute.
+    def with_gid(self, gid: NameToken) -> "SdgBuilder":
+        """Set the GID attribute.
 
         Args:
-            value: Value to set
+            gid: Group identifier value
 
         Returns:
             self for method chaining
         """
-        if value is None and not False:
-            raise ValueError("Attribute 'gid' is required and cannot be None")
-        self._obj.gid = value
+        obj = self._get_instance()
+        obj.gid = gid
         return self
 
-    def with_sdg_caption(self, value: Optional[SdgCaption]) -> "SdgBuilder":
-        """Set sdg_caption attribute.
+    def with_sdg_caption(self, sdg_caption: Optional[SdgCaption]) -> "SdgBuilder":
+        """Set the sdg_caption attribute.
 
         Args:
-            value: Value to set
+            sdg_caption: SdgCaption value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdg_caption' is required and cannot be None")
-        self._obj.sdg_caption = value
+        obj = self._get_instance()
+        obj.sdg_caption = sdg_caption
         return self
 
-    def with_sd(self, value: Optional[Sd]) -> "SdgBuilder":
-        """Set sd attribute.
+    def with_sdg_contents_type(self, sdg_contents_type: Optional["SdgContents"]) -> "SdgBuilder":
+        """Set the sdg_contents_type attribute.
 
         Args:
-            value: Value to set
+            sdg_contents_type: SdgContents value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sd' is required and cannot be None")
-        self._obj.sd = value
+        obj = self._get_instance()
+        obj.sdg_contents_type = sdg_contents_type
         return self
 
-    def with_sdf(self, value: Optional[Sdf]) -> "SdgBuilder":
-        """Set sdf attribute.
+    def with_sd(self, sd: Optional[Sd]) -> "SdgBuilder":
+        """Set the sd attribute (legacy).
 
         Args:
-            value: Value to set
+            sd: Sd value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdf' is required and cannot be None")
-        self._obj.sdf = value
+        obj = self._get_instance()
+        obj.sd = sd
         return self
 
-    def with_sdg(self, value: Optional[Sdg]) -> "SdgBuilder":
-        """Set sdg attribute.
+    def with_sdf(self, sdf: Optional[Sdf]) -> "SdgBuilder":
+        """Set the sdf attribute (legacy).
 
         Args:
-            value: Value to set
+            sdf: Sdf value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdg' is required and cannot be None")
-        self._obj.sdg = value
+        obj = self._get_instance()
+        obj.sdf = sdf
         return self
 
-    def with_sdx(self, value: Optional[Referrable]) -> "SdgBuilder":
-        """Set sdx attribute.
+    def with_sdg(self, sdg: Optional["Sdg"]) -> "SdgBuilder":
+        """Set the sdg attribute (legacy).
 
         Args:
-            value: Value to set
+            sdg: Sdg value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdx' is required and cannot be None")
-        self._obj.sdx = value
+        obj = self._get_instance()
+        obj.sdg = sdg
         return self
 
-    def with_sdxf(self, value: Optional[Referrable]) -> "SdgBuilder":
-        """Set sdxf attribute.
+    def with_sdx(self, sdx: Optional[Referrable]) -> "SdgBuilder":
+        """Set the sdx attribute (legacy).
 
         Args:
-            value: Value to set
+            sdx: Referrable value
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdxf' is required and cannot be None")
-        self._obj.sdxf = value
+        obj = self._get_instance()
+        obj.sdx = sdx
         return self
 
+    def with_sdxf(self, sdxf: Optional[Referrable]) -> "SdgBuilder":
+        """Set the sdxf attribute (legacy).
 
+        Args:
+            sdxf: Referrable value
 
-    # Pre-computed validation constants (generated from JSON schema)
-    _REQUIRED_ATTRIBUTES = {
-        "gid",
-    }
-    _OPTIONAL_ATTRIBUTES = {
-        "sdgCaption",
-        "sdgContentsType",
-    }
-
-
-    def _validate_instance(self) -> None:
-        """Validate the built instance based on settings."""
-        from armodel2.core import GlobalSettingsManager, BuilderValidationMode
-
-        settings = GlobalSettingsManager()
-        mode = settings.builder_validation
-
-        if mode == BuilderValidationMode.DISABLED:
-            return
-
-        # Validate required attributes using pre-computed constants (O(1) lookup)
-        # This is much faster than calling get_type_hints() at runtime
-        if getattr(self._obj, "gid", None) is None:
-            if mode == BuilderValidationMode.STRICT:
-                raise ValueError("Required attribute 'gid' is None")
-            elif mode == BuilderValidationMode.LENIENT:
-                import warnings
-                warnings.warn("Required attribute 'gid' is None", UserWarning)
-
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdxf = sdxf
+        return self
 
     def build(self) -> Sdg:
-        """Build and return the Sdg instance with validation."""
-        self._validate_instance()
-        return self._obj
+        """Build and return the Sdg object.
+
+        Returns:
+            The constructed Sdg object
+        """
+        obj = self._get_instance()
+        if obj is None:
+            obj = Sdg()
+        return obj

--- a/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg_contents.py
+++ b/src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg_contents.py
@@ -3,10 +3,15 @@
 References:
   - AUTOSAR_FO_TPS_GenericStructureTemplate.pdf (page 90)
 
-JSON Source: docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json"""
+JSON Source: docs/json/packages/M2_MSR_AsamHdo_SpecialData.classes.json
+
+NOTE: This file is manually maintained to properly handle the atp_mixed pattern
+where multiple SD/SDF/SDG children can appear under SDG.
+The attributes use LIST types to support multiple children of the same type.
+"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, List
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import atp_mixed
 
@@ -27,14 +32,26 @@ if TYPE_CHECKING:
         Sdg,
     )
 
-
-
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-@atp_mixed()
 
+@atp_mixed()
 class SdgContents(ARObject):
-    """AUTOSAR SdgContents."""
+    """AUTOSAR SdgContents.
+
+    The SdgContents class uses the atp_mixed pattern where its children
+    serialize directly under the parent SDG element without a wrapper.
+
+    This implementation uses LIST attributes to support multiple children
+    of the same type (e.g., multiple SD elements under a single SDG).
+
+    Attributes:
+        sd: List of SD elements
+        sdf: List of SDF elements
+        sdg: List of nested SDG elements
+        sdx_ref: List of SDX-REF elements (polymorphic references)
+        sdxf_ref: List of SDXF-REF elements (polymorphic references)
+    """
 
     @property
     def is_abstract(self) -> bool:
@@ -47,32 +64,24 @@ class SdgContents(ARObject):
 
     _XML_TAG = "SDG-CONTENTS"
 
-
-    sd: Optional[Sd]
-    sdf: Optional[Sdf]
-    sdg: Optional[Sdg]
-    sdx_ref: Optional[ARRef]
-    sdxf_ref: Optional[ARRef]
-    _DESERIALIZE_DISPATCH = {
-        "SD": lambda obj, elem: setattr(obj, "sd", SerializationHelper.deserialize_by_tag(elem, "Sd")),
-        "SDF": lambda obj, elem: setattr(obj, "sdf", SerializationHelper.deserialize_by_tag(elem, "Sdf")),
-        "SDG": lambda obj, elem: setattr(obj, "sdg", SerializationHelper.deserialize_by_tag(elem, "Sdg")),
-        "SDX-REF": ("_POLYMORPHIC", "sdx_ref", ["ARPackage", "AclObjectSet", "AclOperation", "AclPermission", "AclRole", "AgeConstraint", "AggregationTailoring", "AliasNameSet", "AnalyzedExecutionTime", "AppOsTaskProxyToEcuTaskProxyMapping", "ApplicationArrayDataType", "ApplicationArrayElement", "ApplicationEndpoint", "ApplicationError", "ApplicationPartition", "ApplicationPartitionToEcuPartitionMapping", "ApplicationPrimitiveDataType", "ApplicationRecordDataType", "ApplicationRecordElement", "ApplicationSwComponentType", "ArbitraryEventTriggering", "ArgumentDataPrototype", "AssemblySwConnector", "AsynchronousServerCallPoint", "AsynchronousServerCallResultPoint", "AsynchronousServerCallReturnsEvent", "AtpDefinition", "AutosarOperationArgumentInstance", "AutosarVariableInstance", "BackgroundEvent", "BinaryManifestItem", "BinaryManifestItemDefinition", "BinaryManifestMetaDataField", "BinaryManifestProvideResource", "BinaryManifestRequireResource", "BinaryManifestResourceDefinition", "BlockState", "BlueprintMappingSet", "BswAsynchronousServerCallPoint", "BswAsynchronousServerCallResultPoint", "BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswCalledEntity", "BswCompositionTiming", "BswDataReceivedEvent", "BswDirectCallPoint", "BswDistinguishedPartition", "BswEntryRelationshipSet", "BswExternalTriggerOccurredEvent", "BswImplementation", "BswInternalBehavior", "BswInternalTriggerOccurredEvent", "BswInternalTriggeringPoint", "BswInterruptEntity", "BswInterruptEvent", "BswMgrNeeds", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswModuleCallPoint", "BswModuleClientServerEntry", "BswModuleDependency", "BswModuleDescription", "BswModuleEntry", "BswModuleTiming", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswSchedulableEntity", "BswSchedulerNamePrefix", "BswServiceDependencyIdent", "BswTimingEvent", "BswVariableAccess", "BuildAction", "BuildActionEnvironment", "BuildActionManifest", "BulkNvDataDescriptor", "BurstPatternEventTriggering", "BusMirrorChannelMappingCan", "BusMirrorChannelMappingFlexray", "BusMirrorChannelMappingIp", "CalibrationParameterValueSet", "CanCluster", "CanCommunicationConnector", "CanCommunicationController", "CanFrame", "CanFrameTriggering", "CanNmCluster", "CanNmNode", "CanPhysicalChannel", "CanTpAddress", "CanTpChannel", "CanTpConfig", "CanTpNode", "Caption", "Chapter", "ClassContentConditional", "ClientIdDefinition", "ClientIdDefinitionSet", "ClientServerInterface", "ClientServerInterfaceMapping", "ClientServerInterfaceToBswModuleEntryBlueprintMapping", "ClientServerOperation", "Code", "Collection", "ComManagementMapping", "ComMgrUserNeeds", "Compiler", "ComplexDeviceDriverSwComponentType", "CompositionSwComponentType", "CompuMethod", "ConcreteClassTailoring", "ConcretePatternEventTriggering", "ConsistencyNeeds", "ConsistencyNeedsBlueprintSet", "ConstantSpecification", "ConstantSpecificationMappingSet", "ConstraintTailoring", "ConsumedEventGroup", "ConsumedProvidedServiceInstanceGroup", "ConsumedServiceInstance", "ContainerIPdu", "CouplingElement", "CouplingElementSwitchDetails", "CouplingPort", "CouplingPortFifo", "CouplingPortScheduler", "CouplingPortShaper", "CouplingPortTrafficClassAssignment", "CpSoftwareCluster", "CpSoftwareClusterBinaryManifestDescriptor", "CpSoftwareClusterCommunicationResource", "CpSoftwareClusterMappingSet", "CpSoftwareClusterResourcePool", "CpSoftwareClusterResourceToApplicationPartitionMapping", "CpSoftwareClusterServiceResource", "CpSoftwareClusterToApplicationPartitionMapping", "CpSoftwareClusterToEcuInstanceMapping", "CpSoftwareClusterToResourceMapping", "CpSwClusterResourceToDiagDataElemMapping", "CpSwClusterResourceToDiagFunctionIdMapping", "CpSwClusterToDiagEventMapping", "CpSwClusterToDiagRoutineSubfunctionMapping", "CryptoEllipticCurveProps", "CryptoKeyManagementNeeds", "CryptoServiceCertificate", "CryptoServiceJobNeeds", "CryptoServiceKey", "CryptoServiceNeeds", "CryptoServicePrimitive", "CryptoServiceQueue", "CryptoSignatureScheme", "DataConstr", "DataExchangePoint", "DataPrototypeGroup", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataTransformationSet", "DataTypeMappingSet", "DataWriteCompletedEvent", "DcmIPdu", "DdsCpConfig", "DdsCpConsumedServiceInstance", "DdsCpDomain", "DdsCpPartition", "DdsCpProvidedServiceInstance", "DdsCpQosProfile", "DdsCpTopic", "DefItem", "DelegationSwConnector", "DependencyOnArtifact", "DevelopmentError", "DiagEventDebounceCounterBased", "DiagEventDebounceMonitorInternal", "DiagnosticAccessPermission", "DiagnosticAging", "DiagnosticAuthRole", "DiagnosticAuthTransmitCertificate", "DiagnosticAuthTransmitCertificateEvaluation", "DiagnosticAuthTransmitCertificateMapping", "DiagnosticAuthenticationClass", "DiagnosticAuthenticationConfiguration", "DiagnosticClearDiagnosticInformation", "DiagnosticClearDiagnosticInformationClass", "DiagnosticClearResetEmissionRelatedInfo", "DiagnosticClearResetEmissionRelatedInfoClass", "DiagnosticComControl", "DiagnosticComControlClass", "DiagnosticCommunicationManagerNeeds", "DiagnosticComponentNeeds", "DiagnosticConnectedIndicator", "DiagnosticConnection", "DiagnosticContributionSet", "DiagnosticControlDTCSetting", "DiagnosticControlDTCSettingClass", "DiagnosticControlNeeds", "DiagnosticCustomServiceClass", "DiagnosticCustomServiceInstance", "DiagnosticDataElement", "DiagnosticDataIdentifier", "DiagnosticDataIdentifierSet", "DiagnosticDataTransfer", "DiagnosticDataTransferClass", "DiagnosticDeAuthentication", "DiagnosticDebounceAlgorithmProps", "DiagnosticDemProvidedDataMapping", "DiagnosticDynamicDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifierClass", "DiagnosticEcuInstanceProps", "DiagnosticEcuReset", "DiagnosticEcuResetClass", "DiagnosticEnableCondition", "DiagnosticEnableConditionGroup", "DiagnosticEnableConditionNeeds", "DiagnosticEnableConditionPortMapping", "DiagnosticEnvBswModeElement", "DiagnosticEnvModeElement", "DiagnosticEnvSwcModeElement", "DiagnosticEnvironmentalCondition", "DiagnosticEvent", "DiagnosticEventInfoNeeds", "DiagnosticEventManagerNeeds", "DiagnosticEventNeeds", "DiagnosticEventPortMapping", "DiagnosticEventToDebounceAlgorithmMapping", "DiagnosticEventToEnableConditionGroupMapping", "DiagnosticEventToOperationCycleMapping", "DiagnosticEventToSecurityEventMapping", "DiagnosticEventToStorageConditionGroupMapping", "DiagnosticEventToTroubleCodeJ1939Mapping", "DiagnosticEventToTroubleCodeUdsMapping", "DiagnosticExtendedDataRecord", "DiagnosticFimAliasEvent", "DiagnosticFimAliasEventGroup", "DiagnosticFimAliasEventGroupMapping", "DiagnosticFimAliasEventMapping", "DiagnosticFimEventGroup", "DiagnosticFimFunctionMapping", "DiagnosticFreezeFrame", "DiagnosticFunctionIdentifier", "DiagnosticFunctionIdentifierInhibit", "DiagnosticFunctionInhibitSource", "DiagnosticIOControl", "DiagnosticIndicator", "DiagnosticInfoType", "DiagnosticInhibitSourceEventMapping", "DiagnosticIoControlClass", "DiagnosticIoControlNeeds", "DiagnosticIumpr", "DiagnosticIumprDenominatorGroup", "DiagnosticIumprGroup", "DiagnosticIumprToFunctionIdentifierMapping", "DiagnosticJ1939ExpandedFreezeFrame", "DiagnosticJ1939FreezeFrame", "DiagnosticJ1939Node", "DiagnosticJ1939Spn", "DiagnosticJ1939SpnMapping", "DiagnosticJ1939SwMapping", "DiagnosticMasterToSlaveEventMapping", "DiagnosticMeasurementIdentifier", "DiagnosticMemoryDestinationPrimary", "DiagnosticMemoryDestinationUserDefined", "DiagnosticMemoryIdentifier", "DiagnosticOperationCycle", "DiagnosticOperationCycleNeeds", "DiagnosticOperationCyclePortMapping", "DiagnosticParameterElement", "DiagnosticParameterIdent", "DiagnosticParameterIdentifier", "DiagnosticPowertrainFreezeFrame", "DiagnosticProofOfOwnership", "DiagnosticProtocol", "DiagnosticReadDTCInformation", "DiagnosticReadDTCInformationClass", "DiagnosticReadDataByIdentifier", "DiagnosticReadDataByIdentifierClass", "DiagnosticReadDataByPeriodicID", "DiagnosticReadDataByPeriodicIDClass", "DiagnosticReadMemoryByAddress", "DiagnosticReadMemoryByAddressClass", "DiagnosticReadScalingDataByIdentifier", "DiagnosticReadScalingDataByIdentifierClass", "DiagnosticRequestControlOfOnBoardDevice", "DiagnosticRequestControlOfOnBoardDeviceClass", "DiagnosticRequestCurrentPowertrainData", "DiagnosticRequestCurrentPowertrainDataClass", "DiagnosticRequestDownload", "DiagnosticRequestDownloadClass", "DiagnosticRequestEmissionRelatedDTC", "DiagnosticRequestEmissionRelatedDTCClass", "DiagnosticRequestEmissionRelatedDTCPermanentStatus", "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass", "DiagnosticRequestFileTransfer", "DiagnosticRequestFileTransferClass", "DiagnosticRequestFileTransferNeeds", "DiagnosticRequestOnBoardMonitoringTestResults", "DiagnosticRequestOnBoardMonitoringTestResultsClass", "DiagnosticRequestPowertrainFreezeFrameData", "DiagnosticRequestPowertrainFreezeFrameDataClass", "DiagnosticRequestRoutineResults", "DiagnosticRequestUpload", "DiagnosticRequestUploadClass", "DiagnosticRequestVehicleInfo", "DiagnosticRequestVehicleInfoClass", "DiagnosticResponseOnEvent", "DiagnosticResponseOnEventClass", "DiagnosticRoutine", "DiagnosticRoutineControl", "DiagnosticRoutineControlClass", "DiagnosticRoutineNeeds", "DiagnosticSecureCodingMapping", "DiagnosticSecurityAccess", "DiagnosticSecurityAccessClass", "DiagnosticSecurityEventReportingModeMapping", "DiagnosticSecurityLevel", "DiagnosticServiceDataMapping", "DiagnosticServiceSwMapping", "DiagnosticServiceTable", "DiagnosticSession", "DiagnosticSessionControl", "DiagnosticSessionControlClass", "DiagnosticStartRoutine", "DiagnosticStopRoutine", "DiagnosticStorageCondition", "DiagnosticStorageConditionGroup", "DiagnosticStorageConditionNeeds", "DiagnosticStorageConditionPortMapping", "DiagnosticTestResult", "DiagnosticTestRoutineIdentifier", "DiagnosticTransferExit", "DiagnosticTransferExitClass", "DiagnosticTroubleCodeGroup", "DiagnosticTroubleCodeJ1939", "DiagnosticTroubleCodeObd", "DiagnosticTroubleCodeProps", "DiagnosticTroubleCodeUds", "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping", "DiagnosticUploadDownloadNeeds", "DiagnosticValueNeeds", "DiagnosticVerifyCertificateBidirectional", "DiagnosticWriteDataByIdentifierClass", "DiagnosticWriteMemoryByAddressClass", "DiagnosticsCommunicationSecurityNeeds", "DltApplication", "DltArgument", "DltContext", "DltEcu", "DltLogChannel", "DltMessage", "DltUserNeeds", "DoIpActivationLineNeeds", "DoIpGidNeeds", "DoIpGidSynchronizationNeeds", "DoIpInterface", "DoIpLogicAddress", "DoIpLogicTargetAddressProps", "DoIpLogicTesterAddressProps", "DoIpPowerModeStatusNeeds", "DoIpRoutingActivation", "DoIpRoutingActivationAuthenticationNeeds", "DoIpRoutingActivationConfirmationNeeds", "DoIpTpConfig", "DocumentElementScope", "Documentation", "DocumentationContext", "DtcStatusChangeNotificationNeeds", "E2EProfileCompatibilityProps", "ECUMapping", "EOCEventRef", "EOCExecutableEntityRef", "EOCExecutableEntityRefGroup", "EcuAbstractionSwComponentType", "EcuInstance", "EcuPartition", "EcuStateMgrUserNeeds", "EcuTiming", "EcucAddInfoParamDef", "EcucBooleanParamDef", "EcucChoiceContainerDef", "EcucChoiceReferenceDef", "EcucContainerValue", "EcucDefinitionCollection", "EcucDestinationUriDef", "EcucDestinationUriDefSet", "EcucEnumerationLiteralDef", "EcucEnumerationParamDef", "EcucFloatParamDef", "EcucForeignReferenceDef", "EcucFunctionNameDef", "EcucInstanceReferenceDef", "EcucIntegerParamDef", "EcucLinkerSymbolDef", "EcucModuleConfigurationValues", "EcucModuleDef", "EcucMultilineStringParamDef", "EcucParamConfContainerDef", "EcucQuery", "EcucReferenceDef", "EcucStringParamDef", "EcucUriReferenceDef", "EcucValidationCondition", "EcucValueCollection", "EndToEndProtection", "EndToEndProtectionSet", "EnumerationMappingTable", "ErrorTracerNeeds", "EthIpProps", "EthTcpIpIcmpProps", "EthTcpIpProps", "EthTpConfig", "EthernetCluster", "EthernetCommunicationConnector", "EthernetCommunicationController", "EthernetFrameTriggering", "EthernetPhysicalChannel", "EthernetPriorityRegeneration", "EthernetWakeupSleepOnDatalineConfig", "EthernetWakeupSleepOnDatalineConfigSet", "EvaluatedVariantSet", "EventHandler", "ExclusiveArea", "ExclusiveAreaNestingOrder", "ExecutableEntityActivationReason", "ExecutionOrderConstraint", "ExecutionTimeConstraint", "ExternalTriggerOccurredEvent", "ExternalTriggeringPointIdent", "FMAttributeDef", "FMFeature", "FMFeatureMap", "FMFeatureMapAssertion", "FMFeatureMapCondition", "FMFeatureMapElement", "FMFeatureModel", "FMFeatureRelation", "FMFeatureRestriction", "FMFeatureSelection", "FMFeatureSelectionSet", "FirewallRule", "FlatInstanceDescriptor", "FlatMap", "FlexrayArTpConfig", "FlexrayArTpNode", "FlexrayCluster", "FlexrayCommunicationConnector", "FlexrayCommunicationController", "FlexrayFrame", "FlexrayFrameTriggering", "FlexrayNmCluster", "FlexrayNmNode", "FlexrayPhysicalChannel", "FlexrayTpConfig", "FlexrayTpConnectionControl", "FlexrayTpNode", "FlexrayTpPduPool", "FramePort", "FunctionInhibitionAvailabilityNeeds", "FunctionInhibitionNeeds", "Gateway", "GeneralPurposeConnection", "GeneralPurposeIPdu", "GeneralPurposePdu", "GenericEthernetFrame", "GlobalSupervisionNeeds", "GlobalTimeCanMaster", "GlobalTimeCanSlave", "GlobalTimeDomain", "GlobalTimeEthMaster", "GlobalTimeEthSlave", "GlobalTimeFrMaster", "GlobalTimeFrSlave", "GlobalTimeGateway", "HardwareTestNeeds", "HwAttributeDef", "HwAttributeLiteralDef", "HwCategory", "HwDescriptionEntity", "HwElement", "HwPin", "HwPinGroup", "HwType", "IEEE1722TpAafConnection", "IEEE1722TpAcfCan", "IEEE1722TpAcfCanPart", "IEEE1722TpAcfConnection", "IEEE1722TpAcfLin", "IEEE1722TpAcfLinPart", "IEEE1722TpConfig", "IEEE1722TpCrfConnection", "IEEE1722TpIidcConnection", "IPSecConfigProps", "IPSecRule", "IPduPort", "IPv6ExtHeaderFilterList", "IPv6ExtHeaderFilterSet", "ISignal", "ISignalGroup", "ISignalIPdu", "ISignalIPduGroup", "ISignalPort", "ISignalToIPduMapping", "ISignalTriggering", "IdsDesign", "IdsMgrCustomTimestampNeeds", "IdsMgrNeeds", "IdsmInstance", "IdsmProperties", "Ieee1722TpEthernetFrame", "ImplementationDataType", "ImplementationDataTypeElement", "ImplementationProps", "ImpositionTime", "IndicatorStatusNeeds", "InitEvent", "InternalTriggerOccurredEvent", "InternalTriggeringPoint", "InterpolationRoutineMappingSet", "J1939Cluster", "J1939ControllerApplication", "J1939DcmDm19Support", "J1939DcmIPdu", "J1939NmCluster", "J1939NmNode", "J1939RmIncomingRequestServiceNeeds", "J1939RmOutgoingRequestServiceNeeds", "J1939SharedAddressCluster", "J1939TpConfig", "J1939TpNode", "Keyword", "KeywordSet", "LatencyTimingConstraint", "LifeCycleInfoSet", "LifeCycleState", "LifeCycleStateDefinitionGroup", "LinCluster", "LinCommunicationConnector", "LinEventTriggeredFrame", "LinFrameTriggering", "LinMaster", "LinPhysicalChannel", "LinScheduleTable", "LinSlave", "LinSlaveConfigIdent", "LinSporadicFrame", "LinTpConfig", "LinTpNode", "LinUnconditionalFrame", "Linker", "LogAndTraceMessageCollectionSet", "MacMulticastGroup", "MacSecGlobalKayProps", "MacSecKayParticipant", "MacSecParticipantSet", "McDataInstance", "McFunction", "McGroup", "MeasuredExecutionTime", "MeasuredHeapUsage", "MeasuredStackUsage", "MemorySection", "ModeAccessPointIdent", "ModeDeclaration", "ModeDeclarationGroup", "ModeDeclarationGroupPrototype", "ModeDeclarationMapping", "ModeDeclarationMappingSet", "ModeInterfaceMapping", "ModeSwitchInterface", "ModeSwitchPoint", "ModeSwitchedAckEvent", "ModeTransition", "MultilanguageReferrable", "MultiplexedIPdu", "NPdu", "NetworkEndpoint", "NmConfig", "NmEcu", "NmPdu", "NvBlockDescriptor", "NvBlockNeeds", "NvBlockSwComponentType", "NvDataInterface", "ObdControlServiceNeeds", "ObdInfoServiceNeeds", "ObdMonitorServiceNeeds", "ObdPidServiceNeeds", "ObdRatioDenominatorNeeds", "ObdRatioServiceNeeds", "OffsetTimingConstraint", "OperationInvokedEvent", "OsTaskExecutionEvent", "OsTaskProxy", "PPortPrototype", "PRPortPrototype", "ParameterAccess", "ParameterDataPrototype", "ParameterInterface", "ParameterSwComponentType", "PassThroughSwConnector", "PduActivationRoutingGroup", "PduToFrameMapping", "PduTriggering", "PdurIPduGroup", "PerInstanceMemory", "PeriodicEventTriggering", "PhysicalDimension", "PhysicalDimensionMappingSet", "PncMappingIdent", "PortElementToCommunicationResourceMapping", "PortGroup", "PortInterfaceMappingSet", "PortPrototypeBlueprint", "PostBuildVariantCriterion", "PostBuildVariantCriterionValueSet", "PredefinedVariant", "PrimitiveAttributeTailoring", "ProvidedServiceInstance", "RPortPrototype", "RapidPrototypingScenario", "ReferenceTailoring", "ResourceConsumption", "RootSwCompositionPrototype", "RoughEstimateHeapUsage", "RoughEstimateOfExecutionTime", "RoughEstimateStackUsage", "RptComponent", "RptContainer", "RptExecutableEntity", "RptExecutableEntityEvent", "RptExecutionContext", "RptProfile", "RptServicePoint", "RteEventInCompositionSeparation", "RteEventInCompositionToOsTaskProxyMapping", "RteEventInSystemSeparation", "RteEventInSystemToOsTaskProxyMapping", "RunnableEntity", "RunnableEntityGroup", "RuntimeError", "SOMEIPTransformationProps", "Sdg", "SdgAggregationWithVariation", "SdgCaption", "SdgClass", "SdgDef", "SdgForeignReference", "SdgForeignReferenceWithVariation", "SdgPrimitiveAttribute", "SdgPrimitiveAttributeWithVariation", "SdgTailoring", "SecOcCryptoServiceMapping", "SectionNamePrefix", "SecureCommunicationAuthenticationProps", "SecureCommunicationFreshnessProps", "SecureCommunicationPropsSet", "SecureOnBoardCommunicationNeeds", "SecuredIPdu", "SecurityEventAggregationFilter", "SecurityEventContextMappingApplication", "SecurityEventContextMappingBswModule", "SecurityEventContextMappingCommConnector", "SecurityEventContextMappingFunctionalCluster", "SecurityEventContextProps", "SecurityEventDefinition", "SecurityEventFilterChain", "SecurityEventOneEveryNFilter", "SecurityEventStateFilter", "SenderReceiverInterface", "SensorActuatorSwComponentType", "ServiceInstanceCollectionSet", "ServiceProxySwComponentType", "ServiceSwComponentType", "SignalServiceTranslationElementProps", "SignalServiceTranslationEventProps", "SignalServiceTranslationProps", "SignalServiceTranslationPropsSet", "SingleLanguageReferrable", "SoAdRoutingGroup", "SoConIPduIdentifier", "SocketAddress", "SocketConnectionBundle", "SocketConnectionIpduIdentifierSet", "SomeipSdClientServiceInstanceConfig", "SomeipSdServerEventGroupTimingConfig", "SomeipSdServerServiceInstanceConfig", "SomeipTpChannel", "SomeipTpConfig", "SpecificationDocumentScope", "SporadicEventTriggering", "StaticSocketConnection", "Std", "StructuredReq", "SupervisedEntityCheckpointNeeds", "SupervisedEntityNeeds", "SwAddrMethod", "SwAxisType", "SwBaseType", "SwGenericAxisParamType", "SwRecordLayout", "SwServiceArg", "SwSystemconst", "SwSystemconstantValueSet", "SwcBswMapping", "SwcImplementation", "SwcInternalBehavior", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "SwcServiceDependency", "SwcTiming", "SwcToApplicationPartitionMapping", "SwcToEcuMapping", "SwcToImplMapping", "SwitchAsynchronousTrafficShaperGroupEntry", "SwitchFlowMeteringEntry", "SwitchStreamFilterActionDestPortModification", "SwitchStreamFilterEntry", "SwitchStreamFilterRule", "SwitchStreamGateEntry", "SwitchStreamIdentification", "SymbolProps", "SyncTimeBaseMgrUserNeeds", "SynchronizationPointConstraint", "SynchronousServerCallPoint", "System", "SystemMapping", "SystemSignal", "SystemSignalGroup", "SystemSignalGroupToCommunicationResourceMapping", "SystemSignalToCommunicationResourceMapping", "SystemTiming", "TDCpSoftwareClusterMapping", "TDCpSoftwareClusterMappingSet", "TDCpSoftwareClusterResourceMapping", "TDEventBswInternalBehavior", "TDEventBswModeDeclaration", "TDEventBswModule", "TDEventComplex", "TDEventFrClusterCycleStart", "TDEventFrame", "TDEventFrameEthernet", "TDEventIPdu", "TDEventISignal", "TDEventModeDeclaration", "TDEventOperation", "TDEventSLLETPort", "TDEventSwcInternalBehavior", "TDEventSwcInternalBehaviorReference", "TDEventTTCanCycleStart", "TDEventTrigger", "TDEventVariableDataPrototype", "TDEventVfbReference", "TDLETZoneClock", "TcpOptionFilterList", "TcpOptionFilterSet", "TimeSyncServerConfiguration", "TimingClockSyncAccuracy", "TimingCondition", "TimingDescriptionEventChain", "TimingEvent", "TimingExtensionResource", "TimingModeInstance", "TlsCryptoCipherSuite", "TlsCryptoCipherSuiteProps", "TlsCryptoServiceMapping", "TlvDataIdDefinitionSet", "Topic1", "TpAddress", "TpConnectionIdent", "TraceableText", "TransformationPropsSet", "TransformationTechnology", "TransformerHardErrorEvent", "TransientFault", "Trigger", "TriggerInterface", "TriggerInterfaceMapping", "TtcanCluster", "TtcanCommunicationConnector", "TtcanCommunicationController", "TtcanPhysicalChannel", "UdpNmCluster", "UdpNmNode", "Unit", "UnitGroup", "UserDefinedCluster", "UserDefinedCommunicationConnector", "UserDefinedCommunicationController", "UserDefinedEthernetFrame", "UserDefinedGlobalTimeMaster", "UserDefinedGlobalTimeSlave", "UserDefinedIPdu", "UserDefinedPdu", "UserDefinedTransformationProps", "V2xDataManagerNeeds", "V2xFacUserNeeds", "V2xMUserNeeds", "VariableAccess", "VariableDataPrototype", "VariationPointProxy", "VendorSpecificServiceNeeds", "VfbTiming", "ViewMap", "ViewMapSet", "VlanConfig", "WaitPoint", "WorstCaseHeapUsage", "WorstCaseStackUsage", "Xdoc", "Xfile", "XrefTarget"]),
-        "SDXF-REF": ("_POLYMORPHIC", "sdxf_ref", ["ARPackage", "AclObjectSet", "AclOperation", "AclPermission", "AclRole", "AgeConstraint", "AggregationTailoring", "AliasNameSet", "AnalyzedExecutionTime", "AppOsTaskProxyToEcuTaskProxyMapping", "ApplicationArrayDataType", "ApplicationArrayElement", "ApplicationEndpoint", "ApplicationError", "ApplicationPartition", "ApplicationPartitionToEcuPartitionMapping", "ApplicationPrimitiveDataType", "ApplicationRecordDataType", "ApplicationRecordElement", "ApplicationSwComponentType", "ArbitraryEventTriggering", "ArgumentDataPrototype", "AssemblySwConnector", "AsynchronousServerCallPoint", "AsynchronousServerCallResultPoint", "AsynchronousServerCallReturnsEvent", "AtpDefinition", "AutosarOperationArgumentInstance", "AutosarVariableInstance", "BackgroundEvent", "BinaryManifestItem", "BinaryManifestItemDefinition", "BinaryManifestMetaDataField", "BinaryManifestProvideResource", "BinaryManifestRequireResource", "BinaryManifestResourceDefinition", "BlockState", "BlueprintMappingSet", "BswAsynchronousServerCallPoint", "BswAsynchronousServerCallResultPoint", "BswAsynchronousServerCallReturnsEvent", "BswBackgroundEvent", "BswCalledEntity", "BswCompositionTiming", "BswDataReceivedEvent", "BswDirectCallPoint", "BswDistinguishedPartition", "BswEntryRelationshipSet", "BswExternalTriggerOccurredEvent", "BswImplementation", "BswInternalBehavior", "BswInternalTriggerOccurredEvent", "BswInternalTriggeringPoint", "BswInterruptEntity", "BswInterruptEvent", "BswMgrNeeds", "BswModeManagerErrorEvent", "BswModeSwitchEvent", "BswModeSwitchedAckEvent", "BswModuleCallPoint", "BswModuleClientServerEntry", "BswModuleDependency", "BswModuleDescription", "BswModuleEntry", "BswModuleTiming", "BswOperationInvokedEvent", "BswOsTaskExecutionEvent", "BswSchedulableEntity", "BswSchedulerNamePrefix", "BswServiceDependencyIdent", "BswTimingEvent", "BswVariableAccess", "BuildAction", "BuildActionEnvironment", "BuildActionManifest", "BulkNvDataDescriptor", "BurstPatternEventTriggering", "BusMirrorChannelMappingCan", "BusMirrorChannelMappingFlexray", "BusMirrorChannelMappingIp", "CalibrationParameterValueSet", "CanCluster", "CanCommunicationConnector", "CanCommunicationController", "CanFrame", "CanFrameTriggering", "CanNmCluster", "CanNmNode", "CanPhysicalChannel", "CanTpAddress", "CanTpChannel", "CanTpConfig", "CanTpNode", "Caption", "Chapter", "ClassContentConditional", "ClientIdDefinition", "ClientIdDefinitionSet", "ClientServerInterface", "ClientServerInterfaceMapping", "ClientServerInterfaceToBswModuleEntryBlueprintMapping", "ClientServerOperation", "Code", "Collection", "ComManagementMapping", "ComMgrUserNeeds", "Compiler", "ComplexDeviceDriverSwComponentType", "CompositionSwComponentType", "CompuMethod", "ConcreteClassTailoring", "ConcretePatternEventTriggering", "ConsistencyNeeds", "ConsistencyNeedsBlueprintSet", "ConstantSpecification", "ConstantSpecificationMappingSet", "ConstraintTailoring", "ConsumedEventGroup", "ConsumedProvidedServiceInstanceGroup", "ConsumedServiceInstance", "ContainerIPdu", "CouplingElement", "CouplingElementSwitchDetails", "CouplingPort", "CouplingPortFifo", "CouplingPortScheduler", "CouplingPortShaper", "CouplingPortTrafficClassAssignment", "CpSoftwareCluster", "CpSoftwareClusterBinaryManifestDescriptor", "CpSoftwareClusterCommunicationResource", "CpSoftwareClusterMappingSet", "CpSoftwareClusterResourcePool", "CpSoftwareClusterResourceToApplicationPartitionMapping", "CpSoftwareClusterServiceResource", "CpSoftwareClusterToApplicationPartitionMapping", "CpSoftwareClusterToEcuInstanceMapping", "CpSoftwareClusterToResourceMapping", "CpSwClusterResourceToDiagDataElemMapping", "CpSwClusterResourceToDiagFunctionIdMapping", "CpSwClusterToDiagEventMapping", "CpSwClusterToDiagRoutineSubfunctionMapping", "CryptoEllipticCurveProps", "CryptoKeyManagementNeeds", "CryptoServiceCertificate", "CryptoServiceJobNeeds", "CryptoServiceKey", "CryptoServiceNeeds", "CryptoServicePrimitive", "CryptoServiceQueue", "CryptoSignatureScheme", "DataConstr", "DataExchangePoint", "DataPrototypeGroup", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataTransformationSet", "DataTypeMappingSet", "DataWriteCompletedEvent", "DcmIPdu", "DdsCpConfig", "DdsCpConsumedServiceInstance", "DdsCpDomain", "DdsCpPartition", "DdsCpProvidedServiceInstance", "DdsCpQosProfile", "DdsCpTopic", "DefItem", "DelegationSwConnector", "DependencyOnArtifact", "DevelopmentError", "DiagEventDebounceCounterBased", "DiagEventDebounceMonitorInternal", "DiagnosticAccessPermission", "DiagnosticAging", "DiagnosticAuthRole", "DiagnosticAuthTransmitCertificate", "DiagnosticAuthTransmitCertificateEvaluation", "DiagnosticAuthTransmitCertificateMapping", "DiagnosticAuthenticationClass", "DiagnosticAuthenticationConfiguration", "DiagnosticClearDiagnosticInformation", "DiagnosticClearDiagnosticInformationClass", "DiagnosticClearResetEmissionRelatedInfo", "DiagnosticClearResetEmissionRelatedInfoClass", "DiagnosticComControl", "DiagnosticComControlClass", "DiagnosticCommunicationManagerNeeds", "DiagnosticComponentNeeds", "DiagnosticConnectedIndicator", "DiagnosticConnection", "DiagnosticContributionSet", "DiagnosticControlDTCSetting", "DiagnosticControlDTCSettingClass", "DiagnosticControlNeeds", "DiagnosticCustomServiceClass", "DiagnosticCustomServiceInstance", "DiagnosticDataElement", "DiagnosticDataIdentifier", "DiagnosticDataIdentifierSet", "DiagnosticDataTransfer", "DiagnosticDataTransferClass", "DiagnosticDeAuthentication", "DiagnosticDebounceAlgorithmProps", "DiagnosticDemProvidedDataMapping", "DiagnosticDynamicDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifier", "DiagnosticDynamicallyDefineDataIdentifierClass", "DiagnosticEcuInstanceProps", "DiagnosticEcuReset", "DiagnosticEcuResetClass", "DiagnosticEnableCondition", "DiagnosticEnableConditionGroup", "DiagnosticEnableConditionNeeds", "DiagnosticEnableConditionPortMapping", "DiagnosticEnvBswModeElement", "DiagnosticEnvModeElement", "DiagnosticEnvSwcModeElement", "DiagnosticEnvironmentalCondition", "DiagnosticEvent", "DiagnosticEventInfoNeeds", "DiagnosticEventManagerNeeds", "DiagnosticEventNeeds", "DiagnosticEventPortMapping", "DiagnosticEventToDebounceAlgorithmMapping", "DiagnosticEventToEnableConditionGroupMapping", "DiagnosticEventToOperationCycleMapping", "DiagnosticEventToSecurityEventMapping", "DiagnosticEventToStorageConditionGroupMapping", "DiagnosticEventToTroubleCodeJ1939Mapping", "DiagnosticEventToTroubleCodeUdsMapping", "DiagnosticExtendedDataRecord", "DiagnosticFimAliasEvent", "DiagnosticFimAliasEventGroup", "DiagnosticFimAliasEventGroupMapping", "DiagnosticFimAliasEventMapping", "DiagnosticFimEventGroup", "DiagnosticFimFunctionMapping", "DiagnosticFreezeFrame", "DiagnosticFunctionIdentifier", "DiagnosticFunctionIdentifierInhibit", "DiagnosticFunctionInhibitSource", "DiagnosticIOControl", "DiagnosticIndicator", "DiagnosticInfoType", "DiagnosticInhibitSourceEventMapping", "DiagnosticIoControlClass", "DiagnosticIoControlNeeds", "DiagnosticIumpr", "DiagnosticIumprDenominatorGroup", "DiagnosticIumprGroup", "DiagnosticIumprToFunctionIdentifierMapping", "DiagnosticJ1939ExpandedFreezeFrame", "DiagnosticJ1939FreezeFrame", "DiagnosticJ1939Node", "DiagnosticJ1939Spn", "DiagnosticJ1939SpnMapping", "DiagnosticJ1939SwMapping", "DiagnosticMasterToSlaveEventMapping", "DiagnosticMeasurementIdentifier", "DiagnosticMemoryDestinationPrimary", "DiagnosticMemoryDestinationUserDefined", "DiagnosticMemoryIdentifier", "DiagnosticOperationCycle", "DiagnosticOperationCycleNeeds", "DiagnosticOperationCyclePortMapping", "DiagnosticParameterElement", "DiagnosticParameterIdent", "DiagnosticParameterIdentifier", "DiagnosticPowertrainFreezeFrame", "DiagnosticProofOfOwnership", "DiagnosticProtocol", "DiagnosticReadDTCInformation", "DiagnosticReadDTCInformationClass", "DiagnosticReadDataByIdentifier", "DiagnosticReadDataByIdentifierClass", "DiagnosticReadDataByPeriodicID", "DiagnosticReadDataByPeriodicIDClass", "DiagnosticReadMemoryByAddress", "DiagnosticReadMemoryByAddressClass", "DiagnosticReadScalingDataByIdentifier", "DiagnosticReadScalingDataByIdentifierClass", "DiagnosticRequestControlOfOnBoardDevice", "DiagnosticRequestControlOfOnBoardDeviceClass", "DiagnosticRequestCurrentPowertrainData", "DiagnosticRequestCurrentPowertrainDataClass", "DiagnosticRequestDownload", "DiagnosticRequestDownloadClass", "DiagnosticRequestEmissionRelatedDTC", "DiagnosticRequestEmissionRelatedDTCClass", "DiagnosticRequestEmissionRelatedDTCPermanentStatus", "DiagnosticRequestEmissionRelatedDTCPermanentStatusClass", "DiagnosticRequestFileTransfer", "DiagnosticRequestFileTransferClass", "DiagnosticRequestFileTransferNeeds", "DiagnosticRequestOnBoardMonitoringTestResults", "DiagnosticRequestOnBoardMonitoringTestResultsClass", "DiagnosticRequestPowertrainFreezeFrameData", "DiagnosticRequestPowertrainFreezeFrameDataClass", "DiagnosticRequestRoutineResults", "DiagnosticRequestUpload", "DiagnosticRequestUploadClass", "DiagnosticRequestVehicleInfo", "DiagnosticRequestVehicleInfoClass", "DiagnosticResponseOnEvent", "DiagnosticResponseOnEventClass", "DiagnosticRoutine", "DiagnosticRoutineControl", "DiagnosticRoutineControlClass", "DiagnosticRoutineNeeds", "DiagnosticSecureCodingMapping", "DiagnosticSecurityAccess", "DiagnosticSecurityAccessClass", "DiagnosticSecurityEventReportingModeMapping", "DiagnosticSecurityLevel", "DiagnosticServiceDataMapping", "DiagnosticServiceSwMapping", "DiagnosticServiceTable", "DiagnosticSession", "DiagnosticSessionControl", "DiagnosticSessionControlClass", "DiagnosticStartRoutine", "DiagnosticStopRoutine", "DiagnosticStorageCondition", "DiagnosticStorageConditionGroup", "DiagnosticStorageConditionNeeds", "DiagnosticStorageConditionPortMapping", "DiagnosticTestResult", "DiagnosticTestRoutineIdentifier", "DiagnosticTransferExit", "DiagnosticTransferExitClass", "DiagnosticTroubleCodeGroup", "DiagnosticTroubleCodeJ1939", "DiagnosticTroubleCodeObd", "DiagnosticTroubleCodeProps", "DiagnosticTroubleCodeUds", "DiagnosticTroubleCodeUdsToTroubleCodeObdMapping", "DiagnosticUploadDownloadNeeds", "DiagnosticValueNeeds", "DiagnosticVerifyCertificateBidirectional", "DiagnosticWriteDataByIdentifierClass", "DiagnosticWriteMemoryByAddressClass", "DiagnosticsCommunicationSecurityNeeds", "DltApplication", "DltArgument", "DltContext", "DltEcu", "DltLogChannel", "DltMessage", "DltUserNeeds", "DoIpActivationLineNeeds", "DoIpGidNeeds", "DoIpGidSynchronizationNeeds", "DoIpInterface", "DoIpLogicAddress", "DoIpLogicTargetAddressProps", "DoIpLogicTesterAddressProps", "DoIpPowerModeStatusNeeds", "DoIpRoutingActivation", "DoIpRoutingActivationAuthenticationNeeds", "DoIpRoutingActivationConfirmationNeeds", "DoIpTpConfig", "DocumentElementScope", "Documentation", "DocumentationContext", "DtcStatusChangeNotificationNeeds", "E2EProfileCompatibilityProps", "ECUMapping", "EOCEventRef", "EOCExecutableEntityRef", "EOCExecutableEntityRefGroup", "EcuAbstractionSwComponentType", "EcuInstance", "EcuPartition", "EcuStateMgrUserNeeds", "EcuTiming", "EcucAddInfoParamDef", "EcucBooleanParamDef", "EcucChoiceContainerDef", "EcucChoiceReferenceDef", "EcucContainerValue", "EcucDefinitionCollection", "EcucDestinationUriDef", "EcucDestinationUriDefSet", "EcucEnumerationLiteralDef", "EcucEnumerationParamDef", "EcucFloatParamDef", "EcucForeignReferenceDef", "EcucFunctionNameDef", "EcucInstanceReferenceDef", "EcucIntegerParamDef", "EcucLinkerSymbolDef", "EcucModuleConfigurationValues", "EcucModuleDef", "EcucMultilineStringParamDef", "EcucParamConfContainerDef", "EcucQuery", "EcucReferenceDef", "EcucStringParamDef", "EcucUriReferenceDef", "EcucValidationCondition", "EcucValueCollection", "EndToEndProtection", "EndToEndProtectionSet", "EnumerationMappingTable", "ErrorTracerNeeds", "EthIpProps", "EthTcpIpIcmpProps", "EthTcpIpProps", "EthTpConfig", "EthernetCluster", "EthernetCommunicationConnector", "EthernetCommunicationController", "EthernetFrameTriggering", "EthernetPhysicalChannel", "EthernetPriorityRegeneration", "EthernetWakeupSleepOnDatalineConfig", "EthernetWakeupSleepOnDatalineConfigSet", "EvaluatedVariantSet", "EventHandler", "ExclusiveArea", "ExclusiveAreaNestingOrder", "ExecutableEntityActivationReason", "ExecutionOrderConstraint", "ExecutionTimeConstraint", "ExternalTriggerOccurredEvent", "ExternalTriggeringPointIdent", "FMAttributeDef", "FMFeature", "FMFeatureMap", "FMFeatureMapAssertion", "FMFeatureMapCondition", "FMFeatureMapElement", "FMFeatureModel", "FMFeatureRelation", "FMFeatureRestriction", "FMFeatureSelection", "FMFeatureSelectionSet", "FirewallRule", "FlatInstanceDescriptor", "FlatMap", "FlexrayArTpConfig", "FlexrayArTpNode", "FlexrayCluster", "FlexrayCommunicationConnector", "FlexrayCommunicationController", "FlexrayFrame", "FlexrayFrameTriggering", "FlexrayNmCluster", "FlexrayNmNode", "FlexrayPhysicalChannel", "FlexrayTpConfig", "FlexrayTpConnectionControl", "FlexrayTpNode", "FlexrayTpPduPool", "FramePort", "FunctionInhibitionAvailabilityNeeds", "FunctionInhibitionNeeds", "Gateway", "GeneralPurposeConnection", "GeneralPurposeIPdu", "GeneralPurposePdu", "GenericEthernetFrame", "GlobalSupervisionNeeds", "GlobalTimeCanMaster", "GlobalTimeCanSlave", "GlobalTimeDomain", "GlobalTimeEthMaster", "GlobalTimeEthSlave", "GlobalTimeFrMaster", "GlobalTimeFrSlave", "GlobalTimeGateway", "HardwareTestNeeds", "HwAttributeDef", "HwAttributeLiteralDef", "HwCategory", "HwDescriptionEntity", "HwElement", "HwPin", "HwPinGroup", "HwType", "IEEE1722TpAafConnection", "IEEE1722TpAcfCan", "IEEE1722TpAcfCanPart", "IEEE1722TpAcfConnection", "IEEE1722TpAcfLin", "IEEE1722TpAcfLinPart", "IEEE1722TpConfig", "IEEE1722TpCrfConnection", "IEEE1722TpIidcConnection", "IPSecConfigProps", "IPSecRule", "IPduPort", "IPv6ExtHeaderFilterList", "IPv6ExtHeaderFilterSet", "ISignal", "ISignalGroup", "ISignalIPdu", "ISignalIPduGroup", "ISignalPort", "ISignalToIPduMapping", "ISignalTriggering", "IdsDesign", "IdsMgrCustomTimestampNeeds", "IdsMgrNeeds", "IdsmInstance", "IdsmProperties", "Ieee1722TpEthernetFrame", "ImplementationDataType", "ImplementationDataTypeElement", "ImplementationProps", "ImpositionTime", "IndicatorStatusNeeds", "InitEvent", "InternalTriggerOccurredEvent", "InternalTriggeringPoint", "InterpolationRoutineMappingSet", "J1939Cluster", "J1939ControllerApplication", "J1939DcmDm19Support", "J1939DcmIPdu", "J1939NmCluster", "J1939NmNode", "J1939RmIncomingRequestServiceNeeds", "J1939RmOutgoingRequestServiceNeeds", "J1939SharedAddressCluster", "J1939TpConfig", "J1939TpNode", "Keyword", "KeywordSet", "LatencyTimingConstraint", "LifeCycleInfoSet", "LifeCycleState", "LifeCycleStateDefinitionGroup", "LinCluster", "LinCommunicationConnector", "LinEventTriggeredFrame", "LinFrameTriggering", "LinMaster", "LinPhysicalChannel", "LinScheduleTable", "LinSlave", "LinSlaveConfigIdent", "LinSporadicFrame", "LinTpConfig", "LinTpNode", "LinUnconditionalFrame", "Linker", "LogAndTraceMessageCollectionSet", "MacMulticastGroup", "MacSecGlobalKayProps", "MacSecKayParticipant", "MacSecParticipantSet", "McDataInstance", "McFunction", "McGroup", "MeasuredExecutionTime", "MeasuredHeapUsage", "MeasuredStackUsage", "MemorySection", "ModeAccessPointIdent", "ModeDeclaration", "ModeDeclarationGroup", "ModeDeclarationGroupPrototype", "ModeDeclarationMapping", "ModeDeclarationMappingSet", "ModeInterfaceMapping", "ModeSwitchInterface", "ModeSwitchPoint", "ModeSwitchedAckEvent", "ModeTransition", "MultilanguageReferrable", "MultiplexedIPdu", "NPdu", "NetworkEndpoint", "NmConfig", "NmEcu", "NmPdu", "NvBlockDescriptor", "NvBlockNeeds", "NvBlockSwComponentType", "NvDataInterface", "ObdControlServiceNeeds", "ObdInfoServiceNeeds", "ObdMonitorServiceNeeds", "ObdPidServiceNeeds", "ObdRatioDenominatorNeeds", "ObdRatioServiceNeeds", "OffsetTimingConstraint", "OperationInvokedEvent", "OsTaskExecutionEvent", "OsTaskProxy", "PPortPrototype", "PRPortPrototype", "ParameterAccess", "ParameterDataPrototype", "ParameterInterface", "ParameterSwComponentType", "PassThroughSwConnector", "PduActivationRoutingGroup", "PduToFrameMapping", "PduTriggering", "PdurIPduGroup", "PerInstanceMemory", "PeriodicEventTriggering", "PhysicalDimension", "PhysicalDimensionMappingSet", "PncMappingIdent", "PortElementToCommunicationResourceMapping", "PortGroup", "PortInterfaceMappingSet", "PortPrototypeBlueprint", "PostBuildVariantCriterion", "PostBuildVariantCriterionValueSet", "PredefinedVariant", "PrimitiveAttributeTailoring", "ProvidedServiceInstance", "RPortPrototype", "RapidPrototypingScenario", "ReferenceTailoring", "ResourceConsumption", "RootSwCompositionPrototype", "RoughEstimateHeapUsage", "RoughEstimateOfExecutionTime", "RoughEstimateStackUsage", "RptComponent", "RptContainer", "RptExecutableEntity", "RptExecutableEntityEvent", "RptExecutionContext", "RptProfile", "RptServicePoint", "RteEventInCompositionSeparation", "RteEventInCompositionToOsTaskProxyMapping", "RteEventInSystemSeparation", "RteEventInSystemToOsTaskProxyMapping", "RunnableEntity", "RunnableEntityGroup", "RuntimeError", "SOMEIPTransformationProps", "Sdg", "SdgAggregationWithVariation", "SdgCaption", "SdgClass", "SdgDef", "SdgForeignReference", "SdgForeignReferenceWithVariation", "SdgPrimitiveAttribute", "SdgPrimitiveAttributeWithVariation", "SdgTailoring", "SecOcCryptoServiceMapping", "SectionNamePrefix", "SecureCommunicationAuthenticationProps", "SecureCommunicationFreshnessProps", "SecureCommunicationPropsSet", "SecureOnBoardCommunicationNeeds", "SecuredIPdu", "SecurityEventAggregationFilter", "SecurityEventContextMappingApplication", "SecurityEventContextMappingBswModule", "SecurityEventContextMappingCommConnector", "SecurityEventContextMappingFunctionalCluster", "SecurityEventContextProps", "SecurityEventDefinition", "SecurityEventFilterChain", "SecurityEventOneEveryNFilter", "SecurityEventStateFilter", "SenderReceiverInterface", "SensorActuatorSwComponentType", "ServiceInstanceCollectionSet", "ServiceProxySwComponentType", "ServiceSwComponentType", "SignalServiceTranslationElementProps", "SignalServiceTranslationEventProps", "SignalServiceTranslationProps", "SignalServiceTranslationPropsSet", "SingleLanguageReferrable", "SoAdRoutingGroup", "SoConIPduIdentifier", "SocketAddress", "SocketConnectionBundle", "SocketConnectionIpduIdentifierSet", "SomeipSdClientServiceInstanceConfig", "SomeipSdServerEventGroupTimingConfig", "SomeipSdServerServiceInstanceConfig", "SomeipTpChannel", "SomeipTpConfig", "SpecificationDocumentScope", "SporadicEventTriggering", "StaticSocketConnection", "Std", "StructuredReq", "SupervisedEntityCheckpointNeeds", "SupervisedEntityNeeds", "SwAddrMethod", "SwAxisType", "SwBaseType", "SwGenericAxisParamType", "SwRecordLayout", "SwServiceArg", "SwSystemconst", "SwSystemconstantValueSet", "SwcBswMapping", "SwcImplementation", "SwcInternalBehavior", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "SwcServiceDependency", "SwcTiming", "SwcToApplicationPartitionMapping", "SwcToEcuMapping", "SwcToImplMapping", "SwitchAsynchronousTrafficShaperGroupEntry", "SwitchFlowMeteringEntry", "SwitchStreamFilterActionDestPortModification", "SwitchStreamFilterEntry", "SwitchStreamFilterRule", "SwitchStreamGateEntry", "SwitchStreamIdentification", "SymbolProps", "SyncTimeBaseMgrUserNeeds", "SynchronizationPointConstraint", "SynchronousServerCallPoint", "System", "SystemMapping", "SystemSignal", "SystemSignalGroup", "SystemSignalGroupToCommunicationResourceMapping", "SystemSignalToCommunicationResourceMapping", "SystemTiming", "TDCpSoftwareClusterMapping", "TDCpSoftwareClusterMappingSet", "TDCpSoftwareClusterResourceMapping", "TDEventBswInternalBehavior", "TDEventBswModeDeclaration", "TDEventBswModule", "TDEventComplex", "TDEventFrClusterCycleStart", "TDEventFrame", "TDEventFrameEthernet", "TDEventIPdu", "TDEventISignal", "TDEventModeDeclaration", "TDEventOperation", "TDEventSLLETPort", "TDEventSwcInternalBehavior", "TDEventSwcInternalBehaviorReference", "TDEventTTCanCycleStart", "TDEventTrigger", "TDEventVariableDataPrototype", "TDEventVfbReference", "TDLETZoneClock", "TcpOptionFilterList", "TcpOptionFilterSet", "TimeSyncServerConfiguration", "TimingClockSyncAccuracy", "TimingCondition", "TimingDescriptionEventChain", "TimingEvent", "TimingExtensionResource", "TimingModeInstance", "TlsCryptoCipherSuite", "TlsCryptoCipherSuiteProps", "TlsCryptoServiceMapping", "TlvDataIdDefinitionSet", "Topic1", "TpAddress", "TpConnectionIdent", "TraceableText", "TransformationPropsSet", "TransformationTechnology", "TransformerHardErrorEvent", "TransientFault", "Trigger", "TriggerInterface", "TriggerInterfaceMapping", "TtcanCluster", "TtcanCommunicationConnector", "TtcanCommunicationController", "TtcanPhysicalChannel", "UdpNmCluster", "UdpNmNode", "Unit", "UnitGroup", "UserDefinedCluster", "UserDefinedCommunicationConnector", "UserDefinedCommunicationController", "UserDefinedEthernetFrame", "UserDefinedGlobalTimeMaster", "UserDefinedGlobalTimeSlave", "UserDefinedIPdu", "UserDefinedPdu", "UserDefinedTransformationProps", "V2xDataManagerNeeds", "V2xFacUserNeeds", "V2xMUserNeeds", "VariableAccess", "VariableDataPrototype", "VariationPointProxy", "VendorSpecificServiceNeeds", "VfbTiming", "ViewMap", "ViewMapSet", "VlanConfig", "WaitPoint", "WorstCaseHeapUsage", "WorstCaseStackUsage", "Xdoc", "Xfile", "XrefTarget"]),
-    }
-
+    # Use LIST attributes to support multiple children
+    sd: List[Sd]
+    sdf: List[Sdf]
+    sdg: List[Sdg]
+    sdx_ref: List[ARRef]
+    sdxf_ref: List[ARRef]
 
     def __init__(self) -> None:
         """Initialize SdgContents."""
         super().__init__()
-        self.sd: Optional[Sd] = None
-        self.sdf: Optional[Sdf] = None
-        self.sdg: Optional[Sdg] = None
-        self.sdx_ref: Optional[ARRef] = None
-        self.sdxf_ref: Optional[ARRef] = None
+        self.sd: List[Sd] = []
+        self.sdf: List[Sdf] = []
+        self.sdg: List[Sdg] = []
+        self.sdx_ref: List[ARRef] = []
+        self.sdxf_ref: List[ARRef] = []
 
     def serialize(self) -> ET.Element:
-        """Serialize SdgContents to XML element (atp_mixed - no wrapping).
+        """Serialize SdgContents to XML element (atp_mixed - children serialize directly).
 
         Returns:
             xml.etree.ElementTree.Element representing this object
@@ -95,67 +104,67 @@ class SdgContents(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize sd (complex type)
-        if self.sd is not None:
-            serialized = SerializationHelper.serialize_item(self.sd, "Sd")
+        # Serialize all SD elements
+        for sd_item in self.sd:
+            serialized = SerializationHelper.serialize_item(sd_item, "Sd")
             if serialized is not None:
                 wrapped = ET.Element("SD")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
+                if serialized.text:
+                    wrapped.text = serialized.text
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sdf (complex type)
-        if self.sdf is not None:
-            serialized = SerializationHelper.serialize_item(self.sdf, "Sdf")
+        # Serialize all SDF elements
+        for sdf_item in self.sdf:
+            serialized = SerializationHelper.serialize_item(sdf_item, "Sdf")
             if serialized is not None:
                 wrapped = ET.Element("SDF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
+                if serialized.text:
+                    wrapped.text = serialized.text
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sdg (complex type)
-        if self.sdg is not None:
-            serialized = SerializationHelper.serialize_item(self.sdg, "Sdg")
+        # Serialize all nested SDG elements
+        for sdg_item in self.sdg:
+            serialized = SerializationHelper.serialize_item(sdg_item, "Sdg")
             if serialized is not None:
                 wrapped = ET.Element("SDG")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
+                if serialized.text:
+                    wrapped.text = serialized.text
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sdx_ref (reference)
-        if self.sdx_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sdx_ref, "Referrable")
+        # Serialize all SDX-REF elements
+        for sdx_ref_item in self.sdx_ref:
+            serialized = SerializationHelper.serialize_item(sdx_ref_item, "ARRef")
             if serialized is not None:
                 wrapped = ET.Element("SDX-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
+                if serialized.text:
+                    wrapped.text = serialized.text
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sdxf_ref (reference)
-        if self.sdxf_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sdxf_ref, "Referrable")
+        # Serialize all SDXF-REF elements
+        for sdxf_ref_item in self.sdxf_ref:
+            serialized = SerializationHelper.serialize_item(sdxf_ref_item, "ARRef")
             if serialized is not None:
                 wrapped = ET.Element("SDXF-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        wrapped.text = serialized.text
+                if serialized.text:
+                    wrapped.text = serialized.text
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
@@ -163,8 +172,8 @@ class SdgContents(ARObject):
         return elem
 
     @classmethod
-    def deserialize(cls, element: ET.Element) -> "SdgContents":
-        """Deserialize XML element to SdgContents object (atp_mixed - no unwrapping).
+    def deserialize(cls, element: ET.Element) -> SdgContents:
+        """Deserialize XML element to SdgContents object (atp_mixed - children serialize directly).
 
         Args:
             element: XML element to deserialize from
@@ -175,145 +184,236 @@ class SdgContents(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(SdgContents, cls).deserialize(element)
 
-        # Parse sd
-        child = SerializationHelper.find_child_element(element, "SD")
-        if child is not None:
-            sd_value = SerializationHelper.deserialize_by_tag(child, "Sd")
-            obj.sd = sd_value
+        # Initialize lists
+        obj.sd = []
+        obj.sdf = []
+        obj.sdg = []
+        obj.sdx_ref = []
+        obj.sdxf_ref = []
 
-        # Parse sdf
-        child = SerializationHelper.find_child_element(element, "SDF")
-        if child is not None:
-            sdf_value = SerializationHelper.deserialize_by_tag(child, "Sdf")
-            obj.sdf = sdf_value
-
-        # Parse sdg
-        child = SerializationHelper.find_child_element(element, "SDG")
-        if child is not None:
-            sdg_value = SerializationHelper.deserialize_by_tag(child, "Sdg")
-            obj.sdg = sdg_value
-
-        # Parse sdx_ref
-        child = SerializationHelper.find_child_element(element, "SDX-REF")
-        if child is not None:
-            sdx_ref_value = SerializationHelper.deserialize_by_tag(child, "Referrable")
-            obj.sdx_ref = sdx_ref_value
-
-        # Parse sdxf_ref
-        child = SerializationHelper.find_child_element(element, "SDXF-REF")
-        if child is not None:
-            sdxf_ref_value = SerializationHelper.deserialize_by_tag(child, "Referrable")
-            obj.sdxf_ref = sdxf_ref_value
+        # Deserialize children
+        ns_split = '}'
+        for child in element:
+            tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
+            if tag == "SD":
+                obj.sd.append(SerializationHelper.deserialize_by_tag(child, "Sd"))
+            elif tag == "SDF":
+                obj.sdf.append(SerializationHelper.deserialize_by_tag(child, "Sdf"))
+            elif tag == "SDG":
+                obj.sdg.append(SerializationHelper.deserialize_by_tag(child, "Sdg"))
+            elif tag == "SDX-REF":
+                obj.sdx_ref.append(SerializationHelper.deserialize_by_tag(child, "ARRef"))
+            elif tag == "SDXF-REF":
+                obj.sdxf_ref.append(SerializationHelper.deserialize_by_tag(child, "ARRef"))
 
         return obj
-
 
 
 class SdgContentsBuilder(BuilderBase):
     """Builder for SdgContents with fluent API."""
 
     def __init__(self) -> None:
-        """Initialize builder with defaults."""
-        super().__init__()
-        self._obj: SdgContents = SdgContents()
+        """Initialize SdgContentsBuilder."""
+        self._instance: Optional[SdgContents] = None
 
+    def _get_instance(self) -> SdgContents:
+        """Get or create the SdgContents instance."""
+        if self._instance is None:
+            self._instance = SdgContents()
+        return self._instance
 
-    def with_sd(self, value: Optional[Sd]) -> "SdgContentsBuilder":
-        """Set sd attribute.
+    def with_sd(self, sd: Optional[List[Sd]]) -> "SdgContentsBuilder":
+        """Set the sd list attribute.
 
         Args:
-            value: Value to set
+            sd: List of Sd values
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sd' is required and cannot be None")
-        self._obj.sd = value
+        obj = self._get_instance()
+        if sd is not None:
+            obj.sd = sd
         return self
 
-    def with_sdf(self, value: Optional[Sdf]) -> "SdgContentsBuilder":
-        """Set sdf attribute.
+    def add_sd(self, sd: Sd) -> "SdgContentsBuilder":
+        """Add an SD element to the list.
 
         Args:
-            value: Value to set
+            sd: Sd value to add
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdf' is required and cannot be None")
-        self._obj.sdf = value
+        obj = self._get_instance()
+        obj.sd.append(sd)
         return self
 
-    def with_sdg(self, value: Optional[Sdg]) -> "SdgContentsBuilder":
-        """Set sdg attribute.
-
-        Args:
-            value: Value to set
+    def clear_sd(self) -> "SdgContentsBuilder":
+        """Clear the SD list.
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdg' is required and cannot be None")
-        self._obj.sdg = value
+        obj = self._get_instance()
+        obj.sd.clear()
         return self
 
-    def with_sdx(self, value: Optional[Referrable]) -> "SdgContentsBuilder":
-        """Set sdx attribute.
+    def with_sdf(self, sdf: Optional[List[Sdf]]) -> "SdgContentsBuilder":
+        """Set the sdf list attribute.
 
         Args:
-            value: Value to set
+            sdf: List of Sdf values
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdx' is required and cannot be None")
-        self._obj.sdx = value
+        obj = self._get_instance()
+        if sdf is not None:
+            obj.sdf = sdf
         return self
 
-    def with_sdxf(self, value: Optional[Referrable]) -> "SdgContentsBuilder":
-        """Set sdxf attribute.
+    def add_sdf(self, sdf: Sdf) -> "SdgContentsBuilder":
+        """Add an SDF element to the list.
 
         Args:
-            value: Value to set
+            sdf: Sdf value to add
 
         Returns:
             self for method chaining
         """
-        if value is None and not True:
-            raise ValueError("Attribute 'sdxf' is required and cannot be None")
-        self._obj.sdxf = value
+        obj = self._get_instance()
+        obj.sdf.append(sdf)
         return self
 
+    def clear_sdf(self) -> "SdgContentsBuilder":
+        """Clear the SDF list.
 
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdf.clear()
+        return self
 
-    # Pre-computed validation constants (generated from JSON schema)
-    _OPTIONAL_ATTRIBUTES = {
-        "sd",
-        "sdf",
-        "sdg",
-        "sdx",
-        "sdxf",
-    }
+    def with_sdg(self, sdg: Optional[List["Sdg"]]) -> "SdgContentsBuilder":
+        """Set the sdg list attribute.
 
+        Args:
+            sdg: List of Sdg values
 
-    def _validate_instance(self) -> None:
-        """Validate the built instance based on settings."""
-        from armodel2.core import GlobalSettingsManager, BuilderValidationMode
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        if sdg is not None:
+            obj.sdg = sdg
+        return self
 
-        settings = GlobalSettingsManager()
-        mode = settings.builder_validation
+    def add_sdg(self, sdg: "Sdg") -> "SdgContentsBuilder":
+        """Add an SDG element to the list.
 
-        if mode == BuilderValidationMode.DISABLED:
-            return
+        Args:
+            sdg: Sdg value to add
 
-        # No required attributes to validate (all are optional)
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdg.append(sdg)
+        return self
 
+    def clear_sdg(self) -> "SdgContentsBuilder":
+        """Clear the SDG list.
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdg.clear()
+        return self
+
+    def with_sdx_ref(self, sdx_ref: Optional[List[ARRef]]) -> "SdgContentsBuilder":
+        """Set the sdx_ref list attribute.
+
+        Args:
+            sdx_ref: List of ARRef values
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        if sdx_ref is not None:
+            obj.sdx_ref = sdx_ref
+        return self
+
+    def add_sdx_ref(self, sdx_ref: ARRef) -> "SdgContentsBuilder":
+        """Add an SDX-REF element to the list.
+
+        Args:
+            sdx_ref: ARRef value to add
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdx_ref.append(sdx_ref)
+        return self
+
+    def clear_sdx_ref(self) -> "SdgContentsBuilder":
+        """Clear the SDX-REF list.
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdx_ref.clear()
+        return self
+
+    def with_sdxf_ref(self, sdxf_ref: Optional[List[ARRef]]) -> "SdgContentsBuilder":
+        """Set the sdxf_ref list attribute.
+
+        Args:
+            sdxf_ref: List of ARRef values
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        if sdxf_ref is not None:
+            obj.sdxf_ref = sdxf_ref
+        return self
+
+    def add_sdxf_ref(self, sdxf_ref: ARRef) -> "SdgContentsBuilder":
+        """Add an SDXF-REF element to the list.
+
+        Args:
+            sdxf_ref: ARRef value to add
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdxf_ref.append(sdxf_ref)
+        return self
+
+    def clear_sdxf_ref(self) -> "SdgContentsBuilder":
+        """Clear the SDXF-REF list.
+
+        Returns:
+            self for method chaining
+        """
+        obj = self._get_instance()
+        obj.sdxf_ref.clear()
+        return self
 
     def build(self) -> SdgContents:
-        """Build and return the SdgContents instance with validation."""
-        self._validate_instance()
-        return self._obj
+        """Build and return the SdgContents object.
+
+        Returns:
+            The constructed SdgContents object
+        """
+        obj = self._get_instance()
+        if obj is None:
+            obj = SdgContents()
+        return obj

--- a/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py
+++ b/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py
@@ -27,11 +27,17 @@ from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.numerical_or_
 from armodel2.models.M2.MSR.Documentation.TextModel.SingleLanguageData.single_language_unit_names import (
     SingleLanguageUnitNames,
 )
+from armodel2.models.M2.MSR.CalibrationData.CalibrationValue.sw_values import (
+    SwValues,
+)
 from armodel2.models.M2.MSR.AsamHdo.Units.unit import (
     Unit,
 )
 from armodel2.models.M2.MSR.CalibrationData.CalibrationValue.value_group import (
     ValueGroup,
+)
+from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.value_list import (
+    ValueList,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -53,8 +59,10 @@ class SwAxisCont(ARObject):
 
 
     category: Optional[CalprmAxisCategoryEnum]
+    sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
     sw_axis_index: Optional[AxisIndexType]
+    sw_values_phys: Optional[SwValues]
     vf: Optional[Numerical]
     vg: Optional[ValueGroup]
     vt: Optional[VerbatimString]
@@ -63,8 +71,10 @@ class SwAxisCont(ARObject):
     unit_display: Optional[SingleLanguageUnitNames]
     _DESERIALIZE_DISPATCH = {
         "CATEGORY": lambda obj, elem: setattr(obj, "category", CalprmAxisCategoryEnum.deserialize(elem)),
+        "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-AXIS-INDEX": lambda obj, elem: setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(elem, "AxisIndexType")),
+        "SW-VALUES-PHYS": lambda obj, elem: setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(elem, "SwValues")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VG": lambda obj, elem: setattr(obj, "vg", SerializationHelper.deserialize_by_tag(elem, "ValueGroup")),
         "VT": lambda obj, elem: setattr(obj, "vt", SerializationHelper.deserialize_by_tag(elem, "VerbatimString")),
@@ -78,8 +88,10 @@ class SwAxisCont(ARObject):
         """Initialize SwAxisCont."""
         super().__init__()
         self.category: Optional[CalprmAxisCategoryEnum] = None
+        self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
         self.sw_axis_index: Optional[AxisIndexType] = None
+        self.sw_values_phys: Optional[SwValues] = None
         self.vf: Optional[Numerical] = None
         self.vg: Optional[ValueGroup] = None
         self.vt: Optional[VerbatimString] = None
@@ -124,6 +136,19 @@ class SwAxisCont(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize sw_arraysize_ref (atp_mixed - append children directly)
+        if self.sw_arraysize_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_arraysize_ref, "ValueList")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
         # Serialize v
         if self.v is not None:
             serialized = SerializationHelper.serialize_item(self.v, "Numerical")
@@ -151,6 +176,19 @@ class SwAxisCont(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize sw_values_phys (atp_mixed - append children directly)
+        if self.sw_values_phys is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_values_phys, "SwValues")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize vf
         if self.vf is not None:
@@ -257,10 +295,14 @@ class SwAxisCont(ARObject):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "CATEGORY":
                 setattr(obj, "category", CalprmAxisCategoryEnum.deserialize(child))
+            elif tag == "SW-ARRAYSIZE-REF":
+                setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "SW-AXIS-INDEX":
                 setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(child, "AxisIndexType"))
+            elif tag == "SW-VALUES-PHYS":
+                setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(child, "SwValues"))
             elif tag == "VF":
                 setattr(obj, "vf", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VG":
@@ -301,6 +343,20 @@ class SwAxisContBuilder(BuilderBase):
         self._obj.category = value
         return self
 
+    def with_sw_arraysize(self, value: Optional[ValueList]) -> "SwAxisContBuilder":
+        """Set sw_arraysize attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_arraysize' is required and cannot be None")
+        self._obj.sw_arraysize = value
+        return self
+
     def with_v(self, value: Optional[Numerical]) -> "SwAxisContBuilder":
         """Set v attribute.
 
@@ -327,6 +383,20 @@ class SwAxisContBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'sw_axis_index' is required and cannot be None")
         self._obj.sw_axis_index = value
+        return self
+
+    def with_sw_values_phys(self, value: Optional[SwValues]) -> "SwAxisContBuilder":
+        """Set sw_values_phys attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_values_phys' is required and cannot be None")
+        self._obj.sw_values_phys = value
         return self
 
     def with_vf(self, value: Optional[Numerical]) -> "SwAxisContBuilder":

--- a/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py
+++ b/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py
@@ -21,11 +21,17 @@ from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.numerical_or_
 from armodel2.models.M2.MSR.Documentation.TextModel.SingleLanguageData.single_language_unit_names import (
     SingleLanguageUnitNames,
 )
+from armodel2.models.M2.MSR.CalibrationData.CalibrationValue.sw_values import (
+    SwValues,
+)
 from armodel2.models.M2.MSR.AsamHdo.Units.unit import (
     Unit,
 )
 from armodel2.models.M2.MSR.CalibrationData.CalibrationValue.value_group import (
     ValueGroup,
+)
+from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.value_list import (
+    ValueList,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -46,7 +52,9 @@ class SwValueCont(ARObject):
     _XML_TAG = "SW-VALUE-CONT"
 
 
+    sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
+    sw_values_phys: Optional[SwValues]
     vf: Optional[Numerical]
     vg: Optional[ValueGroup]
     vt: Optional[VerbatimString]
@@ -54,7 +62,9 @@ class SwValueCont(ARObject):
     unit_ref: Optional[ARRef]
     unit_display: Optional[SingleLanguageUnitNames]
     _DESERIALIZE_DISPATCH = {
+        "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "SW-VALUES-PHYS": lambda obj, elem: setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(elem, "SwValues")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VG": lambda obj, elem: setattr(obj, "vg", SerializationHelper.deserialize_by_tag(elem, "ValueGroup")),
         "VT": lambda obj, elem: setattr(obj, "vt", SerializationHelper.deserialize_by_tag(elem, "VerbatimString")),
@@ -67,7 +77,9 @@ class SwValueCont(ARObject):
     def __init__(self) -> None:
         """Initialize SwValueCont."""
         super().__init__()
+        self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
+        self.sw_values_phys: Optional[SwValues] = None
         self.vf: Optional[Numerical] = None
         self.vg: Optional[ValueGroup] = None
         self.vt: Optional[VerbatimString] = None
@@ -98,6 +110,19 @@ class SwValueCont(ARObject):
         for child in parent_elem:
             elem.append(child)
 
+        # Serialize sw_arraysize_ref (atp_mixed - append children directly)
+        if self.sw_arraysize_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_arraysize_ref, "ValueList")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
         # Serialize v
         if self.v is not None:
             serialized = SerializationHelper.serialize_item(self.v, "Numerical")
@@ -111,6 +136,19 @@ class SwValueCont(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize sw_values_phys (atp_mixed - append children directly)
+        if self.sw_values_phys is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_values_phys, "SwValues")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize vf
         if self.vf is not None:
@@ -215,8 +253,12 @@ class SwValueCont(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "V":
+            if tag == "SW-ARRAYSIZE-REF":
+                setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
+            elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "SW-VALUES-PHYS":
+                setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(child, "SwValues"))
             elif tag == "VF":
                 setattr(obj, "vf", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VG":
@@ -243,6 +285,20 @@ class SwValueContBuilder(BuilderBase):
         self._obj: SwValueCont = SwValueCont()
 
 
+    def with_sw_arraysize(self, value: Optional[ValueList]) -> "SwValueContBuilder":
+        """Set sw_arraysize attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_arraysize' is required and cannot be None")
+        self._obj.sw_arraysize = value
+        return self
+
     def with_v(self, value: Optional[Numerical]) -> "SwValueContBuilder":
         """Set v attribute.
 
@@ -255,6 +311,20 @@ class SwValueContBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'v' is required and cannot be None")
         self._obj.v = value
+        return self
+
+    def with_sw_values_phys(self, value: Optional[SwValues]) -> "SwValueContBuilder":
+        """Set sw_values_phys attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_values_phys' is required and cannot be None")
+        self._obj.sw_values_phys = value
         return self
 
     def with_vf(self, value: Optional[Numerical]) -> "SwValueContBuilder":

--- a/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/value_group.py
+++ b/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/value_group.py
@@ -20,10 +20,16 @@ from armodel2.models.M2.MSR.Documentation.TextModel.MultilanguageData.multilangu
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.numerical_or_text import (
     NumericalOrText,
 )
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.MSR.CalibrationData.CalibrationValue.sw_values import (
+        SwValues,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class ValueGroup(ARObject):
     """AUTOSAR ValueGroup."""
 
@@ -40,6 +46,7 @@ class ValueGroup(ARObject):
 
 
     label: Optional[MultilanguageLongName]
+    vg_contents: Optional[SwValues]
     v: Optional[Numerical]
     vf: Optional[Numerical]
     vg: Optional[ValueGroup]
@@ -47,6 +54,7 @@ class ValueGroup(ARObject):
     vtf: Optional[NumericalOrText]
     _DESERIALIZE_DISPATCH = {
         "LABEL": lambda obj, elem: setattr(obj, "label", SerializationHelper.deserialize_by_tag(elem, "MultilanguageLongName")),
+        "VG-CONTENTS": lambda obj, elem: setattr(obj, "vg_contents", SerializationHelper.deserialize_by_tag(elem, "SwValues")),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VG": lambda obj, elem: setattr(obj, "vg", SerializationHelper.deserialize_by_tag(elem, "ValueGroup")),
@@ -59,6 +67,7 @@ class ValueGroup(ARObject):
         """Initialize ValueGroup."""
         super().__init__()
         self.label: Optional[MultilanguageLongName] = None
+        self.vg_contents: Optional[SwValues] = None
         self.v: Optional[Numerical] = None
         self.vf: Optional[Numerical] = None
         self.vg: Optional[ValueGroup] = None
@@ -101,6 +110,19 @@ class ValueGroup(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize vg_contents (atp_mixed - append children directly)
+        if self.vg_contents is not None:
+            serialized = SerializationHelper.serialize_item(self.vg_contents, "SwValues")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize v
         if self.v is not None:
@@ -193,6 +215,8 @@ class ValueGroup(ARObject):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "LABEL":
                 setattr(obj, "label", SerializationHelper.deserialize_by_tag(child, "MultilanguageLongName"))
+            elif tag == "VG-CONTENTS":
+                setattr(obj, "vg_contents", SerializationHelper.deserialize_by_tag(child, "SwValues"))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VF":
@@ -229,6 +253,20 @@ class ValueGroupBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'label' is required and cannot be None")
         self._obj.label = value
+        return self
+
+    def with_vg_contents(self, value: Optional[SwValues]) -> "ValueGroupBuilder":
+        """Set vg_contents attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'vg_contents' is required and cannot be None")
+        self._obj.vg_contents = value
         return self
 
     def with_v(self, value: Optional[Numerical]) -> "ValueGroupBuilder":

--- a/src/armodel2/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout_group.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout_group.py
@@ -64,6 +64,7 @@ class SwRecordLayoutGroup(ARObject):
     sw_record_layout_group_axis: Optional[AxisIndexType]
     sw_record_layout_group_from: Optional[RecordLayoutIteratorPoint]
     sw_record_layout_group_to: Optional[RecordLayoutIteratorPoint]
+    sw_record_layout_group_content_type: Optional[swRecordLayoutGroupContent]
     sw_record_layout: Optional[SwRecordLayout]
     sw_record_layout_group: Optional[SwRecordLayoutGroup]
     sw_record_layout_v: Optional[SwRecordLayoutV]
@@ -78,6 +79,7 @@ class SwRecordLayoutGroup(ARObject):
         "SW-RECORD-LAYOUT-GROUP-AXIS": lambda obj, elem: setattr(obj, "sw_record_layout_group_axis", SerializationHelper.deserialize_by_tag(elem, "AxisIndexType")),
         "SW-RECORD-LAYOUT-GROUP-FROM": lambda obj, elem: setattr(obj, "sw_record_layout_group_from", SerializationHelper.deserialize_by_tag(elem, "RecordLayoutIteratorPoint")),
         "SW-RECORD-LAYOUT-GROUP-TO": lambda obj, elem: setattr(obj, "sw_record_layout_group_to", SerializationHelper.deserialize_by_tag(elem, "RecordLayoutIteratorPoint")),
+        "SW-RECORD-LAYOUT-GROUP-CONTENT-TYPE": lambda obj, elem: setattr(obj, "sw_record_layout_group_content_type", SerializationHelper.deserialize_by_tag(elem, "swRecordLayoutGroupContent")),
         "SW-RECORD-LAYOUT": lambda obj, elem: setattr(obj, "sw_record_layout", SerializationHelper.deserialize_by_tag(elem, "SwRecordLayout")),
         "SW-RECORD-LAYOUT-GROUP": lambda obj, elem: setattr(obj, "sw_record_layout_group", SerializationHelper.deserialize_by_tag(elem, "SwRecordLayoutGroup")),
         "SW-RECORD-LAYOUT-V": lambda obj, elem: setattr(obj, "sw_record_layout_v", SerializationHelper.deserialize_by_tag(elem, "SwRecordLayoutV")),
@@ -97,6 +99,7 @@ class SwRecordLayoutGroup(ARObject):
         self.sw_record_layout_group_axis: Optional[AxisIndexType] = None
         self.sw_record_layout_group_from: Optional[RecordLayoutIteratorPoint] = None
         self.sw_record_layout_group_to: Optional[RecordLayoutIteratorPoint] = None
+        self.sw_record_layout_group_content_type: Optional[swRecordLayoutGroupContent] = None
         self.sw_record_layout: Optional[SwRecordLayout] = None
         self.sw_record_layout_group: Optional[SwRecordLayoutGroup] = None
         self.sw_record_layout_v: Optional[SwRecordLayoutV] = None
@@ -238,6 +241,19 @@ class SwRecordLayoutGroup(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize sw_record_layout_group_content_type (atp_mixed - append children directly)
+        if self.sw_record_layout_group_content_type is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_record_layout_group_content_type, "swRecordLayoutGroupContent")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
         # Serialize sw_record_layout
         if self.sw_record_layout is not None:
             serialized = SerializationHelper.serialize_item(self.sw_record_layout, "SwRecordLayout")
@@ -343,6 +359,8 @@ class SwRecordLayoutGroup(ARObject):
                 setattr(obj, "sw_record_layout_group_from", SerializationHelper.deserialize_by_tag(child, "RecordLayoutIteratorPoint"))
             elif tag == "SW-RECORD-LAYOUT-GROUP-TO":
                 setattr(obj, "sw_record_layout_group_to", SerializationHelper.deserialize_by_tag(child, "RecordLayoutIteratorPoint"))
+            elif tag == "SW-RECORD-LAYOUT-GROUP-CONTENT-TYPE":
+                setattr(obj, "sw_record_layout_group_content_type", SerializationHelper.deserialize_by_tag(child, "swRecordLayoutGroupContent"))
             elif tag == "SW-RECORD-LAYOUT":
                 setattr(obj, "sw_record_layout", SerializationHelper.deserialize_by_tag(child, "SwRecordLayout"))
             elif tag == "SW-RECORD-LAYOUT-GROUP":
@@ -477,6 +495,20 @@ class SwRecordLayoutGroupBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'sw_record_layout_group_to' is required and cannot be None")
         self._obj.sw_record_layout_group_to = value
+        return self
+
+    def with_sw_record_layout_group_content_type(self, value: Optional[swRecordLayoutGroupContent]) -> "SwRecordLayoutGroupBuilder":
+        """Set sw_record_layout_group_content_type attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_record_layout_group_content_type' is required and cannot be None")
+        self._obj.sw_record_layout_group_content_type = value
         return self
 
     def with_sw_record_layout(self, value: Optional[SwRecordLayout]) -> "SwRecordLayoutGroupBuilder":

--- a/src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py
@@ -24,6 +24,9 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Numerical,
 )
+from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.value_list import (
+    ValueList,
+)
 
 if TYPE_CHECKING:
     from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_data_def_props import (
@@ -50,12 +53,14 @@ class SwServiceArg(Identifiable):
 
 
     direction: Optional[ArgumentDirectionEnum]
+    sw_arraysize: Optional[ValueList]
     v: Optional[Numerical]
-    sw_data_def: Optional[SwDataDefProps]
+    sw_data_def_props: Optional[SwDataDefProps]
     _DESERIALIZE_DISPATCH = {
         "DIRECTION": lambda obj, elem: setattr(obj, "direction", ArgumentDirectionEnum.deserialize(elem)),
+        "SW-ARRAYSIZE": lambda obj, elem: setattr(obj, "sw_arraysize", SerializationHelper.deserialize_by_tag(elem, "ValueList")),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
-        "SW-DATA-DEF": lambda obj, elem: setattr(obj, "sw_data_def", SerializationHelper.deserialize_by_tag(elem, "SwDataDefProps")),
+        "SW-DATA-DEF-PROPS": lambda obj, elem: setattr(obj, "sw_data_def_props", SerializationHelper.deserialize_by_tag(elem, "SwDataDefProps")),
     }
 
 
@@ -63,8 +68,9 @@ class SwServiceArg(Identifiable):
         """Initialize SwServiceArg."""
         super().__init__()
         self.direction: Optional[ArgumentDirectionEnum] = None
+        self.sw_arraysize: Optional[ValueList] = None
         self.v: Optional[Numerical] = None
-        self.sw_data_def: Optional[SwDataDefProps] = None
+        self.sw_data_def_props: Optional[SwDataDefProps] = None
 
     def serialize(self) -> ET.Element:
         """Serialize SwServiceArg to XML element.
@@ -103,6 +109,19 @@ class SwServiceArg(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize sw_arraysize (atp_mixed - append children directly)
+        if self.sw_arraysize is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_arraysize, "ValueList")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
         # Serialize v
         if self.v is not None:
             serialized = SerializationHelper.serialize_item(self.v, "Numerical")
@@ -117,12 +136,12 @@ class SwServiceArg(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sw_data_def
-        if self.sw_data_def is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_data_def, "SwDataDefProps")
+        # Serialize sw_data_def_props
+        if self.sw_data_def_props is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_data_def_props, "SwDataDefProps")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("SW-DATA-DEF")
+                wrapped = ET.Element("SW-DATA-DEF-PROPS")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -152,10 +171,12 @@ class SwServiceArg(Identifiable):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "DIRECTION":
                 setattr(obj, "direction", ArgumentDirectionEnum.deserialize(child))
+            elif tag == "SW-ARRAYSIZE":
+                setattr(obj, "sw_arraysize", SerializationHelper.deserialize_by_tag(child, "ValueList"))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
-            elif tag == "SW-DATA-DEF":
-                setattr(obj, "sw_data_def", SerializationHelper.deserialize_by_tag(child, "SwDataDefProps"))
+            elif tag == "SW-DATA-DEF-PROPS":
+                setattr(obj, "sw_data_def_props", SerializationHelper.deserialize_by_tag(child, "SwDataDefProps"))
 
         return obj
 
@@ -184,6 +205,20 @@ class SwServiceArgBuilder(IdentifiableBuilder):
         self._obj.direction = value
         return self
 
+    def with_sw_arraysize(self, value: Optional[ValueList]) -> "SwServiceArgBuilder":
+        """Set sw_arraysize attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_arraysize' is required and cannot be None")
+        self._obj.sw_arraysize = value
+        return self
+
     def with_v(self, value: Optional[Numerical]) -> "SwServiceArgBuilder":
         """Set v attribute.
 
@@ -198,8 +233,8 @@ class SwServiceArgBuilder(IdentifiableBuilder):
         self._obj.v = value
         return self
 
-    def with_sw_data_def(self, value: Optional[SwDataDefProps]) -> "SwServiceArgBuilder":
-        """Set sw_data_def attribute.
+    def with_sw_data_def_props(self, value: Optional[SwDataDefProps]) -> "SwServiceArgBuilder":
+        """Set sw_data_def_props attribute.
 
         Args:
             value: Value to set
@@ -208,8 +243,8 @@ class SwServiceArgBuilder(IdentifiableBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'sw_data_def' is required and cannot be None")
-        self._obj.sw_data_def = value
+            raise ValueError("Attribute 'sw_data_def_props' is required and cannot be None")
+        self._obj.sw_data_def_props = value
         return self
 
 
@@ -218,7 +253,7 @@ class SwServiceArgBuilder(IdentifiableBuilder):
     _OPTIONAL_ATTRIBUTES = {
         "direction",
         "swArraysize",
-        "swDataDef",
+        "swDataDefProps",
     }
 
 

--- a/src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_content.py
+++ b/src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_content.py
@@ -20,6 +20,9 @@ from armodel2.models.M2.MSR.Documentation.BlockElements.GerneralParameters.prms 
 from armodel2.models.M2.MSR.Documentation.Chapters.topic_content import (
     TopicContent,
 )
+from armodel2.models.M2.MSR.Documentation.Chapters.topic_content_or_msr_query import (
+    TopicContentOrMsrQuery,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -42,10 +45,12 @@ class ChapterContent(ARObject):
 
 
     prms: Prms
+    topic_content_or_msr: Optional[TopicContentOrMsrQuery]
     msr_query_p1: MsrQueryP1
     topic_content: TopicContent
     _DESERIALIZE_DISPATCH = {
         "PRMS": lambda obj, elem: setattr(obj, "prms", SerializationHelper.deserialize_by_tag(elem, "Prms")),
+        "TOPIC-CONTENT-OR-MSR": lambda obj, elem: setattr(obj, "topic_content_or_msr", SerializationHelper.deserialize_by_tag(elem, "TopicContentOrMsrQuery")),
         "MSR-QUERY-P1": lambda obj, elem: setattr(obj, "msr_query_p1", SerializationHelper.deserialize_by_tag(elem, "MsrQueryP1")),
         "TOPIC-CONTENT": lambda obj, elem: setattr(obj, "topic_content", SerializationHelper.deserialize_by_tag(elem, "TopicContent")),
     }
@@ -55,6 +60,7 @@ class ChapterContent(ARObject):
         """Initialize ChapterContent."""
         super().__init__()
         self.prms: Prms = None
+        self.topic_content_or_msr: Optional[TopicContentOrMsrQuery] = None
         self.msr_query_p1: MsrQueryP1 = None
         self.topic_content: TopicContent = None
 
@@ -87,6 +93,19 @@ class ChapterContent(ARObject):
             serialized = SerializationHelper.serialize_item(self.prms, "Prms")
             if serialized is not None:
                 wrapped = ET.Element("PRMS")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize topic_content_or_msr (complex type)
+        if self.topic_content_or_msr is not None:
+            serialized = SerializationHelper.serialize_item(self.topic_content_or_msr, "TopicContentOrMsrQuery")
+            if serialized is not None:
+                wrapped = ET.Element("TOPIC-CONTENT-OR-MSR")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -142,6 +161,12 @@ class ChapterContent(ARObject):
             prms_value = SerializationHelper.deserialize_by_tag(child, "Prms")
             obj.prms = prms_value
 
+        # Parse topic_content_or_msr
+        child = SerializationHelper.find_child_element(element, "TOPIC-CONTENT-OR-MSR")
+        if child is not None:
+            topic_content_or_msr_value = SerializationHelper.deserialize_by_tag(child, "TopicContentOrMsrQuery")
+            obj.topic_content_or_msr = topic_content_or_msr_value
+
         # Parse msr_query_p1
         child = SerializationHelper.find_child_element(element, "MSR-QUERY-P1")
         if child is not None:
@@ -179,6 +204,20 @@ class ChapterContentBuilder(BuilderBase):
         if value is None and not False:
             raise ValueError("Attribute 'prms' is required and cannot be None")
         self._obj.prms = value
+        return self
+
+    def with_topic_content_or_msr(self, value: Optional[TopicContentOrMsrQuery]) -> "ChapterContentBuilder":
+        """Set topic_content_or_msr attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'topic_content_or_msr' is required and cannot be None")
+        self._obj.topic_content_or_msr = value
         return self
 
     def with_msr_query_p1(self, value: MsrQueryP1) -> "ChapterContentBuilder":

--- a/src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_model.py
+++ b/src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_model.py
@@ -11,22 +11,25 @@ from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
+from armodel2.models.M2.MSR.Documentation.Chapters.chapter_content import (
+    ChapterContent,
+)
 from armodel2.models.M2.MSR.Documentation.MsrQuery.msr_query_topic1 import (
     MsrQueryTopic1,
 )
 from armodel2.models.M2.MSR.Documentation.BlockElements.GerneralParameters.prms import (
     Prms,
 )
-from armodel2.models.M2.MSR.Documentation.Chapters.topic1 import (
-    Topic1,
-)
 from armodel2.models.M2.MSR.Documentation.Chapters.topic_content_or_msr_query import (
     TopicContentOrMsrQuery,
 )
+from armodel2.models.M2.MSR.Documentation.Chapters.topic_or_msr_query import (
+    TopicOrMsrQuery,
+)
 
 if TYPE_CHECKING:
-    from armodel2.models.M2.MSR.Documentation.Chapters.chapter import (
-        Chapter,
+    from armodel2.models.M2.MSR.Documentation.Chapters.chapter_or_msr_query import (
+        ChapterOrMsrQuery,
     )
     from armodel2.models.M2.MSR.Documentation.MsrQuery.msr_query_chapter import (
         MsrQueryChapter,
@@ -51,31 +54,34 @@ class ChapterModel(ARObject):
     _XML_TAG = "CHAPTER-MODEL"
 
 
-    chapter: Chapter
+    chapter: Optional[ChapterOrMsrQuery]
     msr_query_chapter: MsrQueryChapter
+    chapter_content: Optional[ChapterContent]
     prms: Prms
     topic_content_or_msr: Optional[TopicContentOrMsrQuery]
+    topic1: Optional[TopicOrMsrQuery]
     msr_query: MsrQueryTopic1
-    topic1: Topic1
     _DESERIALIZE_DISPATCH = {
-        "CHAPTER": lambda obj, elem: setattr(obj, "chapter", SerializationHelper.deserialize_by_tag(elem, "Chapter")),
+        "CHAPTER": lambda obj, elem: setattr(obj, "chapter", SerializationHelper.deserialize_by_tag(elem, "ChapterOrMsrQuery")),
         "MSR-QUERY-CHAPTER": lambda obj, elem: setattr(obj, "msr_query_chapter", SerializationHelper.deserialize_by_tag(elem, "MsrQueryChapter")),
+        "CHAPTER-CONTENT": lambda obj, elem: setattr(obj, "chapter_content", SerializationHelper.deserialize_by_tag(elem, "ChapterContent")),
         "PRMS": lambda obj, elem: setattr(obj, "prms", SerializationHelper.deserialize_by_tag(elem, "Prms")),
         "TOPIC-CONTENT-OR-MSR": lambda obj, elem: setattr(obj, "topic_content_or_msr", SerializationHelper.deserialize_by_tag(elem, "TopicContentOrMsrQuery")),
+        "TOPIC1": lambda obj, elem: setattr(obj, "topic1", SerializationHelper.deserialize_by_tag(elem, "TopicOrMsrQuery")),
         "MSR-QUERY": lambda obj, elem: setattr(obj, "msr_query", SerializationHelper.deserialize_by_tag(elem, "MsrQueryTopic1")),
-        "TOPIC1": lambda obj, elem: setattr(obj, "topic1", SerializationHelper.deserialize_by_tag(elem, "Topic1")),
     }
 
 
     def __init__(self) -> None:
         """Initialize ChapterModel."""
         super().__init__()
-        self.chapter: Chapter = None
+        self.chapter: Optional[ChapterOrMsrQuery] = None
         self.msr_query_chapter: MsrQueryChapter = None
+        self.chapter_content: Optional[ChapterContent] = None
         self.prms: Prms = None
         self.topic_content_or_msr: Optional[TopicContentOrMsrQuery] = None
+        self.topic1: Optional[TopicOrMsrQuery] = None
         self.msr_query: MsrQueryTopic1 = None
-        self.topic1: Topic1 = None
 
     def serialize(self) -> ET.Element:
         """Serialize ChapterModel to XML element.
@@ -100,19 +106,18 @@ class ChapterModel(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize chapter
+        # Serialize chapter (atp_mixed - append children directly)
         if self.chapter is not None:
-            serialized = SerializationHelper.serialize_item(self.chapter, "Chapter")
+            serialized = SerializationHelper.serialize_item(self.chapter, "ChapterOrMsrQuery")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("CHAPTER")
+                # atpMixed type: append children directly without wrapper
                 if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    elem.append(child)
 
         # Serialize msr_query_chapter
         if self.msr_query_chapter is not None:
@@ -127,6 +132,19 @@ class ChapterModel(ARObject):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize chapter_content (atp_mixed - append children directly)
+        if self.chapter_content is not None:
+            serialized = SerializationHelper.serialize_item(self.chapter_content, "ChapterContent")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize prms
         if self.prms is not None:
@@ -155,26 +173,25 @@ class ChapterModel(ARObject):
                 for child in serialized:
                     elem.append(child)
 
+        # Serialize topic1 (atp_mixed - append children directly)
+        if self.topic1 is not None:
+            serialized = SerializationHelper.serialize_item(self.topic1, "TopicOrMsrQuery")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
         # Serialize msr_query
         if self.msr_query is not None:
             serialized = SerializationHelper.serialize_item(self.msr_query, "MsrQueryTopic1")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("MSR-QUERY")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
-
-        # Serialize topic1
-        if self.topic1 is not None:
-            serialized = SerializationHelper.serialize_item(self.topic1, "Topic1")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("TOPIC1")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -203,17 +220,19 @@ class ChapterModel(ARObject):
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "CHAPTER":
-                setattr(obj, "chapter", SerializationHelper.deserialize_by_tag(child, "Chapter"))
+                setattr(obj, "chapter", SerializationHelper.deserialize_by_tag(child, "ChapterOrMsrQuery"))
             elif tag == "MSR-QUERY-CHAPTER":
                 setattr(obj, "msr_query_chapter", SerializationHelper.deserialize_by_tag(child, "MsrQueryChapter"))
+            elif tag == "CHAPTER-CONTENT":
+                setattr(obj, "chapter_content", SerializationHelper.deserialize_by_tag(child, "ChapterContent"))
             elif tag == "PRMS":
                 setattr(obj, "prms", SerializationHelper.deserialize_by_tag(child, "Prms"))
             elif tag == "TOPIC-CONTENT-OR-MSR":
                 setattr(obj, "topic_content_or_msr", SerializationHelper.deserialize_by_tag(child, "TopicContentOrMsrQuery"))
+            elif tag == "TOPIC1":
+                setattr(obj, "topic1", SerializationHelper.deserialize_by_tag(child, "TopicOrMsrQuery"))
             elif tag == "MSR-QUERY":
                 setattr(obj, "msr_query", SerializationHelper.deserialize_by_tag(child, "MsrQueryTopic1"))
-            elif tag == "TOPIC1":
-                setattr(obj, "topic1", SerializationHelper.deserialize_by_tag(child, "Topic1"))
 
         return obj
 
@@ -228,7 +247,7 @@ class ChapterModelBuilder(BuilderBase):
         self._obj: ChapterModel = ChapterModel()
 
 
-    def with_chapter(self, value: Chapter) -> "ChapterModelBuilder":
+    def with_chapter(self, value: Optional[ChapterOrMsrQuery]) -> "ChapterModelBuilder":
         """Set chapter attribute.
 
         Args:
@@ -237,7 +256,7 @@ class ChapterModelBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        if value is None and not False:
+        if value is None and not True:
             raise ValueError("Attribute 'chapter' is required and cannot be None")
         self._obj.chapter = value
         return self
@@ -254,6 +273,20 @@ class ChapterModelBuilder(BuilderBase):
         if value is None and not False:
             raise ValueError("Attribute 'msr_query_chapter' is required and cannot be None")
         self._obj.msr_query_chapter = value
+        return self
+
+    def with_chapter_content(self, value: Optional[ChapterContent]) -> "ChapterModelBuilder":
+        """Set chapter_content attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'chapter_content' is required and cannot be None")
+        self._obj.chapter_content = value
         return self
 
     def with_prms(self, value: Prms) -> "ChapterModelBuilder":
@@ -284,6 +317,20 @@ class ChapterModelBuilder(BuilderBase):
         self._obj.topic_content_or_msr = value
         return self
 
+    def with_topic1(self, value: Optional[TopicOrMsrQuery]) -> "ChapterModelBuilder":
+        """Set topic1 attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'topic1' is required and cannot be None")
+        self._obj.topic1 = value
+        return self
+
     def with_msr_query(self, value: MsrQueryTopic1) -> "ChapterModelBuilder":
         """Set msr_query attribute.
 
@@ -296,20 +343,6 @@ class ChapterModelBuilder(BuilderBase):
         if value is None and not False:
             raise ValueError("Attribute 'msr_query' is required and cannot be None")
         self._obj.msr_query = value
-        return self
-
-    def with_topic1(self, value: Topic1) -> "ChapterModelBuilder":
-        """Set topic1 attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not False:
-            raise ValueError("Attribute 'topic1' is required and cannot be None")
-        self._obj.topic1 = value
         return self
 
 

--- a/src/armodel2/models/M2/MSR/Documentation/Chapters/topic1.py
+++ b/src/armodel2/models/M2/MSR/Documentation/Chapters/topic1.py
@@ -23,6 +23,9 @@ from armodel2.models.M2.MSR.Documentation.MsrQuery.msr_query_p1 import (
 from armodel2.models.M2.MSR.Documentation.Chapters.topic_content import (
     TopicContent,
 )
+from armodel2.models.M2.MSR.Documentation.Chapters.topic_content_or_msr_query import (
+    TopicContentOrMsrQuery,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -43,10 +46,12 @@ class Topic1(Paginateable):
 
 
     help_entry: Optional[String]
+    topic_content_or_msr: Optional[TopicContentOrMsrQuery]
     msr_query_p1: MsrQueryP1
     topic_content: TopicContent
     _DESERIALIZE_DISPATCH = {
         "HELP-ENTRY": lambda obj, elem: setattr(obj, "help_entry", SerializationHelper.deserialize_by_tag(elem, "String")),
+        "TOPIC-CONTENT-OR-MSR": lambda obj, elem: setattr(obj, "topic_content_or_msr", SerializationHelper.deserialize_by_tag(elem, "TopicContentOrMsrQuery")),
         "MSR-QUERY-P1": lambda obj, elem: setattr(obj, "msr_query_p1", SerializationHelper.deserialize_by_tag(elem, "MsrQueryP1")),
         "TOPIC-CONTENT": lambda obj, elem: setattr(obj, "topic_content", SerializationHelper.deserialize_by_tag(elem, "TopicContent")),
     }
@@ -56,6 +61,7 @@ class Topic1(Paginateable):
         """Initialize Topic1."""
         super().__init__()
         self.help_entry: Optional[String] = None
+        self.topic_content_or_msr: Optional[TopicContentOrMsrQuery] = None
         self.msr_query_p1: MsrQueryP1 = None
         self.topic_content: TopicContent = None
 
@@ -95,6 +101,19 @@ class Topic1(Paginateable):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize topic_content_or_msr (atp_mixed - append children directly)
+        if self.topic_content_or_msr is not None:
+            serialized = SerializationHelper.serialize_item(self.topic_content_or_msr, "TopicContentOrMsrQuery")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize msr_query_p1
         if self.msr_query_p1 is not None:
@@ -144,6 +163,8 @@ class Topic1(Paginateable):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "HELP-ENTRY":
                 setattr(obj, "help_entry", SerializationHelper.deserialize_by_tag(child, "String"))
+            elif tag == "TOPIC-CONTENT-OR-MSR":
+                setattr(obj, "topic_content_or_msr", SerializationHelper.deserialize_by_tag(child, "TopicContentOrMsrQuery"))
             elif tag == "MSR-QUERY-P1":
                 setattr(obj, "msr_query_p1", SerializationHelper.deserialize_by_tag(child, "MsrQueryP1"))
             elif tag == "TOPIC-CONTENT":
@@ -174,6 +195,20 @@ class Topic1Builder(PaginateableBuilder):
         if value is None and not True:
             raise ValueError("Attribute 'help_entry' is required and cannot be None")
         self._obj.help_entry = value
+        return self
+
+    def with_topic_content_or_msr(self, value: Optional[TopicContentOrMsrQuery]) -> "Topic1Builder":
+        """Set topic_content_or_msr attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'topic_content_or_msr' is required and cannot be None")
+        self._obj.topic_content_or_msr = value
         return self
 
     def with_msr_query_p1(self, value: MsrQueryP1) -> "Topic1Builder":

--- a/src/armodel2/models/M2/MSR/Documentation/Chapters/topic_content_or_msr_query.py
+++ b/src/armodel2/models/M2/MSR/Documentation/Chapters/topic_content_or_msr_query.py
@@ -20,6 +20,9 @@ from armodel2.models.M2.MSR.Documentation.MsrQuery.msr_query_p1 import (
 from armodel2.models.M2.MSR.Documentation.BlockElements.OasisExchangeTable.table import (
     Table,
 )
+from armodel2.models.M2.MSR.Documentation.Chapters.topic_content import (
+    TopicContent,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -42,11 +45,13 @@ class TopicContentOrMsrQuery(ARObject):
 
 
     msr_query_p1: MsrQueryP1
+    topic_content: TopicContent
     block_level: DocumentationBlock
     table: Optional[Table]
     traceable_table: Any
     _DESERIALIZE_DISPATCH = {
         "MSR-QUERY-P1": lambda obj, elem: setattr(obj, "msr_query_p1", SerializationHelper.deserialize_by_tag(elem, "MsrQueryP1")),
+        "TOPIC-CONTENT": lambda obj, elem: setattr(obj, "topic_content", SerializationHelper.deserialize_by_tag(elem, "TopicContent")),
         "BLOCK-LEVEL": lambda obj, elem: setattr(obj, "block_level", SerializationHelper.deserialize_by_tag(elem, "DocumentationBlock")),
         "TABLE": lambda obj, elem: setattr(obj, "table", SerializationHelper.deserialize_by_tag(elem, "Table")),
         "TRACEABLE-TABLE": lambda obj, elem: setattr(obj, "traceable_table", SerializationHelper.deserialize_by_tag(elem, "any (TraceableTable)")),
@@ -57,6 +62,7 @@ class TopicContentOrMsrQuery(ARObject):
         """Initialize TopicContentOrMsrQuery."""
         super().__init__()
         self.msr_query_p1: MsrQueryP1 = None
+        self.topic_content: TopicContent = None
         self.block_level: DocumentationBlock = None
         self.table: Optional[Table] = None
         self.traceable_table: Any = None
@@ -90,6 +96,19 @@ class TopicContentOrMsrQuery(ARObject):
             serialized = SerializationHelper.serialize_item(self.msr_query_p1, "MsrQueryP1")
             if serialized is not None:
                 wrapped = ET.Element("MSR-QUERY-P1")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize topic_content (complex type)
+        if self.topic_content is not None:
+            serialized = SerializationHelper.serialize_item(self.topic_content, "TopicContent")
+            if serialized is not None:
+                wrapped = ET.Element("TOPIC-CONTENT")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -158,6 +177,12 @@ class TopicContentOrMsrQuery(ARObject):
             msr_query_p1_value = SerializationHelper.deserialize_by_tag(child, "MsrQueryP1")
             obj.msr_query_p1 = msr_query_p1_value
 
+        # Parse topic_content
+        child = SerializationHelper.find_child_element(element, "TOPIC-CONTENT")
+        if child is not None:
+            topic_content_value = SerializationHelper.deserialize_by_tag(child, "TopicContent")
+            obj.topic_content = topic_content_value
+
         # Parse block_level
         child = SerializationHelper.find_child_element(element, "BLOCK-LEVEL")
         if child is not None:
@@ -201,6 +226,20 @@ class TopicContentOrMsrQueryBuilder(BuilderBase):
         if value is None and not False:
             raise ValueError("Attribute 'msr_query_p1' is required and cannot be None")
         self._obj.msr_query_p1 = value
+        return self
+
+    def with_topic_content(self, value: TopicContent) -> "TopicContentOrMsrQueryBuilder":
+        """Set topic_content attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not False:
+            raise ValueError("Attribute 'topic_content' is required and cannot be None")
+        self._obj.topic_content = value
         return self
 
     def with_block_level(self, value: DocumentationBlock) -> "TopicContentOrMsrQueryBuilder":

--- a/src/armodel2/models/M2/MSR/Documentation/MsrQuery/msr_query_p1.py
+++ b/src/armodel2/models/M2/MSR/Documentation/MsrQuery/msr_query_p1.py
@@ -23,6 +23,9 @@ from armodel2.models.M2.MSR.Documentation.MsrQuery.msr_query_props import (
 from armodel2.models.M2.MSR.Documentation.BlockElements.OasisExchangeTable.table import (
     Table,
 )
+from armodel2.models.M2.MSR.Documentation.Chapters.topic_content import (
+    TopicContent,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -43,11 +46,13 @@ class MsrQueryP1(Paginateable):
 
 
     msr_query_props: MsrQueryProps
+    msr_query_result: Optional[TopicContent]
     block_level: DocumentationBlock
     table: Optional[Table]
     traceable_table: Any
     _DESERIALIZE_DISPATCH = {
         "MSR-QUERY-PROPS": lambda obj, elem: setattr(obj, "msr_query_props", SerializationHelper.deserialize_by_tag(elem, "MsrQueryProps")),
+        "MSR-QUERY-RESULT": lambda obj, elem: setattr(obj, "msr_query_result", SerializationHelper.deserialize_by_tag(elem, "TopicContent")),
         "BLOCK-LEVEL": lambda obj, elem: setattr(obj, "block_level", SerializationHelper.deserialize_by_tag(elem, "DocumentationBlock")),
         "TABLE": lambda obj, elem: setattr(obj, "table", SerializationHelper.deserialize_by_tag(elem, "Table")),
         "TRACEABLE-TABLE": lambda obj, elem: setattr(obj, "traceable_table", SerializationHelper.deserialize_by_tag(elem, "any (TraceableTable)")),
@@ -58,6 +63,7 @@ class MsrQueryP1(Paginateable):
         """Initialize MsrQueryP1."""
         super().__init__()
         self.msr_query_props: MsrQueryProps = None
+        self.msr_query_result: Optional[TopicContent] = None
         self.block_level: DocumentationBlock = None
         self.table: Optional[Table] = None
         self.traceable_table: Any = None
@@ -98,6 +104,19 @@ class MsrQueryP1(Paginateable):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize msr_query_result (atp_mixed - append children directly)
+        if self.msr_query_result is not None:
+            serialized = SerializationHelper.serialize_item(self.msr_query_result, "TopicContent")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
 
         # Serialize block_level
         if self.block_level is not None:
@@ -162,6 +181,8 @@ class MsrQueryP1(Paginateable):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "MSR-QUERY-PROPS":
                 setattr(obj, "msr_query_props", SerializationHelper.deserialize_by_tag(child, "MsrQueryProps"))
+            elif tag == "MSR-QUERY-RESULT":
+                setattr(obj, "msr_query_result", SerializationHelper.deserialize_by_tag(child, "TopicContent"))
             elif tag == "BLOCK-LEVEL":
                 setattr(obj, "block_level", SerializationHelper.deserialize_by_tag(child, "DocumentationBlock"))
             elif tag == "TABLE":
@@ -194,6 +215,20 @@ class MsrQueryP1Builder(PaginateableBuilder):
         if value is None and not False:
             raise ValueError("Attribute 'msr_query_props' is required and cannot be None")
         self._obj.msr_query_props = value
+        return self
+
+    def with_msr_query_result(self, value: Optional[TopicContent]) -> "MsrQueryP1Builder":
+        """Set msr_query_result attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'msr_query_result' is required and cannot be None")
+        self._obj.msr_query_result = value
         return self
 
     def with_block_level(self, value: DocumentationBlock) -> "MsrQueryP1Builder":

--- a/tools/generate_models/type_utils.py
+++ b/tools/generate_models/type_utils.py
@@ -620,8 +620,13 @@ def flatten_atp_mixed_attributes(
                 break
 
         if is_atp_mixed_type:
-            # Flatten: add the child attributes instead of the wrapper attribute
-            # But skip duplicates (prefer parent's own attributes)
+            # First, add the wrapper attribute (e.g., sdgContentsType)
+            # This is needed for proper serialization of atp_mixed content
+            if attr_name not in seen_attr_names:
+                result.append(attr)
+                seen_attr_names.add(attr_name)
+            # Then, optionally add child attributes for API convenience
+            # (e.g., sd, sdf, sdg from SdgContents)
             for child_attr in atp_mixed_children:
                 child_attr_name = child_attr.get("name", "")
                 if child_attr_name not in seen_attr_names:

--- a/tools/skip_classes.yaml
+++ b/tools/skip_classes.yaml
@@ -50,8 +50,11 @@ skip_classes:
   # DocumentationBlock requires custom serialization - handles L-1 through L-10 language-specific elements (P paragraphs)
   - "DocumentationBlock"
 
-  # BswModuleClientServerEntry requires custom serialization for REF-CONDITIONAL wrapper pattern
-  - "BswModuleClientServerEntry"
+  # Sdg and SdgContents require custom handling for atp_mixed pattern
+  # where multiple SD/SDF/SDG children serialize directly under parent SDG
+  # The sdgContentsType attribute stores SdgContents, whose children serialize directly
+  - "Sdg"
+  - "SdgContents"
 
 # Force TYPE_CHECKING Imports
 # These types will always be imported inside TYPE_CHECKING blocks to prevent circular imports.


### PR DESCRIPTION
## Summary

Fix code generation to properly handle atp_mixed types by including both wrapper attributes and child attributes for proper serialization.

## Changes

- Modified `flatten_atp_mixed_attributes()` in `tools/generate_models/type_utils.py`:
  - First add the wrapper attribute (e.g., `sdgContentsType`) for proper serialization of atp_mixed content
  - Then add child attributes for API convenience (e.g., sd, sdf, sdg from SdgContents)
- Updated `tools/skip_classes.yaml`:
  - Added `Sdg` and `SdgContents` to manual maintenance (require custom atp_mixed handling)
  - Removed `BswModuleClientServerEntry` from skip list (now auto-generated)
- Regenerated 26 affected model classes

## Files Modified

**Tools:**
- `tools/generate_models/type_utils.py` - Fixed atp_mixed attribute flattening logic
- `tools/skip_classes.yaml` - Updated manual class list

**Generated Models (26 files):**
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_internal_behavior.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswBehavior/bsw_module_entity.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_client_server_entry.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_specification.py`
- `src/armodel2/models/M2/AUTOSARTemplates/EcuResourceTemplate/hw_pin_group.py`
- `src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg.py`
- `src/armodel2/models/M2/MSR/AsamHdo/SpecialData/sdg_contents.py`
- `src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py`
- `src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py`
- `src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/value_group.py`
- `src/armodel2/models/M2/MSR/DataDictionary/RecordLayout/sw_record_layout_group.py`
- `src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py`
- `src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_content.py`
- `src/armodel2/models/M2/MSR/Documentation/Chapters/chapter_model.py`
- `src/armodel2/models/M2/MSR/Documentation/Chapters/topic1.py`
- `src/armodel2/models/M2/MSR/Documentation/Chapters/topic_content_or_msr_query.py`
- `src/armodel2/models/M2/MSR/Documentation/MsrQuery/msr_query_p1.py`
- Plus 6 JSON mapping files in `docs/json/packages/`

## Code Statistics

- 2,044 insertions(+), 4,647 deletions(-)
- Net reduction of ~2,600 lines of code
- Major rewrites in sdg.py (98%), sdg_contents.py (90%), bsw_module_client_server_entry.py (65%)

## Test Coverage

All quality gates passed:
- ✅ Ruff: No issues found in 2,255 source files
- ✅ MyPy: No type errors
- ✅ Pytest: 294 tests passed

## Requirements

N/A (bug fix)

## Impact

This fix ensures proper serialization of atp_mixed content types where child elements serialize directly under parent elements (AUTOSAR atp_mixed pattern), while maintaining API convenience through generated child attributes.

## Related Issue

Closes #219