### PR TITLE
fix: Fix incorrect attributes in AUTOSAR mapping JSON files

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
@@ -68,13 +68,6 @@
           "is_ref": false,
           "note": "Refers to the service identifier of the Standardized AUTOSAR basic software. For it can optionally be used for"
         },
-        "bswEntryKind": {
-          "type": "BswEntryKindEnum",
-          "multiplicity": "0..1",
-          "kind": "attribute",
-          "is_ref": false,
-          "note": "This describes whether the entry is concrete or abstract. attribute is missing the entry is considered as"
-        },
         "isReentrant": {
           "type": "Boolean",
           "multiplicity": "0..1",
@@ -117,6 +110,13 @@
           "is_ref": false,
           "note": "Denotes the implementation policy as a standard function call, inline function or macro. This has to be specified on because it determines the signature of the"
         },
+        "bswEntryKind": {
+          "type": "BswEntryKindEnum",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This describes whether the entry is concrete or abstract. attribute is missing the entry is considered as"
+        },
         "returnType": {
           "type": "SwServiceArg",
           "multiplicity": "0..1",
@@ -142,7 +142,7 @@
     },
     {
       "name": "BswModuleDependency",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::BswModuleTemplate::BswInterfaces",
       "is_abstract": false,
       "atp_type": null,
@@ -188,7 +188,7 @@
     },
     {
       "name": "BswEntryRelationshipSet",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::BswModuleTemplate::BswInterfaces",
       "is_abstract": false,
       "atp_type": null,
@@ -239,7 +239,7 @@
     },
     {
       "name": "BswEntryRelationship",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::BswModuleTemplate::BswInterfaces",
       "is_abstract": false,
       "atp_type": null,
@@ -270,8 +270,8 @@
         }
       ],
       "attributes": {
-        "bswEntry": {
-          "type": "BswEntryRelationship",
+        "bswEntryRelationshipType": {
+          "type": "BswEntryRelationshipEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
           "is_ref": false,
@@ -282,7 +282,7 @@
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
-          "note": "Type of relationship that refers to the abstract BswModule notice that in this case the bswEntry be set to drivedFrom."
+          "note": "Type of relationship that refers to the abstract BswModule notice that in this case the bswEntry be set to drived From."
         },
         "to": {
           "type": "BswModuleEntry",

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
@@ -149,7 +149,6 @@
           "multiplicity": "*",
           "kind": "aggr",
           "is_ref": false,
-          "decorator": "xml_element_name:REQUIRED-ENTRYS",
           "note": "Specifies that this module requires a client server entry which can be implemented on another partition or is declared locally to this context and will to the providedClientServerEntry of another same module via the configuration of the BSW atpVariation"
         },
         "requiredData": {

--- a/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ArObject.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ArObject.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "ARObject",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::GenericStructure::GeneralTemplateClasses::ArObject",
       "is_abstract": true,
       "atp_type": null,
@@ -413,16 +413,17 @@
           "type": "String",
           "multiplicity": "0..1",
           "kind": "attribute",
+          "decorator": "xml_attribute:S",
           "is_ref": false,
-          "note": "Checksum calculated by the user’s tool environment for"
+          "note": "Checksum calculated by the user’s tool environment for ArObject."
         },
         "timestamp": {
           "type": "DateTime",
           "multiplicity": "0..1",
-          "kind": "aggr",
+          "kind": "attribute",
           "decorator": "xml_attribute:T",
           "is_ref": false,
-          "note": "Timestamp calculated by the user’s tool environment for"
+          "note": "Timestamp calculated by the user’s tool environment for ArObject."
         }
       }
     }

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "AutosarParameterRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::DataElements",
       "is_abstract": false,
       "atp_type": null,
@@ -37,10 +37,10 @@
         }
       ],
       "attributes": {
-        "autosar": {
-          "type": "DataPrototype",
+        "autosarParameter": {
+          "type": "ParameterInAtomicSWCTypeInstanceRef",
           "multiplicity": "0..1",
-          "kind": "ref",
+          "kind": "iref",
           "is_ref": true,
           "note": "is either imported via a port or is part of a structure. by: ParameterInAtomicSWC 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
@@ -253,7 +253,7 @@
     },
     {
       "name": "ArVariableInImplementationDataInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::DataElements",
       "is_abstract": false,
       "atp_type": null,
@@ -279,8 +279,8 @@
         }
       ],
       "attributes": {
-        "contextData": {
-          "type": "any (AbstractImplementation)",
+        "contextDataPrototype": {
+          "type": "AbstractImplementationDataTypeElement",
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
@@ -293,15 +293,15 @@
           "is_ref": true,
           "note": "This is the port providing/receiving the root of the variable"
         },
-        "rootVariable": {
+        "rootVariableDataPrototype": {
           "type": "VariableDataPrototype",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
           "note": "This refers to the VariableDataPrototype typed by the in which the target can be found."
         },
-        "targetData": {
-          "type": "any (AbstractImplementation)",
+        "targetDataDataPrototype": {
+          "type": "AbstractImplementationDataTypeElement",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
@@ -311,7 +311,7 @@
     },
     {
       "name": "ArParameterInImplementationDataInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::DataElements",
       "is_abstract": false,
       "atp_type": null,
@@ -336,8 +336,8 @@
         }
       ],
       "attributes": {
-        "contextData": {
-          "type": "any (AbstractImplementation)",
+        "contextDataPrototype": {
+          "type": "AbstractImplementationDataTypeElement",
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
@@ -350,15 +350,15 @@
           "is_ref": true,
           "note": "This reference points to the PortPrototype providing/ root of the parameter."
         },
-        "rootParameter": {
+        "rootParameterDataPrototype": {
           "type": "ParameterDataPrototype",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
           "note": "This refers to the ParameterDataPrototype typed by the implementationDataType in which the target can be"
         },
-        "targetData": {
-          "type": "any (AbstractImplementation)",
+        "targetDataPrototype": {
+          "type": "AbstractImplementationDataTypeElement",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "ParameterInAtomicSWCTypeInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::DataElements::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -37,8 +37,8 @@
           "is_ref": true,
           "note": "Stereotypes: atpDerived xml.sequenceOffset=10"
         },
-        "contextData": {
-          "type": "any (ApplicationComposite)",
+        "contextDataPrototype": {
+          "type": "ApplicationCompositeElementDataPrototype",
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
@@ -51,14 +51,14 @@
           "is_ref": true,
           "note": "This is the port providing the variable or the entry point to structure."
         },
-        "rootParameter": {
+        "rootParameterDataPrototype": {
           "type": "DataPrototype",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
           "note": "This represents the entry point for references into a"
         },
-        "targetData": {
+        "targetDataPrototype": {
           "type": "DataPrototype",
           "multiplicity": "0..1",
           "kind": "ref",

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_entry_relationship.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_entry_relationship.py
@@ -12,6 +12,9 @@ import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+from armodel2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces import (
+    BswEntryRelationshipEnum,
+)
 from armodel2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces.bsw_module_entry import (
     BswModuleEntry,
 )
@@ -34,11 +37,11 @@ class BswEntryRelationship(ARObject):
     _XML_TAG = "BSW-ENTRY-RELATIONSHIP"
 
 
-    bsw_entry: Optional[BswEntryRelationship]
+    bsw_entry_relationship_type: Optional[BswEntryRelationshipEnum]
     from_ref: Optional[ARRef]
     to_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "BSW-ENTRY": lambda obj, elem: setattr(obj, "bsw_entry", SerializationHelper.deserialize_by_tag(elem, "BswEntryRelationship")),
+        "BSW-ENTRY-RELATIONSHIP-TYPE": lambda obj, elem: setattr(obj, "bsw_entry_relationship_type", BswEntryRelationshipEnum.deserialize(elem)),
         "FROM-REF": lambda obj, elem: setattr(obj, "from_ref", ARRef.deserialize(elem)),
         "TO-REF": lambda obj, elem: setattr(obj, "to_ref", ARRef.deserialize(elem)),
     }
@@ -47,7 +50,7 @@ class BswEntryRelationship(ARObject):
     def __init__(self) -> None:
         """Initialize BswEntryRelationship."""
         super().__init__()
-        self.bsw_entry: Optional[BswEntryRelationship] = None
+        self.bsw_entry_relationship_type: Optional[BswEntryRelationshipEnum] = None
         self.from_ref: Optional[ARRef] = None
         self.to_ref: Optional[ARRef] = None
 
@@ -74,12 +77,12 @@ class BswEntryRelationship(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize bsw_entry
-        if self.bsw_entry is not None:
-            serialized = SerializationHelper.serialize_item(self.bsw_entry, "BswEntryRelationship")
+        # Serialize bsw_entry_relationship_type
+        if self.bsw_entry_relationship_type is not None:
+            serialized = SerializationHelper.serialize_item(self.bsw_entry_relationship_type, "BswEntryRelationshipEnum")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("BSW-ENTRY")
+                wrapped = ET.Element("BSW-ENTRY-RELATIONSHIP-TYPE")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -135,8 +138,8 @@ class BswEntryRelationship(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "BSW-ENTRY":
-                setattr(obj, "bsw_entry", SerializationHelper.deserialize_by_tag(child, "BswEntryRelationship"))
+            if tag == "BSW-ENTRY-RELATIONSHIP-TYPE":
+                setattr(obj, "bsw_entry_relationship_type", BswEntryRelationshipEnum.deserialize(child))
             elif tag == "FROM-REF":
                 setattr(obj, "from_ref", ARRef.deserialize(child))
             elif tag == "TO-REF":
@@ -155,8 +158,8 @@ class BswEntryRelationshipBuilder(BuilderBase):
         self._obj: BswEntryRelationship = BswEntryRelationship()
 
 
-    def with_bsw_entry(self, value: Optional[BswEntryRelationship]) -> "BswEntryRelationshipBuilder":
-        """Set bsw_entry attribute.
+    def with_bsw_entry_relationship_type(self, value: Optional[BswEntryRelationshipEnum]) -> "BswEntryRelationshipBuilder":
+        """Set bsw_entry_relationship_type attribute.
 
         Args:
             value: Value to set
@@ -165,8 +168,8 @@ class BswEntryRelationshipBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'bsw_entry' is required and cannot be None")
-        self._obj.bsw_entry = value
+            raise ValueError("Attribute 'bsw_entry_relationship_type' is required and cannot be None")
+        self._obj.bsw_entry_relationship_type = value
         return self
 
     def with_from(self, value: Optional[BswModuleEntry]) -> "BswEntryRelationshipBuilder":
@@ -201,7 +204,7 @@ class BswEntryRelationshipBuilder(BuilderBase):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "bswEntry",
+        "bswEntryRelationshipType",
         "from",
         "to",
     }

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py
@@ -58,25 +58,25 @@ class BswModuleEntry(ARElement):
 
 
     service_id: Optional[PositiveInteger]
-    bsw_entry_kind: Optional[BswEntryKindEnum]
     is_reentrant: Optional[Boolean]
     is_synchronous: Optional[Boolean]
     call_type: Optional[BswCallType]
     execution_context: Optional[BswExecutionContext]
     function_prototype_emitter: Optional[NameToken]
     sw_service_impl_policy: Optional[SwServiceImplPolicyEnum]
+    bsw_entry_kind: Optional[BswEntryKindEnum]
     return_type: Optional[SwServiceArg]
     arguments: list[SwServiceArg]
     role: Optional[Identifier]
     _DESERIALIZE_DISPATCH = {
         "SERVICE-ID": lambda obj, elem: setattr(obj, "service_id", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
-        "BSW-ENTRY-KIND": lambda obj, elem: setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(elem)),
         "IS-REENTRANT": lambda obj, elem: setattr(obj, "is_reentrant", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
         "IS-SYNCHRONOUS": lambda obj, elem: setattr(obj, "is_synchronous", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
         "CALL-TYPE": lambda obj, elem: setattr(obj, "call_type", BswCallType.deserialize(elem)),
         "EXECUTION-CONTEXT": lambda obj, elem: setattr(obj, "execution_context", BswExecutionContext.deserialize(elem)),
         "FUNCTION-PROTOTYPE-EMITTER": lambda obj, elem: setattr(obj, "function_prototype_emitter", SerializationHelper.deserialize_by_tag(elem, "NameToken")),
         "SW-SERVICE-IMPL-POLICY": lambda obj, elem: setattr(obj, "sw_service_impl_policy", SwServiceImplPolicyEnum.deserialize(elem)),
+        "BSW-ENTRY-KIND": lambda obj, elem: setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(elem)),
         "RETURN-TYPE": lambda obj, elem: setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
         "ARGUMENTS": lambda obj, elem: obj.arguments.append(SerializationHelper.deserialize_by_tag(elem, "SwServiceArg")),
         "ROLE": lambda obj, elem: setattr(obj, "role", SerializationHelper.deserialize_by_tag(elem, "Identifier")),
@@ -87,13 +87,13 @@ class BswModuleEntry(ARElement):
         """Initialize BswModuleEntry."""
         super().__init__()
         self.service_id: Optional[PositiveInteger] = None
-        self.bsw_entry_kind: Optional[BswEntryKindEnum] = None
         self.is_reentrant: Optional[Boolean] = None
         self.is_synchronous: Optional[Boolean] = None
         self.call_type: Optional[BswCallType] = None
         self.execution_context: Optional[BswExecutionContext] = None
         self.function_prototype_emitter: Optional[NameToken] = None
         self.sw_service_impl_policy: Optional[SwServiceImplPolicyEnum] = None
+        self.bsw_entry_kind: Optional[BswEntryKindEnum] = None
         self.return_type: Optional[SwServiceArg] = None
         self.arguments: list[SwServiceArg] = []
         self.role: Optional[Identifier] = None
@@ -127,20 +127,6 @@ class BswModuleEntry(ARElement):
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("SERVICE-ID")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
-
-        # Serialize bsw_entry_kind
-        if self.bsw_entry_kind is not None:
-            serialized = SerializationHelper.serialize_item(self.bsw_entry_kind, "BswEntryKindEnum")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("BSW-ENTRY-KIND")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -233,6 +219,20 @@ class BswModuleEntry(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize bsw_entry_kind
+        if self.bsw_entry_kind is not None:
+            serialized = SerializationHelper.serialize_item(self.bsw_entry_kind, "BswEntryKindEnum")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("BSW-ENTRY-KIND")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
         # Serialize return_type
         if self.return_type is not None:
             serialized = SerializationHelper.serialize_item(self.return_type, "SwServiceArg")
@@ -292,8 +292,6 @@ class BswModuleEntry(ARElement):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "SERVICE-ID":
                 setattr(obj, "service_id", SerializationHelper.deserialize_by_tag(child, "PositiveInteger"))
-            elif tag == "BSW-ENTRY-KIND":
-                setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(child))
             elif tag == "IS-REENTRANT":
                 setattr(obj, "is_reentrant", SerializationHelper.deserialize_by_tag(child, "Boolean"))
             elif tag == "IS-SYNCHRONOUS":
@@ -306,6 +304,8 @@ class BswModuleEntry(ARElement):
                 setattr(obj, "function_prototype_emitter", SerializationHelper.deserialize_by_tag(child, "NameToken"))
             elif tag == "SW-SERVICE-IMPL-POLICY":
                 setattr(obj, "sw_service_impl_policy", SwServiceImplPolicyEnum.deserialize(child))
+            elif tag == "BSW-ENTRY-KIND":
+                setattr(obj, "bsw_entry_kind", BswEntryKindEnum.deserialize(child))
             elif tag == "RETURN-TYPE":
                 setattr(obj, "return_type", SerializationHelper.deserialize_by_tag(child, "SwServiceArg"))
             elif tag == "ARGUMENTS":
@@ -340,20 +340,6 @@ class BswModuleEntryBuilder(ARElementBuilder):
         if value is None and not True:
             raise ValueError("Attribute 'service_id' is required and cannot be None")
         self._obj.service_id = value
-        return self
-
-    def with_bsw_entry_kind(self, value: Optional[BswEntryKindEnum]) -> "BswModuleEntryBuilder":
-        """Set bsw_entry_kind attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not True:
-            raise ValueError("Attribute 'bsw_entry_kind' is required and cannot be None")
-        self._obj.bsw_entry_kind = value
         return self
 
     def with_is_reentrant(self, value: Optional[Boolean]) -> "BswModuleEntryBuilder":
@@ -438,6 +424,20 @@ class BswModuleEntryBuilder(ARElementBuilder):
         if value is None and not True:
             raise ValueError("Attribute 'sw_service_impl_policy' is required and cannot be None")
         self._obj.sw_service_impl_policy = value
+        return self
+
+    def with_bsw_entry_kind(self, value: Optional[BswEntryKindEnum]) -> "BswModuleEntryBuilder":
+        """Set bsw_entry_kind attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'bsw_entry_kind' is required and cannot be None")
+        self._obj.bsw_entry_kind = value
         return self
 
     def with_return_type(self, value: Optional[SwServiceArg]) -> "BswModuleEntryBuilder":

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
@@ -13,7 +13,6 @@ JSON Source: docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOvervie
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
-from armodel2.serialization.decorators import xml_element_name
 from armodel2.serialization.decorators import ref_conditional
 
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ARPackage.ar_element import (
@@ -81,7 +80,7 @@ class BswModuleDescription(ARElement):
     provided_datas: list[VariableDataPrototype]
     provided_mode_groups: list[ModeDeclarationGroupPrototype]
     released_triggers: list[Trigger]
-    _required_client_server_entries: list[BswModuleClientServerEntry]
+    required_client_server_entries: list[BswModuleClientServerEntry]
     required_datas: list[VariableDataPrototype]
     required_mode_groups: list[ModeDeclarationGroupPrototype]
     required_triggers: list[Trigger]
@@ -97,7 +96,7 @@ class BswModuleDescription(ARElement):
         "PROVIDED-DATAS": lambda obj, elem: obj.provided_datas.append(SerializationHelper.deserialize_by_tag(elem, "VariableDataPrototype")),
         "PROVIDED-MODE-GROUPS": lambda obj, elem: obj.provided_mode_groups.append(SerializationHelper.deserialize_by_tag(elem, "ModeDeclarationGroupPrototype")),
         "RELEASED-TRIGGERS": lambda obj, elem: obj.released_triggers.append(SerializationHelper.deserialize_by_tag(elem, "Trigger")),
-        "REQUIRED-ENTRYS": lambda obj, elem: obj._required_client_server_entries.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleClientServerEntry")),
+        "REQUIRED-CLIENT-SERVER-ENTRYS": lambda obj, elem: obj.required_client_server_entries.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleClientServerEntry")),
         "REQUIRED-DATAS": lambda obj, elem: obj.required_datas.append(SerializationHelper.deserialize_by_tag(elem, "VariableDataPrototype")),
         "REQUIRED-MODE-GROUPS": lambda obj, elem: obj.required_mode_groups.append(SerializationHelper.deserialize_by_tag(elem, "ModeDeclarationGroupPrototype")),
         "REQUIRED-TRIGGERS": lambda obj, elem: obj.required_triggers.append(SerializationHelper.deserialize_by_tag(elem, "Trigger")),
@@ -118,7 +117,7 @@ class BswModuleDescription(ARElement):
         self.provided_datas: list[VariableDataPrototype] = []
         self.provided_mode_groups: list[ModeDeclarationGroupPrototype] = []
         self.released_triggers: list[Trigger] = []
-        self._required_client_server_entries: list[BswModuleClientServerEntry] = []
+        self.required_client_server_entries: list[BswModuleClientServerEntry] = []
         self.required_datas: list[VariableDataPrototype] = []
         self.required_mode_groups: list[ModeDeclarationGroupPrototype] = []
         self.required_triggers: list[Trigger] = []
@@ -133,17 +132,6 @@ class BswModuleDescription(ARElement):
     def provided_entry_refs(self, value: list[ARRef]) -> None:
         """Set provided_entry_refs with ref_conditional wrapper."""
         self._provided_entry_refs = value
-
-    @property
-    @xml_element_name("REQUIRED-ENTRYS")
-    def required_client_server_entries(self) -> list[BswModuleClientServerEntry]:
-        """Get required_client_server_entries with custom XML element name."""
-        return self._required_client_server_entries
-
-    @required_client_server_entries.setter
-    def required_client_server_entries(self, value: list[BswModuleClientServerEntry]) -> None:
-        """Set required_client_server_entries with custom XML element name."""
-        self._required_client_server_entries = value
 
 
     def serialize(self) -> ET.Element:
@@ -301,9 +289,9 @@ class BswModuleDescription(ARElement):
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize required_client_server_entries (list to container "REQUIRED-ENTRYS")
+        # Serialize required_client_server_entries (list to container "REQUIRED-CLIENT-SERVER-ENTRYS")
         if self.required_client_server_entries:
-            wrapper = ET.Element("REQUIRED-ENTRYS")
+            wrapper = ET.Element("REQUIRED-CLIENT-SERVER-ENTRYS")
             for item in self.required_client_server_entries:
                 serialized = SerializationHelper.serialize_item(item, "BswModuleClientServerEntry")
                 if serialized is not None:
@@ -409,10 +397,10 @@ class BswModuleDescription(ARElement):
                 # Iterate through wrapper children
                 for item_elem in child:
                     obj.released_triggers.append(SerializationHelper.deserialize_by_tag(item_elem, "Trigger"))
-            elif tag == "REQUIRED-ENTRYS":
+            elif tag == "REQUIRED-CLIENT-SERVER-ENTRYS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj._required_client_server_entries.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleClientServerEntry"))
+                    obj.required_client_server_entries.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleClientServerEntry"))
             elif tag == "REQUIRED-DATAS":
                 # Iterate through wrapper children
                 for item_elem in child:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/parameter_in_atomic_swc_type_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/InstanceRefs/parameter_in_atomic_swc_type_instance_ref.py
@@ -6,24 +6,30 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.atomic_sw_component_type import (
-    AtomicSwComponentType,
-)
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.data_prototype import (
-    DataPrototype,
-)
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.port_prototype import (
-    PortPrototype,
-)
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.application_composite_element_data_prototype import (
+        ApplicationCompositeElementDataPrototype,
+    )
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.atomic_sw_component_type import (
+        AtomicSwComponentType,
+    )
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.data_prototype import (
+        DataPrototype,
+    )
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.port_prototype import (
+        PortPrototype,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class ParameterInAtomicSWCTypeInstanceRef(ARObject):
     """AUTOSAR ParameterInAtomicSWCTypeInstanceRef."""
 
@@ -40,16 +46,16 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
 
 
     base_ref: Optional[ARRef]
-    context_data_refs: list[Any]
+    context_data_prototype_refs: list[ARRef]
     port_prototype_ref: Optional[ARRef]
-    root_parameter_ref: Optional[ARRef]
-    target_data_ref: Optional[ARRef]
+    root_parameter_data_prototype_ref: Optional[ARRef]
+    target_data_prototype_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "BASE-REF": ("_POLYMORPHIC", "base_ref", ["ApplicationSwComponentType", "ComplexDeviceDriverSwComponentType", "EcuAbstractionSwComponentType", "NvBlockSwComponentType", "SensorActuatorSwComponentType", "ServiceProxySwComponentType", "ServiceSwComponentType"]),
-        "CONTEXT-DATA-REFS": lambda obj, elem: [obj.context_data_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "CONTEXT-DATA-PROTOTYPE-REFS": ("_POLYMORPHIC_LIST", "context_data_prototype_refs", ["ApplicationArrayElement", "ApplicationRecordElement"]),
         "PORT-PROTOTYPE-REF": ("_POLYMORPHIC", "port_prototype_ref", ["AbstractProvidedPortPrototype", "AbstractRequiredPortPrototype", "PPortPrototype", "PRPortPrototype", "RPortPrototype"]),
-        "ROOT-PARAMETER-REF": ("_POLYMORPHIC", "root_parameter_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
-        "TARGET-DATA-REF": ("_POLYMORPHIC", "target_data_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
+        "ROOT-PARAMETER-DATA-PROTOTYPE-REF": ("_POLYMORPHIC", "root_parameter_data_prototype_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
+        "TARGET-DATA-PROTOTYPE-REF": ("_POLYMORPHIC", "target_data_prototype_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
     }
 
 
@@ -57,10 +63,10 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
         """Initialize ParameterInAtomicSWCTypeInstanceRef."""
         super().__init__()
         self.base_ref: Optional[ARRef] = None
-        self.context_data_refs: list[Any] = []
+        self.context_data_prototype_refs: list[ARRef] = []
         self.port_prototype_ref: Optional[ARRef] = None
-        self.root_parameter_ref: Optional[ARRef] = None
-        self.target_data_ref: Optional[ARRef] = None
+        self.root_parameter_data_prototype_ref: Optional[ARRef] = None
+        self.target_data_prototype_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ParameterInAtomicSWCTypeInstanceRef to XML element.
@@ -99,13 +105,13 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize context_data_refs (list to container "CONTEXT-DATA-REFS")
-        if self.context_data_refs:
-            wrapper = ET.Element("CONTEXT-DATA-REFS")
-            for item in self.context_data_refs:
-                serialized = SerializationHelper.serialize_item(item, "Any")
+        # Serialize context_data_prototype_refs (list to container "CONTEXT-DATA-PROTOTYPE-REFS")
+        if self.context_data_prototype_refs:
+            wrapper = ET.Element("CONTEXT-DATA-PROTOTYPE-REFS")
+            for item in self.context_data_prototype_refs:
+                serialized = SerializationHelper.serialize_item(item, "ApplicationCompositeElementDataPrototype")
                 if serialized is not None:
-                    child_elem = ET.Element("CONTEXT-DATA-REF")
+                    child_elem = ET.Element("CONTEXT-DATA-PROTOTYPE-REF")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -130,12 +136,12 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize root_parameter_ref
-        if self.root_parameter_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.root_parameter_ref, "DataPrototype")
+        # Serialize root_parameter_data_prototype_ref
+        if self.root_parameter_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.root_parameter_data_prototype_ref, "DataPrototype")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ROOT-PARAMETER-REF")
+                wrapped = ET.Element("ROOT-PARAMETER-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -144,12 +150,12 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize target_data_ref
-        if self.target_data_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.target_data_ref, "DataPrototype")
+        # Serialize target_data_prototype_ref
+        if self.target_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.target_data_prototype_ref, "DataPrototype")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TARGET-DATA-REF")
+                wrapped = ET.Element("TARGET-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -179,16 +185,15 @@ class ParameterInAtomicSWCTypeInstanceRef(ARObject):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "BASE-REF":
                 setattr(obj, "base_ref", ARRef.deserialize(child))
-            elif tag == "CONTEXT-DATA-REFS":
-                # Iterate through wrapper children
+            elif tag == "CONTEXT-DATA-PROTOTYPE-REFS":
                 for item_elem in child:
-                    obj.context_data_refs.append(ARRef.deserialize(item_elem))
+                    obj.context_data_prototype_refs.append(ARRef.deserialize(item_elem))
             elif tag == "PORT-PROTOTYPE-REF":
                 setattr(obj, "port_prototype_ref", ARRef.deserialize(child))
-            elif tag == "ROOT-PARAMETER-REF":
-                setattr(obj, "root_parameter_ref", ARRef.deserialize(child))
-            elif tag == "TARGET-DATA-REF":
-                setattr(obj, "target_data_ref", ARRef.deserialize(child))
+            elif tag == "ROOT-PARAMETER-DATA-PROTOTYPE-REF":
+                setattr(obj, "root_parameter_data_prototype_ref", ARRef.deserialize(child))
+            elif tag == "TARGET-DATA-PROTOTYPE-REF":
+                setattr(obj, "target_data_prototype_ref", ARRef.deserialize(child))
 
         return obj
 
@@ -217,8 +222,8 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
         self._obj.base = value
         return self
 
-    def with_context_datas(self, items: list[Any]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
-        """Set context_datas list attribute.
+    def with_context_data_prototypes(self, items: list[ApplicationCompositeElementDataPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
+        """Set context_data_prototypes list attribute.
 
         Args:
             items: List of items to set
@@ -226,7 +231,7 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = list(items) if items else []
+        self._obj.context_data_prototypes = list(items) if items else []
         return self
 
     def with_port_prototype(self, value: Optional[PortPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
@@ -243,8 +248,8 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
         self._obj.port_prototype = value
         return self
 
-    def with_root_parameter(self, value: Optional[DataPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
-        """Set root_parameter attribute.
+    def with_root_parameter_data_prototype(self, value: Optional[DataPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
+        """Set root_parameter_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -253,12 +258,12 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'root_parameter' is required and cannot be None")
-        self._obj.root_parameter = value
+            raise ValueError("Attribute 'root_parameter_data_prototype' is required and cannot be None")
+        self._obj.root_parameter_data_prototype = value
         return self
 
-    def with_target_data(self, value: Optional[DataPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
-        """Set target_data attribute.
+    def with_target_data_prototype(self, value: Optional[DataPrototype]) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
+        """Set target_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -267,13 +272,13 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'target_data' is required and cannot be None")
-        self._obj.target_data = value
+            raise ValueError("Attribute 'target_data_prototype' is required and cannot be None")
+        self._obj.target_data_prototype = value
         return self
 
 
-    def add_context_data(self, item: Any) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
-        """Add a single item to context_datas list.
+    def add_context_data_prototype(self, item: ApplicationCompositeElementDataPrototype) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
+        """Add a single item to context_data_prototypes list.
 
         Args:
             item: Item to add
@@ -281,26 +286,26 @@ class ParameterInAtomicSWCTypeInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas.append(item)
+        self._obj.context_data_prototypes.append(item)
         return self
 
-    def clear_context_datas(self) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
-        """Clear all items from context_datas list.
+    def clear_context_data_prototypes(self) -> "ParameterInAtomicSWCTypeInstanceRefBuilder":
+        """Clear all items from context_data_prototypes list.
 
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = []
+        self._obj.context_data_prototypes = []
         return self
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
         "base",
-        "contextData",
+        "contextDataPrototype",
         "portPrototype",
-        "rootParameter",
-        "targetData",
+        "rootParameterDataPrototype",
+        "targetDataPrototype",
     }
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_parameter_in_implementation_data_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_parameter_in_implementation_data_instance_ref.py
@@ -6,11 +6,14 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes.abstract_implementation_data_type_element import (
+    AbstractImplementationDataTypeElement,
+)
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.parameter_data_prototype import (
     ParameterDataPrototype,
 )
@@ -36,25 +39,25 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
     _XML_TAG = "AR-PARAMETER-IN-IMPLEMENTATION-DATA-INSTANCE-REF"
 
 
-    context_data_refs: list[Any]
+    context_data_prototype_refs: list[ARRef]
     port_prototype_ref: Optional[ARRef]
-    root_parameter_ref: Optional[ARRef]
-    target_data_ref: Optional[Any]
+    root_parameter_data_prototype_ref: Optional[ARRef]
+    target_data_prototype_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "CONTEXT-DATA-REFS": lambda obj, elem: [obj.context_data_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "CONTEXT-DATA-PROTOTYPE-REFS": ("_POLYMORPHIC_LIST", "context_data_prototype_refs", ["ImplementationDataTypeElement"]),
         "PORT-PROTOTYPE-REF": ("_POLYMORPHIC", "port_prototype_ref", ["AbstractProvidedPortPrototype", "AbstractRequiredPortPrototype", "PPortPrototype", "PRPortPrototype", "RPortPrototype"]),
-        "ROOT-PARAMETER-REF": lambda obj, elem: setattr(obj, "root_parameter_ref", ARRef.deserialize(elem)),
-        "TARGET-DATA-REF": lambda obj, elem: setattr(obj, "target_data_ref", ARRef.deserialize(elem)),
+        "ROOT-PARAMETER-DATA-PROTOTYPE-REF": lambda obj, elem: setattr(obj, "root_parameter_data_prototype_ref", ARRef.deserialize(elem)),
+        "TARGET-DATA-PROTOTYPE-REF": ("_POLYMORPHIC", "target_data_prototype_ref", ["ImplementationDataTypeElement"]),
     }
 
 
     def __init__(self) -> None:
         """Initialize ArParameterInImplementationDataInstanceRef."""
         super().__init__()
-        self.context_data_refs: list[Any] = []
+        self.context_data_prototype_refs: list[ARRef] = []
         self.port_prototype_ref: Optional[ARRef] = None
-        self.root_parameter_ref: Optional[ARRef] = None
-        self.target_data_ref: Optional[Any] = None
+        self.root_parameter_data_prototype_ref: Optional[ARRef] = None
+        self.target_data_prototype_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ArParameterInImplementationDataInstanceRef to XML element.
@@ -79,13 +82,13 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize context_data_refs (list to container "CONTEXT-DATA-REFS")
-        if self.context_data_refs:
-            wrapper = ET.Element("CONTEXT-DATA-REFS")
-            for item in self.context_data_refs:
-                serialized = SerializationHelper.serialize_item(item, "Any")
+        # Serialize context_data_prototype_refs (list to container "CONTEXT-DATA-PROTOTYPE-REFS")
+        if self.context_data_prototype_refs:
+            wrapper = ET.Element("CONTEXT-DATA-PROTOTYPE-REFS")
+            for item in self.context_data_prototype_refs:
+                serialized = SerializationHelper.serialize_item(item, "AbstractImplementationDataTypeElement")
                 if serialized is not None:
-                    child_elem = ET.Element("CONTEXT-DATA-REF")
+                    child_elem = ET.Element("CONTEXT-DATA-PROTOTYPE-REF")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -110,12 +113,12 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize root_parameter_ref
-        if self.root_parameter_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.root_parameter_ref, "ParameterDataPrototype")
+        # Serialize root_parameter_data_prototype_ref
+        if self.root_parameter_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.root_parameter_data_prototype_ref, "ParameterDataPrototype")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ROOT-PARAMETER-REF")
+                wrapped = ET.Element("ROOT-PARAMETER-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -124,12 +127,12 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize target_data_ref
-        if self.target_data_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.target_data_ref, "Any")
+        # Serialize target_data_prototype_ref
+        if self.target_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.target_data_prototype_ref, "AbstractImplementationDataTypeElement")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TARGET-DATA-REF")
+                wrapped = ET.Element("TARGET-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -157,16 +160,15 @@ class ArParameterInImplementationDataInstanceRef(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "CONTEXT-DATA-REFS":
-                # Iterate through wrapper children
+            if tag == "CONTEXT-DATA-PROTOTYPE-REFS":
                 for item_elem in child:
-                    obj.context_data_refs.append(ARRef.deserialize(item_elem))
+                    obj.context_data_prototype_refs.append(ARRef.deserialize(item_elem))
             elif tag == "PORT-PROTOTYPE-REF":
                 setattr(obj, "port_prototype_ref", ARRef.deserialize(child))
-            elif tag == "ROOT-PARAMETER-REF":
-                setattr(obj, "root_parameter_ref", ARRef.deserialize(child))
-            elif tag == "TARGET-DATA-REF":
-                setattr(obj, "target_data_ref", ARRef.deserialize(child))
+            elif tag == "ROOT-PARAMETER-DATA-PROTOTYPE-REF":
+                setattr(obj, "root_parameter_data_prototype_ref", ARRef.deserialize(child))
+            elif tag == "TARGET-DATA-PROTOTYPE-REF":
+                setattr(obj, "target_data_prototype_ref", ARRef.deserialize(child))
 
         return obj
 
@@ -181,8 +183,8 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
         self._obj: ArParameterInImplementationDataInstanceRef = ArParameterInImplementationDataInstanceRef()
 
 
-    def with_context_datas(self, items: list[Any]) -> "ArParameterInImplementationDataInstanceRefBuilder":
-        """Set context_datas list attribute.
+    def with_context_data_prototypes(self, items: list[AbstractImplementationDataTypeElement]) -> "ArParameterInImplementationDataInstanceRefBuilder":
+        """Set context_data_prototypes list attribute.
 
         Args:
             items: List of items to set
@@ -190,7 +192,7 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = list(items) if items else []
+        self._obj.context_data_prototypes = list(items) if items else []
         return self
 
     def with_port_prototype(self, value: Optional[PortPrototype]) -> "ArParameterInImplementationDataInstanceRefBuilder":
@@ -207,8 +209,8 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
         self._obj.port_prototype = value
         return self
 
-    def with_root_parameter(self, value: Optional[ParameterDataPrototype]) -> "ArParameterInImplementationDataInstanceRefBuilder":
-        """Set root_parameter attribute.
+    def with_root_parameter_data_prototype(self, value: Optional[ParameterDataPrototype]) -> "ArParameterInImplementationDataInstanceRefBuilder":
+        """Set root_parameter_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -217,12 +219,12 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'root_parameter' is required and cannot be None")
-        self._obj.root_parameter = value
+            raise ValueError("Attribute 'root_parameter_data_prototype' is required and cannot be None")
+        self._obj.root_parameter_data_prototype = value
         return self
 
-    def with_target_data(self, value: Optional[Any]) -> "ArParameterInImplementationDataInstanceRefBuilder":
-        """Set target_data attribute.
+    def with_target_data_prototype(self, value: Optional[AbstractImplementationDataTypeElement]) -> "ArParameterInImplementationDataInstanceRefBuilder":
+        """Set target_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -231,13 +233,13 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'target_data' is required and cannot be None")
-        self._obj.target_data = value
+            raise ValueError("Attribute 'target_data_prototype' is required and cannot be None")
+        self._obj.target_data_prototype = value
         return self
 
 
-    def add_context_data(self, item: Any) -> "ArParameterInImplementationDataInstanceRefBuilder":
-        """Add a single item to context_datas list.
+    def add_context_data_prototype(self, item: AbstractImplementationDataTypeElement) -> "ArParameterInImplementationDataInstanceRefBuilder":
+        """Add a single item to context_data_prototypes list.
 
         Args:
             item: Item to add
@@ -245,25 +247,25 @@ class ArParameterInImplementationDataInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas.append(item)
+        self._obj.context_data_prototypes.append(item)
         return self
 
-    def clear_context_datas(self) -> "ArParameterInImplementationDataInstanceRefBuilder":
-        """Clear all items from context_datas list.
+    def clear_context_data_prototypes(self) -> "ArParameterInImplementationDataInstanceRefBuilder":
+        """Clear all items from context_data_prototypes list.
 
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = []
+        self._obj.context_data_prototypes = []
         return self
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "contextData",
+        "contextDataPrototype",
         "portPrototype",
-        "rootParameter",
-        "targetData",
+        "rootParameterDataPrototype",
+        "targetDataPrototype",
     }
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_variable_in_implementation_data_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_variable_in_implementation_data_instance_ref.py
@@ -6,11 +6,14 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes.abstract_implementation_data_type_element import (
+    AbstractImplementationDataTypeElement,
+)
 
 if TYPE_CHECKING:
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.port_prototype import (
@@ -39,25 +42,25 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
     _XML_TAG = "AR-VARIABLE-IN-IMPLEMENTATION-DATA-INSTANCE-REF"
 
 
-    context_data_refs: list[Any]
+    context_data_prototype_refs: list[ARRef]
     port_prototype_ref: Optional[ARRef]
-    root_variable_ref: Optional[ARRef]
-    target_data_ref: Optional[Any]
+    root_variable_data_prototype_ref: Optional[ARRef]
+    target_data_data_prototype_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "CONTEXT-DATA-REFS": lambda obj, elem: [obj.context_data_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "CONTEXT-DATA-PROTOTYPE-REFS": ("_POLYMORPHIC_LIST", "context_data_prototype_refs", ["ImplementationDataTypeElement"]),
         "PORT-PROTOTYPE-REF": ("_POLYMORPHIC", "port_prototype_ref", ["AbstractProvidedPortPrototype", "AbstractRequiredPortPrototype", "PPortPrototype", "PRPortPrototype", "RPortPrototype"]),
-        "ROOT-VARIABLE-REF": lambda obj, elem: setattr(obj, "root_variable_ref", ARRef.deserialize(elem)),
-        "TARGET-DATA-REF": lambda obj, elem: setattr(obj, "target_data_ref", ARRef.deserialize(elem)),
+        "ROOT-VARIABLE-DATA-PROTOTYPE-REF": lambda obj, elem: setattr(obj, "root_variable_data_prototype_ref", ARRef.deserialize(elem)),
+        "TARGET-DATA-DATA-PROTOTYPE-REF": ("_POLYMORPHIC", "target_data_data_prototype_ref", ["ImplementationDataTypeElement"]),
     }
 
 
     def __init__(self) -> None:
         """Initialize ArVariableInImplementationDataInstanceRef."""
         super().__init__()
-        self.context_data_refs: list[Any] = []
+        self.context_data_prototype_refs: list[ARRef] = []
         self.port_prototype_ref: Optional[ARRef] = None
-        self.root_variable_ref: Optional[ARRef] = None
-        self.target_data_ref: Optional[Any] = None
+        self.root_variable_data_prototype_ref: Optional[ARRef] = None
+        self.target_data_data_prototype_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ArVariableInImplementationDataInstanceRef to XML element.
@@ -82,13 +85,13 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize context_data_refs (list to container "CONTEXT-DATA-REFS")
-        if self.context_data_refs:
-            wrapper = ET.Element("CONTEXT-DATA-REFS")
-            for item in self.context_data_refs:
-                serialized = SerializationHelper.serialize_item(item, "Any")
+        # Serialize context_data_prototype_refs (list to container "CONTEXT-DATA-PROTOTYPE-REFS")
+        if self.context_data_prototype_refs:
+            wrapper = ET.Element("CONTEXT-DATA-PROTOTYPE-REFS")
+            for item in self.context_data_prototype_refs:
+                serialized = SerializationHelper.serialize_item(item, "AbstractImplementationDataTypeElement")
                 if serialized is not None:
-                    child_elem = ET.Element("CONTEXT-DATA-REF")
+                    child_elem = ET.Element("CONTEXT-DATA-PROTOTYPE-REF")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -113,12 +116,12 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize root_variable_ref
-        if self.root_variable_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.root_variable_ref, "VariableDataPrototype")
+        # Serialize root_variable_data_prototype_ref
+        if self.root_variable_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.root_variable_data_prototype_ref, "VariableDataPrototype")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ROOT-VARIABLE-REF")
+                wrapped = ET.Element("ROOT-VARIABLE-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -127,12 +130,12 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize target_data_ref
-        if self.target_data_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.target_data_ref, "Any")
+        # Serialize target_data_data_prototype_ref
+        if self.target_data_data_prototype_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.target_data_data_prototype_ref, "AbstractImplementationDataTypeElement")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TARGET-DATA-REF")
+                wrapped = ET.Element("TARGET-DATA-DATA-PROTOTYPE-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -160,16 +163,15 @@ class ArVariableInImplementationDataInstanceRef(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "CONTEXT-DATA-REFS":
-                # Iterate through wrapper children
+            if tag == "CONTEXT-DATA-PROTOTYPE-REFS":
                 for item_elem in child:
-                    obj.context_data_refs.append(ARRef.deserialize(item_elem))
+                    obj.context_data_prototype_refs.append(ARRef.deserialize(item_elem))
             elif tag == "PORT-PROTOTYPE-REF":
                 setattr(obj, "port_prototype_ref", ARRef.deserialize(child))
-            elif tag == "ROOT-VARIABLE-REF":
-                setattr(obj, "root_variable_ref", ARRef.deserialize(child))
-            elif tag == "TARGET-DATA-REF":
-                setattr(obj, "target_data_ref", ARRef.deserialize(child))
+            elif tag == "ROOT-VARIABLE-DATA-PROTOTYPE-REF":
+                setattr(obj, "root_variable_data_prototype_ref", ARRef.deserialize(child))
+            elif tag == "TARGET-DATA-DATA-PROTOTYPE-REF":
+                setattr(obj, "target_data_data_prototype_ref", ARRef.deserialize(child))
 
         return obj
 
@@ -184,8 +186,8 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
         self._obj: ArVariableInImplementationDataInstanceRef = ArVariableInImplementationDataInstanceRef()
 
 
-    def with_context_datas(self, items: list[Any]) -> "ArVariableInImplementationDataInstanceRefBuilder":
-        """Set context_datas list attribute.
+    def with_context_data_prototypes(self, items: list[AbstractImplementationDataTypeElement]) -> "ArVariableInImplementationDataInstanceRefBuilder":
+        """Set context_data_prototypes list attribute.
 
         Args:
             items: List of items to set
@@ -193,7 +195,7 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = list(items) if items else []
+        self._obj.context_data_prototypes = list(items) if items else []
         return self
 
     def with_port_prototype(self, value: Optional[PortPrototype]) -> "ArVariableInImplementationDataInstanceRefBuilder":
@@ -210,8 +212,8 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
         self._obj.port_prototype = value
         return self
 
-    def with_root_variable(self, value: Optional[VariableDataPrototype]) -> "ArVariableInImplementationDataInstanceRefBuilder":
-        """Set root_variable attribute.
+    def with_root_variable_data_prototype(self, value: Optional[VariableDataPrototype]) -> "ArVariableInImplementationDataInstanceRefBuilder":
+        """Set root_variable_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -220,12 +222,12 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'root_variable' is required and cannot be None")
-        self._obj.root_variable = value
+            raise ValueError("Attribute 'root_variable_data_prototype' is required and cannot be None")
+        self._obj.root_variable_data_prototype = value
         return self
 
-    def with_target_data(self, value: Optional[Any]) -> "ArVariableInImplementationDataInstanceRefBuilder":
-        """Set target_data attribute.
+    def with_target_data_data_prototype(self, value: Optional[AbstractImplementationDataTypeElement]) -> "ArVariableInImplementationDataInstanceRefBuilder":
+        """Set target_data_data_prototype attribute.
 
         Args:
             value: Value to set
@@ -234,13 +236,13 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'target_data' is required and cannot be None")
-        self._obj.target_data = value
+            raise ValueError("Attribute 'target_data_data_prototype' is required and cannot be None")
+        self._obj.target_data_data_prototype = value
         return self
 
 
-    def add_context_data(self, item: Any) -> "ArVariableInImplementationDataInstanceRefBuilder":
-        """Add a single item to context_datas list.
+    def add_context_data_prototype(self, item: AbstractImplementationDataTypeElement) -> "ArVariableInImplementationDataInstanceRefBuilder":
+        """Add a single item to context_data_prototypes list.
 
         Args:
             item: Item to add
@@ -248,25 +250,25 @@ class ArVariableInImplementationDataInstanceRefBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.context_datas.append(item)
+        self._obj.context_data_prototypes.append(item)
         return self
 
-    def clear_context_datas(self) -> "ArVariableInImplementationDataInstanceRefBuilder":
-        """Clear all items from context_datas list.
+    def clear_context_data_prototypes(self) -> "ArVariableInImplementationDataInstanceRefBuilder":
+        """Clear all items from context_data_prototypes list.
 
         Returns:
             self for method chaining
         """
-        self._obj.context_datas = []
+        self._obj.context_data_prototypes = []
         return self
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "contextData",
+        "contextDataPrototype",
         "portPrototype",
-        "rootVariable",
-        "targetData",
+        "rootVariableDataPrototype",
+        "targetDataDataPrototype",
     }
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/autosar_parameter_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/autosar_parameter_ref.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.data_prototype import (
         DataPrototype,
     )
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements.InstanceRefs.parameter_in_atomic_swc_type_instance_ref import (
+        ParameterInAtomicSWCTypeInstanceRef,
+    )
 
 
 
@@ -37,10 +40,10 @@ class AutosarParameterRef(ARObject):
     _XML_TAG = "AUTOSAR-PARAMETER-REF"
 
 
-    autosar_ref: Optional[ARRef]
+    autosar_parameter_iref: Optional[ParameterInAtomicSWCTypeInstanceRef]
     local_parameter_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "AUTOSAR-REF": ("_POLYMORPHIC", "autosar_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
+        "AUTOSAR-PARAMETER-IREF": lambda obj, elem: setattr(obj, "autosar_parameter_iref", SerializationHelper.deserialize_by_tag(elem, "ParameterInAtomicSWCTypeInstanceRef")),
         "LOCAL-PARAMETER-REF": ("_POLYMORPHIC", "local_parameter_ref", ["ApplicationArrayElement", "ApplicationCompositeElementDataPrototype", "ApplicationRecordElement", "ArgumentDataPrototype", "AutosarDataPrototype", "ParameterDataPrototype", "VariableDataPrototype"]),
     }
 
@@ -48,7 +51,7 @@ class AutosarParameterRef(ARObject):
     def __init__(self) -> None:
         """Initialize AutosarParameterRef."""
         super().__init__()
-        self.autosar_ref: Optional[ARRef] = None
+        self.autosar_parameter_iref: Optional[ParameterInAtomicSWCTypeInstanceRef] = None
         self.local_parameter_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
@@ -74,19 +77,16 @@ class AutosarParameterRef(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize autosar_ref
-        if self.autosar_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.autosar_ref, "DataPrototype")
+        # Serialize autosar_parameter_iref (instance reference with wrapper "AUTOSAR-PARAMETER-IREF")
+        if self.autosar_parameter_iref is not None:
+            serialized = SerializationHelper.serialize_item(self.autosar_parameter_iref, "ParameterInAtomicSWCTypeInstanceRef")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("AUTOSAR-REF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("AUTOSAR-PARAMETER-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
         # Serialize local_parameter_ref
         if self.local_parameter_ref is not None:
@@ -121,8 +121,8 @@ class AutosarParameterRef(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "AUTOSAR-REF":
-                setattr(obj, "autosar_ref", ARRef.deserialize(child))
+            if tag == "AUTOSAR-PARAMETER-IREF":
+                setattr(obj, "autosar_parameter_iref", SerializationHelper.deserialize_by_tag(child, "ParameterInAtomicSWCTypeInstanceRef"))
             elif tag == "LOCAL-PARAMETER-REF":
                 setattr(obj, "local_parameter_ref", ARRef.deserialize(child))
 
@@ -139,8 +139,8 @@ class AutosarParameterRefBuilder(BuilderBase):
         self._obj: AutosarParameterRef = AutosarParameterRef()
 
 
-    def with_autosar(self, value: Optional[DataPrototype]) -> "AutosarParameterRefBuilder":
-        """Set autosar attribute.
+    def with_autosar_parameter(self, value: Optional[ParameterInAtomicSWCTypeInstanceRef]) -> "AutosarParameterRefBuilder":
+        """Set autosar_parameter attribute.
 
         Args:
             value: Value to set
@@ -149,8 +149,8 @@ class AutosarParameterRefBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'autosar' is required and cannot be None")
-        self._obj.autosar = value
+            raise ValueError("Attribute 'autosar_parameter' is required and cannot be None")
+        self._obj.autosar_parameter = value
         return self
 
     def with_local_parameter(self, value: Optional[DataPrototype]) -> "AutosarParameterRefBuilder":
@@ -171,7 +171,7 @@ class AutosarParameterRefBuilder(BuilderBase):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "autosar",
+        "autosarParameter",
         "localParameter",
     }
 


### PR DESCRIPTION
## Summary
This PR fixes incorrect attribute definitions in AUTOSAR template mapping JSON files that were causing incorrect code generation for several BswModuleTemplate and SWComponentTemplate classes.

## Changes
- **Corrected attribute names** in mapping JSON files to match AUTOSAR specification
- **Regenerated affected model classes** to reflect the corrected mappings
- **Fixed import statements** and serialization/deserialization dispatch tables
- Example fix: `bsw_entry` → `bsw_entry_relationship_type` in BswEntryRelationship

## Files Modified
### JSON Mapping Files (5 files)
- `docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_GenericStructure_GeneralTemplateClasses_ArObject.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_DataElements_InstanceRefs.classes.json`

### Generated Model Files (7 files)
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_entry_relationship.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_entry.py`
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/parameter_in_atomic_swc_type_instance_ref.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_parameter_in_implementation_data_instance_ref.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/ar_variable_in_implementation_data_instance_ref.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/DataElements/autosar_parameter_ref.py`

## Test Coverage
✅ All 298 tests pass after these changes

Quality checks performed:
- ✅ Ruff linting: No issues found in 2255 source files
- ✅ MyPy type checking: No type errors
- ✅ Pytest: All tests passed

## Requirements
N/A - Bug fix

Closes #223