### PR TITLE
refactor: Update JSON mapping files and regenerate model classes

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
@@ -78,7 +78,16 @@
           "is_ref": false,
           "note": "Refers to the BSW Module Identifier defined by the For non-standardized modules, a can be optionally chosen."
         },
-        "bswModulesDependency": {
+        "providedEntry": {
+          "type": "BswModuleEntry",
+          "multiplicity": "*",
+          "kind": "ref",
+          "is_ref": true,
+          "revision": "4.0.3",
+          "decorator": "ref_conditional:PROVIDED-ENTRYS",
+          "note": "Specifies an entry provided by this module which can be called by other modules. This includes \"main\" functions and interrupt routines, but not callbacks (because the signature of a callback is defined by the caller)."
+        },
+        "bswModuleDependency": {
           "type": "BswModuleDependency",
           "multiplicity": "*",
           "kind": "aggr",
@@ -105,15 +114,6 @@
           "kind": "ref",
           "is_ref": true,
           "note": "Specifies an entry provided by this module which can be by other modules. This includes \"main\" functions, and callbacks. Replacement of expectedCallback. atpVariation"
-        },
-        "providedEntry": {
-          "type": "BswModuleEntry",
-          "multiplicity": "*",
-          "kind": "ref",
-          "is_ref": true,
-          "revision": "4.0.3",
-          "decorator": "ref_conditional:PROVIDED-ENTRYS",
-          "note": "Specifies an entry provided by this module which can be called by other modules. This includes \"main\" functions and interrupt routines, but not callbacks (because the signature of a callback is defined by the caller)."
         },
         "providedClientServerEntry": {
           "type": "BswModuleClientServerEntry",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "McSupportData",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -34,28 +34,28 @@
         }
       ],
       "attributes": {
-        "emulation": {
+        "emulationSupport": {
           "type": "McSwEmulationMethodSupport",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "Describes the calibration method used by the RTE. This information is not needed for A2L generation, but to setup in the ECU. atpVariation"
         },
-        "mcParameter": {
+        "mcParameterInstance": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A data instance to be used for calibration. atpSplitable; atpVariation"
         },
-        "mcVariable": {
+        "mcVariableInstance": {
           "type": "McDataInstance",
           "multiplicity": "*",
           "kind": "attribute",
           "is_ref": false,
           "note": "A data instance to be used for measurement. atpSplitable; atpVariation"
         },
-        "measurable": {
+        "measurableSystemConstantValues": {
           "type": "SwSystemconstantValueSet",
           "multiplicity": "*",
           "kind": "ref",
@@ -73,7 +73,7 @@
     },
     {
       "name": "McDataInstance",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -130,38 +130,38 @@
           "is_ref": true,
           "note": "Reference to the corresponding entry in the ECU Flat allows to trace back to the original specification generated data instance. This link shall be added RTE generator mainly for documentation purposes. is optional because McDataInstance may represent an array or struct only the subElements correspond to FlatMap McDataInstance may represent a task local buffer prototyping access which is different from the used for measurement access."
         },
-        "instanceIn": {
+        "instanceInMemory": {
           "type": "ImplementationElementInParameterInstanceRef",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Reference to the corresponding data instance in the description of calibration data structures published by the generator. This is used to support emulation the ECU, it is not required for A2L"
         },
         "mcDataAccessDetails": {
           "type": "McDataAccessDetails",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Refers to \"upstream\" information on how the RTE uses data instance. Use Case: Rapid Prototyping"
         },
-        "mcData": {
+        "mcDataAssignment": {
           "type": "RoleBasedMcDataAssignment",
           "multiplicity": "*",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "An assignment between McDataInstances. This supports the indication of related McDataElement implementing \"RP global buffer\", \"RP global measurement enabler flag\"."
         },
-        "resulting": {
+        "resultingProperties": {
           "type": "SwDataDefProps",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "These are the generated properties resulting from"
         },
-        "resultingRptSw": {
+        "resultingRptSwPrototypingAccess": {
           "type": "RptSwPrototypingAccess",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Describes the implemented accessibility of data and modes by the rapid prototyping tooling. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
@@ -197,7 +197,7 @@
     },
     {
       "name": "McSwEmulationMethodSupport",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -239,7 +239,7 @@
         "elementGroup": {
           "type": "McParameterElementGroup",
           "multiplicity": "*",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Denotes the grouping of calibration parameters in the RTE code. Depending on the category, this required to set up the emulation code."
         },
@@ -261,7 +261,7 @@
     },
     {
       "name": "McParameterElementGroup",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -311,7 +311,7 @@
     },
     {
       "name": "ImplementationElementInParameterInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -344,7 +344,7 @@
           "note": "The context for the referred element."
         },
         "target": {
-          "type": "any (AbstractImplementation)",
+          "type": "AbstractImplementationDataTypeElement",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
@@ -354,7 +354,7 @@
     },
     {
       "name": "McFunction",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -388,36 +388,36 @@
         "defCalprmSet": {
           "type": "McFunctionDataRefSet",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Refers to the set of adjustable data (= calibration in this function."
         },
-        "inMeasurement": {
+        "inMeasurementSet": {
           "type": "McFunctionDataRefSet",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Refers to the set of measurable input data for this"
         },
-        "loc": {
+        "locMeasurementSet": {
           "type": "McFunctionDataRefSet",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Refers to the set of measurable local data in this function. atpSplitable Set Tags:"
         },
-        "out": {
+        "outMeasurementSet": {
           "type": "McFunctionDataRefSet",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Refers to the set of measurable output data from this atpSplitable"
         },
         "refCalprmSet": {
           "type": "McFunctionDataRefSet",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Refers to the set of adjustable data (= calibration by this function."
         },
         "subFunction": {
@@ -431,7 +431,7 @@
     },
     {
       "name": "McDataAccessDetails",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -456,25 +456,25 @@
         }
       ],
       "attributes": {
-        "rteEventRef": {
+        "rteEvent": {
           "type": "RTEEvent",
           "multiplicity": "*",
-          "kind": "attribute",
-          "is_ref": false,
+          "kind": "iref",
+          "is_ref": true,
           "note": "by: RteEventInEcuInstance"
         },
         "variableAccess": {
           "type": "VariableAccess",
           "multiplicity": "*",
-          "kind": "attribute",
-          "is_ref": false,
+          "kind": "iref",
+          "is_ref": true,
           "note": "The VariableAccess for which the data buffer is used."
         }
       }
     },
     {
       "name": "RoleBasedMcDataAssignment",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::MeasurementCalibrationSupport",
       "is_abstract": false,
       "atp_type": null,
@@ -503,7 +503,7 @@
         }
       ],
       "attributes": {
-        "execution": {
+        "executionContext": {
           "type": "RptExecutionContext",
           "multiplicity": "*",
           "kind": "ref",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json
@@ -68,7 +68,7 @@
       ],
       "attributes": {
         "argument": {
-          "type": "RunnableEntity",
+          "type": "RunnableEntityArgument",
           "multiplicity": "*",
           "kind": "aggr",
           "is_ref": false,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RunnableEntity.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RunnableEntity.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "RunnableEntityArgument",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RunnableEntity",
       "is_abstract": false,
       "atp_type": null,

--- a/docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json
+++ b/docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json
@@ -283,20 +283,6 @@
           "is_ref": false,
           "note": "<desc> represents a general but brief description of the in question."
         },
-        "lowerLimit": {
-          "type": "Limit",
-          "multiplicity": "0..1",
-          "kind": "attribute",
-          "is_ref": false,
-          "note": "This specifies the lower limit of the scale."
-        },
-        "mask": {
-          "type": "PositiveUnlimitedInteger",
-          "multiplicity": "0..1",
-          "kind": "attribute",
-          "is_ref": false,
-          "note": "In difference to all the other computational methods every be applied including the bit MASK. is allowed for this type of COMPU-METHOD, overlap. the string reverse to a value, the string has to and the according value for each substring has to up. The sum is finally transmitted. has to be done in order of the"
-        },
         "shortLabel": {
           "type": "Identifier",
           "multiplicity": "0..1",
@@ -310,6 +296,20 @@
           "kind": "attribute",
           "is_ref": false,
           "note": "The symbol, if provided, is used by code generators to get"
+        },
+         "mask": {
+          "type": "PositiveUnlimitedInteger",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "In difference to all the other computational methods every be applied including the bit MASK. is allowed for this type of COMPU-METHOD, overlap. the string reverse to a value, the string has to and the according value for each substring has to up. The sum is finally transmitted. has to be done in order of the"
+        },
+        "lowerLimit": {
+          "type": "Limit",
+          "multiplicity": "0..1",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This specifies the lower limit of the scale."
         },
         "upperLimit": {
           "type": "Limit",

--- a/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.classes.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.classes.json
@@ -380,7 +380,7 @@
     },
     {
       "name": "SwTextProps",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "is_abstract": false,
       "atp_type": null,
@@ -423,7 +423,7 @@
         }
       ],
       "attributes": {
-        "arraySize": {
+        "arraySizeSemantics": {
           "type": "ArraySizeSemanticsEnum",
           "multiplicity": "0..1",
           "kind": "attribute",
@@ -455,7 +455,7 @@
     },
     {
       "name": "ValueList",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "is_abstract": false,
       "atp_type": "atpMixed",
@@ -508,12 +508,19 @@
           "kind": "attribute",
           "is_ref": false,
           "note": "This is a particular numerical value without variation."
+        },
+        "vt": {
+          "type": "Numerical",
+          "multiplicity": "*",
+          "kind": "attribute",
+          "is_ref": false,
+          "note": "This is a particular numerical value without variation."
         }
       }
     },
     {
       "name": "SwBitRepresentation",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "is_abstract": false,
       "atp_type": null,
@@ -556,7 +563,7 @@
     },
     {
       "name": "SwDataDependency",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "is_abstract": false,
       "atp_type": null,
@@ -581,10 +588,17 @@
         }
       ],
       "attributes": {
-        "swData": {
+        "swDataDependencyArgs": {
+          "type": "SwDataDependencyArgs",
+          "multiplicity": "0..1",
+          "kind": "aggr",
+          "is_ref": false,
+          "note": "This element describes the formula with which the between the participating objects are"
+        },
+         "swDataDependencyFormula": {
           "type": "CompuGenericMath",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "This element describes the formula with which the between the participating objects are"
         }
@@ -592,7 +606,7 @@
     },
     {
       "name": "SwDataDependencyArgs",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "is_abstract": false,
       "atp_type": "atpMixed",
@@ -617,18 +631,18 @@
         }
       ],
       "attributes": {
-        "swCalprmRefProxy": {
+        "swCalprmRef": {
           "type": "SwCalprmRefProxy",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Specifies a calibration parameter as an input argument to"
         },
-        "swVariableRefProxy": {
+        "swVariable": {
           "type": "SwVariableRefProxy",
           "multiplicity": "0..1",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "aggr",
+          "is_ref": false,
           "note": "Specifies a variable as an input argument to the"
         }
       }

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
@@ -71,11 +71,11 @@ class BswModuleDescription(ARElement):
 
 
     module_id: Optional[PositiveInteger]
-    bsw_modules_dependencies: list[BswModuleDependency]
+    _provided_entry_refs: list[ARRef]
+    bsw_module_dependencies: list[BswModuleDependency]
     bsw_module_documentation: Optional[SwComponentDocumentation]
     expected_entry_refs: list[ARRef]
     implemented_entry_refs: list[ARRef]
-    _provided_entry_refs: list[ARRef]
     provided_client_server_entries: list[BswModuleClientServerEntry]
     provided_datas: list[VariableDataPrototype]
     provided_mode_groups: list[ModeDeclarationGroupPrototype]
@@ -87,11 +87,11 @@ class BswModuleDescription(ARElement):
     internal_behaviors: list[BswInternalBehavior]
     _DESERIALIZE_DISPATCH = {
         "MODULE-ID": lambda obj, elem: setattr(obj, "module_id", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
-        "BSW-MODULES-DEPENDENCYS": lambda obj, elem: obj.bsw_modules_dependencies.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleDependency")),
+        "PROVIDED-ENTRY-REFS": lambda obj, elem: [obj._provided_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "BSW-MODULE-DEPENDENCYS": lambda obj, elem: obj.bsw_module_dependencies.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleDependency")),
         "BSW-MODULE-DOCUMENTATION": lambda obj, elem: setattr(obj, "bsw_module_documentation", SerializationHelper.deserialize_by_tag(elem, "SwComponentDocumentation")),
         "EXPECTED-ENTRY-REFS": lambda obj, elem: [obj.expected_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "IMPLEMENTED-ENTRY-REFS": lambda obj, elem: [obj.implemented_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
-        "PROVIDED-ENTRY-REFS": lambda obj, elem: [obj._provided_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "PROVIDED-CLIENT-SERVER-ENTRYS": lambda obj, elem: obj.provided_client_server_entries.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleClientServerEntry")),
         "PROVIDED-DATAS": lambda obj, elem: obj.provided_datas.append(SerializationHelper.deserialize_by_tag(elem, "VariableDataPrototype")),
         "PROVIDED-MODE-GROUPS": lambda obj, elem: obj.provided_mode_groups.append(SerializationHelper.deserialize_by_tag(elem, "ModeDeclarationGroupPrototype")),
@@ -108,11 +108,11 @@ class BswModuleDescription(ARElement):
         """Initialize BswModuleDescription."""
         super().__init__()
         self.module_id: Optional[PositiveInteger] = None
-        self.bsw_modules_dependencies: list[BswModuleDependency] = []
+        self._provided_entry_refs: list[ARRef] = []
+        self.bsw_module_dependencies: list[BswModuleDependency] = []
         self.bsw_module_documentation: Optional[SwComponentDocumentation] = None
         self.expected_entry_refs: list[ARRef] = []
         self.implemented_entry_refs: list[ARRef] = []
-        self._provided_entry_refs: list[ARRef] = []
         self.provided_client_server_entries: list[BswModuleClientServerEntry] = []
         self.provided_datas: list[VariableDataPrototype] = []
         self.provided_mode_groups: list[ModeDeclarationGroupPrototype] = []
@@ -171,10 +171,30 @@ class BswModuleDescription(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize bsw_modules_dependencies (list to container "BSW-MODULES-DEPENDENCYS")
-        if self.bsw_modules_dependencies:
-            wrapper = ET.Element("BSW-MODULES-DEPENDENCYS")
-            for item in self.bsw_modules_dependencies:
+        # Serialize provided_entry_refs (list to container "PROVIDED-ENTRYS")
+        if self.provided_entry_refs:
+            wrapper = ET.Element("PROVIDED-ENTRYS")
+            for item in self.provided_entry_refs:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
+                if serialized is not None:
+                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
+                    if hasattr(serialized, 'attrib'):
+                        ref_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        ref_elem.text = serialized.text
+                    for child in serialized:
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize bsw_module_dependencies (list to container "BSW-MODULE-DEPENDENCYS")
+        if self.bsw_module_dependencies:
+            wrapper = ET.Element("BSW-MODULE-DEPENDENCYS")
+            for item in self.bsw_module_dependencies:
                 serialized = SerializationHelper.serialize_item(item, "BswModuleDependency")
                 if serialized is not None:
                     wrapper.append(serialized)
@@ -226,26 +246,6 @@ class BswModuleDescription(ARElement):
                     for child in serialized:
                         child_elem.append(child)
                     wrapper.append(child_elem)
-            if len(wrapper) > 0:
-                elem.append(wrapper)
-
-        # Serialize provided_entry_refs (list to container "PROVIDED-ENTRYS")
-        if self.provided_entry_refs:
-            wrapper = ET.Element("PROVIDED-ENTRYS")
-            for item in self.provided_entry_refs:
-                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
-                if serialized is not None:
-                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
-                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
-                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
-                    if hasattr(serialized, 'attrib'):
-                        ref_elem.attrib.update(serialized.attrib)
-                    if serialized.text:
-                        ref_elem.text = serialized.text
-                    for child in serialized:
-                        ref_elem.append(child)
-                    conditional.append(ref_elem)
-                    wrapper.append(conditional)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
@@ -360,10 +360,17 @@ class BswModuleDescription(ARElement):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "MODULE-ID":
                 setattr(obj, "module_id", SerializationHelper.deserialize_by_tag(child, "PositiveInteger"))
-            elif tag == "BSW-MODULES-DEPENDENCYS":
+            elif tag == "PROVIDED-ENTRYS":
+                # Unwrap ref_conditional pattern
+                for item_elem in child:
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._provided_entry_refs.append(ARRef.deserialize(ref_elem))
+            elif tag == "BSW-MODULE-DEPENDENCYS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.bsw_modules_dependencies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleDependency"))
+                    obj.bsw_module_dependencies.append(SerializationHelper.deserialize_by_tag(item_elem, "BswModuleDependency"))
             elif tag == "BSW-MODULE-DOCUMENTATION":
                 setattr(obj, "bsw_module_documentation", SerializationHelper.deserialize_by_tag(child, "SwComponentDocumentation"))
             elif tag == "EXPECTED-ENTRY-REFS":
@@ -374,13 +381,6 @@ class BswModuleDescription(ARElement):
                 # Iterate through wrapper children
                 for item_elem in child:
                     obj.implemented_entry_refs.append(ARRef.deserialize(item_elem))
-            elif tag == "PROVIDED-ENTRYS":
-                # Unwrap ref_conditional pattern
-                for item_elem in child:
-                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
-                    if len(item_elem) > 0:
-                        ref_elem = item_elem[0]
-                        obj._provided_entry_refs.append(ARRef.deserialize(ref_elem))
             elif tag == "PROVIDED-CLIENT-SERVER-ENTRYS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -445,8 +445,8 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         self._obj.module_id = value
         return self
 
-    def with_bsw_modules_dependencies(self, items: list[BswModuleDependency]) -> "BswModuleDescriptionBuilder":
-        """Set bsw_modules_dependencies list attribute.
+    def with_provided_entries(self, items: list[BswModuleEntry]) -> "BswModuleDescriptionBuilder":
+        """Set provided_entries list attribute.
 
         Args:
             items: List of items to set
@@ -454,7 +454,19 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         Returns:
             self for method chaining
         """
-        self._obj.bsw_modules_dependencies = list(items) if items else []
+        self._obj.provided_entries = list(items) if items else []
+        return self
+
+    def with_bsw_module_dependencies(self, items: list[BswModuleDependency]) -> "BswModuleDescriptionBuilder":
+        """Set bsw_module_dependencies list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.bsw_module_dependencies = list(items) if items else []
         return self
 
     def with_bsw_module_documentation(self, value: Optional[SwComponentDocumentation]) -> "BswModuleDescriptionBuilder":
@@ -493,18 +505,6 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.implemented_entries = list(items) if items else []
-        return self
-
-    def with_provided_entries(self, items: list[BswModuleEntry]) -> "BswModuleDescriptionBuilder":
-        """Set provided_entries list attribute.
-
-        Args:
-            items: List of items to set
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.provided_entries = list(items) if items else []
         return self
 
     def with_provided_client_server_entries(self, items: list[BswModuleClientServerEntry]) -> "BswModuleDescriptionBuilder":
@@ -616,8 +616,8 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         return self
 
 
-    def add_bsw_modules_dependency(self, item: BswModuleDependency) -> "BswModuleDescriptionBuilder":
-        """Add a single item to bsw_modules_dependencies list.
+    def add_provided_entry(self, item: BswModuleEntry) -> "BswModuleDescriptionBuilder":
+        """Add a single item to provided_entries list.
 
         Args:
             item: Item to add
@@ -625,16 +625,37 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         Returns:
             self for method chaining
         """
-        self._obj.bsw_modules_dependencies.append(item)
+        self._obj.provided_entries.append(item)
         return self
 
-    def clear_bsw_modules_dependencies(self) -> "BswModuleDescriptionBuilder":
-        """Clear all items from bsw_modules_dependencies list.
+    def clear_provided_entries(self) -> "BswModuleDescriptionBuilder":
+        """Clear all items from provided_entries list.
 
         Returns:
             self for method chaining
         """
-        self._obj.bsw_modules_dependencies = []
+        self._obj.provided_entries = []
+        return self
+
+    def add_bsw_module_dependency(self, item: BswModuleDependency) -> "BswModuleDescriptionBuilder":
+        """Add a single item to bsw_module_dependencies list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.bsw_module_dependencies.append(item)
+        return self
+
+    def clear_bsw_module_dependencies(self) -> "BswModuleDescriptionBuilder":
+        """Clear all items from bsw_module_dependencies list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.bsw_module_dependencies = []
         return self
 
     def add_expected_entry(self, item: BswModuleEntry) -> "BswModuleDescriptionBuilder":
@@ -677,27 +698,6 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.implemented_entries = []
-        return self
-
-    def add_provided_entry(self, item: BswModuleEntry) -> "BswModuleDescriptionBuilder":
-        """Add a single item to provided_entries list.
-
-        Args:
-            item: Item to add
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.provided_entries.append(item)
-        return self
-
-    def clear_provided_entries(self) -> "BswModuleDescriptionBuilder":
-        """Clear all items from provided_entries list.
-
-        Returns:
-            self for method chaining
-        """
-        self._obj.provided_entries = []
         return self
 
     def add_provided_client_server_entry(self, item: BswModuleClientServerEntry) -> "BswModuleDescriptionBuilder":
@@ -892,8 +892,8 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
+        "bswModuleDependency",
         "bswModuleDocumentation",
-        "bswModulesDependency",
         "expectedEntry",
         "implementedEntry",
         "internalBehavior",

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py
@@ -49,6 +49,7 @@ class RuleBasedAxisCont(ARObject):
     rule_based: Optional[Any]
     sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
+    vts: list[Numerical]
     sw_axis_index: Optional[AxisIndexType]
     unit_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
@@ -56,6 +57,7 @@ class RuleBasedAxisCont(ARObject):
         "RULE-BASED": lambda obj, elem: setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(elem, "any (RuleBasedValue)")),
         "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-AXIS-INDEX": lambda obj, elem: setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(elem, "AxisIndexType")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
     }
@@ -68,6 +70,7 @@ class RuleBasedAxisCont(ARObject):
         self.rule_based: Optional[Any] = None
         self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
         self.sw_axis_index: Optional[AxisIndexType] = None
         self.unit_ref: Optional[ARRef] = None
 
@@ -149,6 +152,23 @@ class RuleBasedAxisCont(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize vts (list to container "VTS")
+        if self.vts:
+            wrapper = ET.Element("VTS")
+            for item in self.vts:
+                serialized = SerializationHelper.serialize_item(item, "Numerical")
+                if serialized is not None:
+                    child_elem = ET.Element("VT")
+                    if hasattr(serialized, 'attrib'):
+                        child_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        child_elem.text = serialized.text
+                    for child in serialized:
+                        child_elem.append(child)
+                    wrapper.append(child_elem)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize sw_axis_index
         if self.sw_axis_index is not None:
             serialized = SerializationHelper.serialize_item(self.sw_axis_index, "AxisIndexType")
@@ -204,6 +224,10 @@ class RuleBasedAxisCont(ARObject):
                 setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "VTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.vts.append(SerializationHelper.deserialize_by_tag(item_elem, "Numerical"))
             elif tag == "SW-AXIS-INDEX":
                 setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(child, "AxisIndexType"))
             elif tag == "UNIT-REF":
@@ -278,6 +302,18 @@ class RuleBasedAxisContBuilder(BuilderBase):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "RuleBasedAxisContBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
     def with_sw_axis_index(self, value: Optional[AxisIndexType]) -> "RuleBasedAxisContBuilder":
         """Set sw_axis_index attribute.
 
@@ -306,6 +342,27 @@ class RuleBasedAxisContBuilder(BuilderBase):
         self._obj.unit = value
         return self
 
+
+    def add_vt(self, item: Numerical) -> "RuleBasedAxisContBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "RuleBasedAxisContBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py
@@ -43,11 +43,13 @@ class RuleBasedValueCont(ARObject):
     rule_based: Optional[Any]
     sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
+    vts: list[Numerical]
     unit_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "RULE-BASED": lambda obj, elem: setattr(obj, "rule_based", SerializationHelper.deserialize_by_tag(elem, "any (RuleBasedValue)")),
         "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
     }
 
@@ -58,6 +60,7 @@ class RuleBasedValueCont(ARObject):
         self.rule_based: Optional[Any] = None
         self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
         self.unit_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
@@ -124,6 +127,23 @@ class RuleBasedValueCont(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize vts (list to container "VTS")
+        if self.vts:
+            wrapper = ET.Element("VTS")
+            for item in self.vts:
+                serialized = SerializationHelper.serialize_item(item, "Numerical")
+                if serialized is not None:
+                    child_elem = ET.Element("VT")
+                    if hasattr(serialized, 'attrib'):
+                        child_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        child_elem.text = serialized.text
+                    for child in serialized:
+                        child_elem.append(child)
+                    wrapper.append(child_elem)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize unit_ref
         if self.unit_ref is not None:
             serialized = SerializationHelper.serialize_item(self.unit_ref, "Unit")
@@ -163,6 +183,10 @@ class RuleBasedValueCont(ARObject):
                 setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "VTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.vts.append(SerializationHelper.deserialize_by_tag(item_elem, "Numerical"))
             elif tag == "UNIT-REF":
                 setattr(obj, "unit_ref", ARRef.deserialize(child))
 
@@ -221,6 +245,18 @@ class RuleBasedValueContBuilder(BuilderBase):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "RuleBasedValueContBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
     def with_unit(self, value: Optional[Unit]) -> "RuleBasedValueContBuilder":
         """Set unit attribute.
 
@@ -235,6 +271,27 @@ class RuleBasedValueContBuilder(BuilderBase):
         self._obj.unit = value
         return self
 
+
+    def add_vt(self, item: Numerical) -> "RuleBasedValueContBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "RuleBasedValueContBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/implementation_element_in_parameter_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/implementation_element_in_parameter_instance_ref.py
@@ -6,11 +6,14 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ImplementationDataTypes.abstract_implementation_data_type_element import (
+    AbstractImplementationDataTypeElement,
+)
 
 if TYPE_CHECKING:
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.parameter_data_prototype import (
@@ -37,10 +40,10 @@ class ImplementationElementInParameterInstanceRef(ARObject):
 
 
     context_ref: Optional[ARRef]
-    target_ref: Optional[Any]
+    target_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "CONTEXT-REF": lambda obj, elem: setattr(obj, "context_ref", ARRef.deserialize(elem)),
-        "TARGET-REF": lambda obj, elem: setattr(obj, "target_ref", ARRef.deserialize(elem)),
+        "TARGET-REF": ("_POLYMORPHIC", "target_ref", ["ImplementationDataTypeElement"]),
     }
 
 
@@ -48,7 +51,7 @@ class ImplementationElementInParameterInstanceRef(ARObject):
         """Initialize ImplementationElementInParameterInstanceRef."""
         super().__init__()
         self.context_ref: Optional[ARRef] = None
-        self.target_ref: Optional[Any] = None
+        self.target_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ImplementationElementInParameterInstanceRef to XML element.
@@ -89,7 +92,7 @@ class ImplementationElementInParameterInstanceRef(ARObject):
 
         # Serialize target_ref
         if self.target_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.target_ref, "Any")
+            serialized = SerializationHelper.serialize_item(self.target_ref, "AbstractImplementationDataTypeElement")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("TARGET-REF")
@@ -152,7 +155,7 @@ class ImplementationElementInParameterInstanceRefBuilder(BuilderBase):
         self._obj.context = value
         return self
 
-    def with_target(self, value: Optional[Any]) -> "ImplementationElementInParameterInstanceRefBuilder":
+    def with_target(self, value: Optional[AbstractImplementationDataTypeElement]) -> "ImplementationElementInParameterInstanceRefBuilder":
         """Set target attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_access_details.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_access_details.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
+from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 
 if TYPE_CHECKING:
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import (
@@ -38,19 +39,19 @@ class McDataAccessDetails(ARObject):
     _XML_TAG = "MC-DATA-ACCESS-DETAILS"
 
 
-    rte_event_refs: list[RTEEvent]
-    variable_accesses: list[VariableAccess]
+    rte_event_irefs: list[RTEEvent]
+    variable_acces_irefs: list[VariableAccess]
     _DESERIALIZE_DISPATCH = {
-        "RTE-EVENT-REFS": ("_POLYMORPHIC_LIST", "rte_event_refs", ["AsynchronousServerCallReturnsEvent", "BackgroundEvent", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataWriteCompletedEvent", "ExternalTriggerOccurredEvent", "InitEvent", "InternalTriggerOccurredEvent", "ModeSwitchedAckEvent", "OperationInvokedEvent", "OsTaskExecutionEvent", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "TimingEvent", "TransformerHardErrorEvent"]),
-        "VARIABLE-ACCESSS": lambda obj, elem: obj.variable_accesses.append(SerializationHelper.deserialize_by_tag(elem, "VariableAccess")),
+        "RTE-EVENTS-IREF": ("_POLYMORPHIC_LIST", "rte_event_irefs", ["AsynchronousServerCallReturnsEvent", "BackgroundEvent", "DataReceiveErrorEvent", "DataReceivedEvent", "DataSendCompletedEvent", "DataWriteCompletedEvent", "ExternalTriggerOccurredEvent", "InitEvent", "InternalTriggerOccurredEvent", "ModeSwitchedAckEvent", "OperationInvokedEvent", "OsTaskExecutionEvent", "SwcModeManagerErrorEvent", "SwcModeSwitchEvent", "TimingEvent", "TransformerHardErrorEvent"]),
+        "VARIABLE-ACCESSS-IREF": lambda obj, elem: obj.variable_acces_irefs.append(SerializationHelper.deserialize_by_tag(elem, "VariableAccess")),
     }
 
 
     def __init__(self) -> None:
         """Initialize McDataAccessDetails."""
         super().__init__()
-        self.rte_event_refs: list[RTEEvent] = []
-        self.variable_accesses: list[VariableAccess] = []
+        self.rte_event_irefs: list[RTEEvent] = []
+        self.variable_acces_irefs: list[VariableAccess] = []
 
     def serialize(self) -> ET.Element:
         """Serialize McDataAccessDetails to XML element.
@@ -75,25 +76,27 @@ class McDataAccessDetails(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize rte_event_refs (list to container "RTE-EVENT-REFS")
-        if self.rte_event_refs:
-            wrapper = ET.Element("RTE-EVENT-REFS")
-            for item in self.rte_event_refs:
-                serialized = SerializationHelper.serialize_item(item, "RTEEvent")
-                if serialized is not None:
-                    wrapper.append(serialized)
-            if len(wrapper) > 0:
-                elem.append(wrapper)
+        # Serialize rte_event_irefs (list of instance references with wrapper "RTE-EVENTS-IREF")
+        if self.rte_event_irefs:
+            serialized = SerializationHelper.serialize_item(self.rte_event_irefs, "RTEEvent")
+            if serialized is not None:
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("RTE-EVENTS-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
+                for child in serialized:
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
-        # Serialize variable_accesses (list to container "VARIABLE-ACCESSS")
-        if self.variable_accesses:
-            wrapper = ET.Element("VARIABLE-ACCESSS")
-            for item in self.variable_accesses:
-                serialized = SerializationHelper.serialize_item(item, "VariableAccess")
-                if serialized is not None:
-                    wrapper.append(serialized)
-            if len(wrapper) > 0:
-                elem.append(wrapper)
+        # Serialize variable_acces_irefs (list of instance references with wrapper "VARIABLE-ACCESSS-IREF")
+        if self.variable_acces_irefs:
+            serialized = SerializationHelper.serialize_item(self.variable_acces_irefs, "VariableAccess")
+            if serialized is not None:
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("VARIABLE-ACCESSS-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
+                for child in serialized:
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
         return elem
 
@@ -114,46 +117,46 @@ class McDataAccessDetails(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "RTE-EVENT-REFS":
+            if tag == "RTE-EVENT-IREFS":
                 # Iterate through all child elements and deserialize each based on its concrete type
                 for item_elem in child:
                     concrete_tag = item_elem.tag.split(ns_split, 1)[1] if item_elem.tag.startswith("{") else item_elem.tag
                     if concrete_tag == "ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "AsynchronousServerCallReturnsEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "AsynchronousServerCallReturnsEvent"))
                     elif concrete_tag == "BACKGROUND-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "BackgroundEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "BackgroundEvent"))
                     elif concrete_tag == "DATA-RECEIVE-ERROR-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataReceiveErrorEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataReceiveErrorEvent"))
                     elif concrete_tag == "DATA-RECEIVED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataReceivedEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataReceivedEvent"))
                     elif concrete_tag == "DATA-SEND-COMPLETED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataSendCompletedEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataSendCompletedEvent"))
                     elif concrete_tag == "DATA-WRITE-COMPLETED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataWriteCompletedEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "DataWriteCompletedEvent"))
                     elif concrete_tag == "EXTERNAL-TRIGGER-OCCURRED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "ExternalTriggerOccurredEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "ExternalTriggerOccurredEvent"))
                     elif concrete_tag == "INIT-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "InitEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "InitEvent"))
                     elif concrete_tag == "INTERNAL-TRIGGER-OCCURRED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "InternalTriggerOccurredEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "InternalTriggerOccurredEvent"))
                     elif concrete_tag == "MODE-SWITCHED-ACK-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "ModeSwitchedAckEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "ModeSwitchedAckEvent"))
                     elif concrete_tag == "OPERATION-INVOKED-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "OperationInvokedEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "OperationInvokedEvent"))
                     elif concrete_tag == "OS-TASK-EXECUTION-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "OsTaskExecutionEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "OsTaskExecutionEvent"))
                     elif concrete_tag == "SWC-MODE-MANAGER-ERROR-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "SwcModeManagerErrorEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "SwcModeManagerErrorEvent"))
                     elif concrete_tag == "SWC-MODE-SWITCH-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "SwcModeSwitchEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "SwcModeSwitchEvent"))
                     elif concrete_tag == "TIMING-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "TimingEvent"))
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "TimingEvent"))
                     elif concrete_tag == "TRANSFORMER-HARD-ERROR-EVENT":
-                        obj.rte_event_refs.append(SerializationHelper.deserialize_by_tag(item_elem, "TransformerHardErrorEvent"))
-            elif tag == "VARIABLE-ACCESSS":
+                        obj.rte_event_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "TransformerHardErrorEvent"))
+            elif tag == "VARIABLE-ACCESS-IREFS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.variable_accesses.append(SerializationHelper.deserialize_by_tag(item_elem, "VariableAccess"))
+                    obj.variable_acces_irefs.append(SerializationHelper.deserialize_by_tag(item_elem, "VariableAccess"))
 
         return obj
 
@@ -168,8 +171,8 @@ class McDataAccessDetailsBuilder(BuilderBase):
         self._obj: McDataAccessDetails = McDataAccessDetails()
 
 
-    def with_rte_event_refs(self, items: list[RTEEvent]) -> "McDataAccessDetailsBuilder":
-        """Set rte_event_refs list attribute.
+    def with_rte_events(self, items: list[RTEEvent]) -> "McDataAccessDetailsBuilder":
+        """Set rte_events list attribute.
 
         Args:
             items: List of items to set
@@ -177,7 +180,7 @@ class McDataAccessDetailsBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.rte_event_refs = list(items) if items else []
+        self._obj.rte_events = list(items) if items else []
         return self
 
     def with_variable_accesses(self, items: list[VariableAccess]) -> "McDataAccessDetailsBuilder":
@@ -193,8 +196,8 @@ class McDataAccessDetailsBuilder(BuilderBase):
         return self
 
 
-    def add_rte_event_ref(self, item: RTEEvent) -> "McDataAccessDetailsBuilder":
-        """Add a single item to rte_event_refs list.
+    def add_rte_event(self, item: RTEEvent) -> "McDataAccessDetailsBuilder":
+        """Add a single item to rte_events list.
 
         Args:
             item: Item to add
@@ -202,16 +205,16 @@ class McDataAccessDetailsBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.rte_event_refs.append(item)
+        self._obj.rte_events.append(item)
         return self
 
-    def clear_rte_event_refs(self) -> "McDataAccessDetailsBuilder":
-        """Clear all items from rte_event_refs list.
+    def clear_rte_events(self) -> "McDataAccessDetailsBuilder":
+        """Clear all items from rte_events list.
 
         Returns:
             self for method chaining
         """
-        self._obj.rte_event_refs = []
+        self._obj.rte_events = []
         return self
 
     def add_variable_access(self, item: VariableAccess) -> "McDataAccessDetailsBuilder":
@@ -238,7 +241,7 @@ class McDataAccessDetailsBuilder(BuilderBase):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "rteEventRef",
+        "rteEvent",
         "variableAccess",
     }
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_instance.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_instance.py
@@ -68,11 +68,11 @@ class McDataInstance(Identifiable):
     array_size: Optional[PositiveInteger]
     display_identifier: Optional[McdIdentifier]
     flat_map_entry_ref: Optional[ARRef]
-    instance_in: Optional[ImplementationElementInParameterInstanceRef]
+    instance_in_memory: Optional[ImplementationElementInParameterInstanceRef]
     mc_data_access_details: Optional[McDataAccessDetails]
-    mc_datas: list[RoleBasedMcDataAssignment]
-    resulting: Optional[SwDataDefProps]
-    resulting_rpt_sw: Optional[RptSwPrototypingAccess]
+    mc_data_assignments: list[RoleBasedMcDataAssignment]
+    resulting_properties: Optional[SwDataDefProps]
+    resulting_rpt_sw_prototyping_access: Optional[RptSwPrototypingAccess]
     role: Optional[Identifier]
     rpt_impl_policy: Optional[RptImplPolicy]
     sub_elements: list[McDataInstance]
@@ -81,11 +81,11 @@ class McDataInstance(Identifiable):
         "ARRAY-SIZE": lambda obj, elem: setattr(obj, "array_size", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
         "DISPLAY-IDENTIFIER": lambda obj, elem: setattr(obj, "display_identifier", SerializationHelper.deserialize_by_tag(elem, "McdIdentifier")),
         "FLAT-MAP-ENTRY-REF": lambda obj, elem: setattr(obj, "flat_map_entry_ref", ARRef.deserialize(elem)),
-        "INSTANCE-IN": lambda obj, elem: setattr(obj, "instance_in", SerializationHelper.deserialize_by_tag(elem, "ImplementationElementInParameterInstanceRef")),
+        "INSTANCE-IN-MEMORY": lambda obj, elem: setattr(obj, "instance_in_memory", SerializationHelper.deserialize_by_tag(elem, "ImplementationElementInParameterInstanceRef")),
         "MC-DATA-ACCESS-DETAILS": lambda obj, elem: setattr(obj, "mc_data_access_details", SerializationHelper.deserialize_by_tag(elem, "McDataAccessDetails")),
-        "MC-DATAS": lambda obj, elem: obj.mc_datas.append(SerializationHelper.deserialize_by_tag(elem, "RoleBasedMcDataAssignment")),
-        "RESULTING": lambda obj, elem: setattr(obj, "resulting", SerializationHelper.deserialize_by_tag(elem, "SwDataDefProps")),
-        "RESULTING-RPT-SW": lambda obj, elem: setattr(obj, "resulting_rpt_sw", SerializationHelper.deserialize_by_tag(elem, "RptSwPrototypingAccess")),
+        "MC-DATA-ASSIGNMENTS": lambda obj, elem: obj.mc_data_assignments.append(SerializationHelper.deserialize_by_tag(elem, "RoleBasedMcDataAssignment")),
+        "RESULTING-PROPERTIES": lambda obj, elem: setattr(obj, "resulting_properties", SerializationHelper.deserialize_by_tag(elem, "SwDataDefProps")),
+        "RESULTING-RPT-SW-PROTOTYPING-ACCESS": lambda obj, elem: setattr(obj, "resulting_rpt_sw_prototyping_access", SerializationHelper.deserialize_by_tag(elem, "RptSwPrototypingAccess")),
         "ROLE": lambda obj, elem: setattr(obj, "role", SerializationHelper.deserialize_by_tag(elem, "Identifier")),
         "RPT-IMPL-POLICY": lambda obj, elem: setattr(obj, "rpt_impl_policy", SerializationHelper.deserialize_by_tag(elem, "RptImplPolicy")),
         "SUB-ELEMENTS": lambda obj, elem: obj.sub_elements.append(SerializationHelper.deserialize_by_tag(elem, "McDataInstance")),
@@ -99,11 +99,11 @@ class McDataInstance(Identifiable):
         self.array_size: Optional[PositiveInteger] = None
         self.display_identifier: Optional[McdIdentifier] = None
         self.flat_map_entry_ref: Optional[ARRef] = None
-        self.instance_in: Optional[ImplementationElementInParameterInstanceRef] = None
+        self.instance_in_memory: Optional[ImplementationElementInParameterInstanceRef] = None
         self.mc_data_access_details: Optional[McDataAccessDetails] = None
-        self.mc_datas: list[RoleBasedMcDataAssignment] = []
-        self.resulting: Optional[SwDataDefProps] = None
-        self.resulting_rpt_sw: Optional[RptSwPrototypingAccess] = None
+        self.mc_data_assignments: list[RoleBasedMcDataAssignment] = []
+        self.resulting_properties: Optional[SwDataDefProps] = None
+        self.resulting_rpt_sw_prototyping_access: Optional[RptSwPrototypingAccess] = None
         self.role: Optional[Identifier] = None
         self.rpt_impl_policy: Optional[RptImplPolicy] = None
         self.sub_elements: list[McDataInstance] = []
@@ -174,12 +174,12 @@ class McDataInstance(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize instance_in
-        if self.instance_in is not None:
-            serialized = SerializationHelper.serialize_item(self.instance_in, "ImplementationElementInParameterInstanceRef")
+        # Serialize instance_in_memory
+        if self.instance_in_memory is not None:
+            serialized = SerializationHelper.serialize_item(self.instance_in_memory, "ImplementationElementInParameterInstanceRef")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("INSTANCE-IN")
+                wrapped = ET.Element("INSTANCE-IN-MEMORY")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -202,22 +202,22 @@ class McDataInstance(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize mc_datas (list to container "MC-DATAS")
-        if self.mc_datas:
-            wrapper = ET.Element("MC-DATAS")
-            for item in self.mc_datas:
+        # Serialize mc_data_assignments (list to container "MC-DATA-ASSIGNMENTS")
+        if self.mc_data_assignments:
+            wrapper = ET.Element("MC-DATA-ASSIGNMENTS")
+            for item in self.mc_data_assignments:
                 serialized = SerializationHelper.serialize_item(item, "RoleBasedMcDataAssignment")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize resulting
-        if self.resulting is not None:
-            serialized = SerializationHelper.serialize_item(self.resulting, "SwDataDefProps")
+        # Serialize resulting_properties
+        if self.resulting_properties is not None:
+            serialized = SerializationHelper.serialize_item(self.resulting_properties, "SwDataDefProps")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("RESULTING")
+                wrapped = ET.Element("RESULTING-PROPERTIES")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -226,12 +226,12 @@ class McDataInstance(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize resulting_rpt_sw
-        if self.resulting_rpt_sw is not None:
-            serialized = SerializationHelper.serialize_item(self.resulting_rpt_sw, "RptSwPrototypingAccess")
+        # Serialize resulting_rpt_sw_prototyping_access
+        if self.resulting_rpt_sw_prototyping_access is not None:
+            serialized = SerializationHelper.serialize_item(self.resulting_rpt_sw_prototyping_access, "RptSwPrototypingAccess")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("RESULTING-RPT-SW")
+                wrapped = ET.Element("RESULTING-RPT-SW-PROTOTYPING-ACCESS")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -317,18 +317,18 @@ class McDataInstance(Identifiable):
                 setattr(obj, "display_identifier", SerializationHelper.deserialize_by_tag(child, "McdIdentifier"))
             elif tag == "FLAT-MAP-ENTRY-REF":
                 setattr(obj, "flat_map_entry_ref", ARRef.deserialize(child))
-            elif tag == "INSTANCE-IN":
-                setattr(obj, "instance_in", SerializationHelper.deserialize_by_tag(child, "ImplementationElementInParameterInstanceRef"))
+            elif tag == "INSTANCE-IN-MEMORY":
+                setattr(obj, "instance_in_memory", SerializationHelper.deserialize_by_tag(child, "ImplementationElementInParameterInstanceRef"))
             elif tag == "MC-DATA-ACCESS-DETAILS":
                 setattr(obj, "mc_data_access_details", SerializationHelper.deserialize_by_tag(child, "McDataAccessDetails"))
-            elif tag == "MC-DATAS":
+            elif tag == "MC-DATA-ASSIGNMENTS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.mc_datas.append(SerializationHelper.deserialize_by_tag(item_elem, "RoleBasedMcDataAssignment"))
-            elif tag == "RESULTING":
-                setattr(obj, "resulting", SerializationHelper.deserialize_by_tag(child, "SwDataDefProps"))
-            elif tag == "RESULTING-RPT-SW":
-                setattr(obj, "resulting_rpt_sw", SerializationHelper.deserialize_by_tag(child, "RptSwPrototypingAccess"))
+                    obj.mc_data_assignments.append(SerializationHelper.deserialize_by_tag(item_elem, "RoleBasedMcDataAssignment"))
+            elif tag == "RESULTING-PROPERTIES":
+                setattr(obj, "resulting_properties", SerializationHelper.deserialize_by_tag(child, "SwDataDefProps"))
+            elif tag == "RESULTING-RPT-SW-PROTOTYPING-ACCESS":
+                setattr(obj, "resulting_rpt_sw_prototyping_access", SerializationHelper.deserialize_by_tag(child, "RptSwPrototypingAccess"))
             elif tag == "ROLE":
                 setattr(obj, "role", SerializationHelper.deserialize_by_tag(child, "Identifier"))
             elif tag == "RPT-IMPL-POLICY":
@@ -395,8 +395,8 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         self._obj.flat_map_entry = value
         return self
 
-    def with_instance_in(self, value: Optional[ImplementationElementInParameterInstanceRef]) -> "McDataInstanceBuilder":
-        """Set instance_in attribute.
+    def with_instance_in_memory(self, value: Optional[ImplementationElementInParameterInstanceRef]) -> "McDataInstanceBuilder":
+        """Set instance_in_memory attribute.
 
         Args:
             value: Value to set
@@ -405,8 +405,8 @@ class McDataInstanceBuilder(IdentifiableBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'instance_in' is required and cannot be None")
-        self._obj.instance_in = value
+            raise ValueError("Attribute 'instance_in_memory' is required and cannot be None")
+        self._obj.instance_in_memory = value
         return self
 
     def with_mc_data_access_details(self, value: Optional[McDataAccessDetails]) -> "McDataInstanceBuilder":
@@ -423,8 +423,8 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         self._obj.mc_data_access_details = value
         return self
 
-    def with_mc_datas(self, items: list[RoleBasedMcDataAssignment]) -> "McDataInstanceBuilder":
-        """Set mc_datas list attribute.
+    def with_mc_data_assignments(self, items: list[RoleBasedMcDataAssignment]) -> "McDataInstanceBuilder":
+        """Set mc_data_assignments list attribute.
 
         Args:
             items: List of items to set
@@ -432,11 +432,11 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         Returns:
             self for method chaining
         """
-        self._obj.mc_datas = list(items) if items else []
+        self._obj.mc_data_assignments = list(items) if items else []
         return self
 
-    def with_resulting(self, value: Optional[SwDataDefProps]) -> "McDataInstanceBuilder":
-        """Set resulting attribute.
+    def with_resulting_properties(self, value: Optional[SwDataDefProps]) -> "McDataInstanceBuilder":
+        """Set resulting_properties attribute.
 
         Args:
             value: Value to set
@@ -445,12 +445,12 @@ class McDataInstanceBuilder(IdentifiableBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'resulting' is required and cannot be None")
-        self._obj.resulting = value
+            raise ValueError("Attribute 'resulting_properties' is required and cannot be None")
+        self._obj.resulting_properties = value
         return self
 
-    def with_resulting_rpt_sw(self, value: Optional[RptSwPrototypingAccess]) -> "McDataInstanceBuilder":
-        """Set resulting_rpt_sw attribute.
+    def with_resulting_rpt_sw_prototyping_access(self, value: Optional[RptSwPrototypingAccess]) -> "McDataInstanceBuilder":
+        """Set resulting_rpt_sw_prototyping_access attribute.
 
         Args:
             value: Value to set
@@ -459,8 +459,8 @@ class McDataInstanceBuilder(IdentifiableBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'resulting_rpt_sw' is required and cannot be None")
-        self._obj.resulting_rpt_sw = value
+            raise ValueError("Attribute 'resulting_rpt_sw_prototyping_access' is required and cannot be None")
+        self._obj.resulting_rpt_sw_prototyping_access = value
         return self
 
     def with_role(self, value: Optional[Identifier]) -> "McDataInstanceBuilder":
@@ -518,8 +518,8 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         return self
 
 
-    def add_mc_data(self, item: RoleBasedMcDataAssignment) -> "McDataInstanceBuilder":
-        """Add a single item to mc_datas list.
+    def add_mc_data_assignment(self, item: RoleBasedMcDataAssignment) -> "McDataInstanceBuilder":
+        """Add a single item to mc_data_assignments list.
 
         Args:
             item: Item to add
@@ -527,16 +527,16 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         Returns:
             self for method chaining
         """
-        self._obj.mc_datas.append(item)
+        self._obj.mc_data_assignments.append(item)
         return self
 
-    def clear_mc_datas(self) -> "McDataInstanceBuilder":
-        """Clear all items from mc_datas list.
+    def clear_mc_data_assignments(self) -> "McDataInstanceBuilder":
+        """Clear all items from mc_data_assignments list.
 
         Returns:
             self for method chaining
         """
-        self._obj.mc_datas = []
+        self._obj.mc_data_assignments = []
         return self
 
     def add_sub_element(self, item: McDataInstance) -> "McDataInstanceBuilder":
@@ -566,11 +566,11 @@ class McDataInstanceBuilder(IdentifiableBuilder):
         "arraySize",
         "displayIdentifier",
         "flatMapEntry",
-        "instanceIn",
-        "mcData",
+        "instanceInMemory",
         "mcDataAccessDetails",
-        "resulting",
-        "resultingRptSw",
+        "mcDataAssignment",
+        "resultingProperties",
+        "resultingRptSwPrototypingAccess",
         "role",
         "rptImplPolicy",
         "subElement",

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_function.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_function.py
@@ -37,18 +37,18 @@ class McFunction(ARElement):
     _XML_TAG = "MC-FUNCTION"
 
 
-    def_calprm_set_ref: Optional[ARRef]
-    in_measurement_ref: Optional[ARRef]
-    loc_ref: Optional[ARRef]
-    out_ref: Optional[ARRef]
-    ref_calprm_set_ref: Optional[ARRef]
+    def_calprm_set: Optional[McFunctionDataRefSet]
+    in_measurement_set: Optional[McFunctionDataRefSet]
+    loc_measurement_set: Optional[McFunctionDataRefSet]
+    out_measurement_set: Optional[McFunctionDataRefSet]
+    ref_calprm_set: Optional[McFunctionDataRefSet]
     sub_function_refs: list[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "DEF-CALPRM-SET-REF": lambda obj, elem: setattr(obj, "def_calprm_set_ref", ARRef.deserialize(elem)),
-        "IN-MEASUREMENT-REF": lambda obj, elem: setattr(obj, "in_measurement_ref", ARRef.deserialize(elem)),
-        "LOC-REF": lambda obj, elem: setattr(obj, "loc_ref", ARRef.deserialize(elem)),
-        "OUT-REF": lambda obj, elem: setattr(obj, "out_ref", ARRef.deserialize(elem)),
-        "REF-CALPRM-SET-REF": lambda obj, elem: setattr(obj, "ref_calprm_set_ref", ARRef.deserialize(elem)),
+        "DEF-CALPRM-SET": lambda obj, elem: setattr(obj, "def_calprm_set", SerializationHelper.deserialize_by_tag(elem, "McFunctionDataRefSet")),
+        "IN-MEASUREMENT-SET": lambda obj, elem: setattr(obj, "in_measurement_set", SerializationHelper.deserialize_by_tag(elem, "McFunctionDataRefSet")),
+        "LOC-MEASUREMENT-SET": lambda obj, elem: setattr(obj, "loc_measurement_set", SerializationHelper.deserialize_by_tag(elem, "McFunctionDataRefSet")),
+        "OUT-MEASUREMENT-SET": lambda obj, elem: setattr(obj, "out_measurement_set", SerializationHelper.deserialize_by_tag(elem, "McFunctionDataRefSet")),
+        "REF-CALPRM-SET": lambda obj, elem: setattr(obj, "ref_calprm_set", SerializationHelper.deserialize_by_tag(elem, "McFunctionDataRefSet")),
         "SUB-FUNCTION-REFS": lambda obj, elem: [obj.sub_function_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
     }
 
@@ -56,11 +56,11 @@ class McFunction(ARElement):
     def __init__(self) -> None:
         """Initialize McFunction."""
         super().__init__()
-        self.def_calprm_set_ref: Optional[ARRef] = None
-        self.in_measurement_ref: Optional[ARRef] = None
-        self.loc_ref: Optional[ARRef] = None
-        self.out_ref: Optional[ARRef] = None
-        self.ref_calprm_set_ref: Optional[ARRef] = None
+        self.def_calprm_set: Optional[McFunctionDataRefSet] = None
+        self.in_measurement_set: Optional[McFunctionDataRefSet] = None
+        self.loc_measurement_set: Optional[McFunctionDataRefSet] = None
+        self.out_measurement_set: Optional[McFunctionDataRefSet] = None
+        self.ref_calprm_set: Optional[McFunctionDataRefSet] = None
         self.sub_function_refs: list[ARRef] = []
 
     def serialize(self) -> ET.Element:
@@ -86,12 +86,12 @@ class McFunction(ARElement):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize def_calprm_set_ref
-        if self.def_calprm_set_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.def_calprm_set_ref, "McFunctionDataRefSet")
+        # Serialize def_calprm_set
+        if self.def_calprm_set is not None:
+            serialized = SerializationHelper.serialize_item(self.def_calprm_set, "McFunctionDataRefSet")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("DEF-CALPRM-SET-REF")
+                wrapped = ET.Element("DEF-CALPRM-SET")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -100,12 +100,12 @@ class McFunction(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize in_measurement_ref
-        if self.in_measurement_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.in_measurement_ref, "McFunctionDataRefSet")
+        # Serialize in_measurement_set
+        if self.in_measurement_set is not None:
+            serialized = SerializationHelper.serialize_item(self.in_measurement_set, "McFunctionDataRefSet")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("IN-MEASUREMENT-REF")
+                wrapped = ET.Element("IN-MEASUREMENT-SET")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -114,12 +114,12 @@ class McFunction(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize loc_ref
-        if self.loc_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.loc_ref, "McFunctionDataRefSet")
+        # Serialize loc_measurement_set
+        if self.loc_measurement_set is not None:
+            serialized = SerializationHelper.serialize_item(self.loc_measurement_set, "McFunctionDataRefSet")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("LOC-REF")
+                wrapped = ET.Element("LOC-MEASUREMENT-SET")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -128,12 +128,12 @@ class McFunction(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize out_ref
-        if self.out_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.out_ref, "McFunctionDataRefSet")
+        # Serialize out_measurement_set
+        if self.out_measurement_set is not None:
+            serialized = SerializationHelper.serialize_item(self.out_measurement_set, "McFunctionDataRefSet")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("OUT-REF")
+                wrapped = ET.Element("OUT-MEASUREMENT-SET")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -142,12 +142,12 @@ class McFunction(ARElement):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize ref_calprm_set_ref
-        if self.ref_calprm_set_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.ref_calprm_set_ref, "McFunctionDataRefSet")
+        # Serialize ref_calprm_set
+        if self.ref_calprm_set is not None:
+            serialized = SerializationHelper.serialize_item(self.ref_calprm_set, "McFunctionDataRefSet")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("REF-CALPRM-SET-REF")
+                wrapped = ET.Element("REF-CALPRM-SET")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -192,16 +192,16 @@ class McFunction(ARElement):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "DEF-CALPRM-SET-REF":
-                setattr(obj, "def_calprm_set_ref", ARRef.deserialize(child))
-            elif tag == "IN-MEASUREMENT-REF":
-                setattr(obj, "in_measurement_ref", ARRef.deserialize(child))
-            elif tag == "LOC-REF":
-                setattr(obj, "loc_ref", ARRef.deserialize(child))
-            elif tag == "OUT-REF":
-                setattr(obj, "out_ref", ARRef.deserialize(child))
-            elif tag == "REF-CALPRM-SET-REF":
-                setattr(obj, "ref_calprm_set_ref", ARRef.deserialize(child))
+            if tag == "DEF-CALPRM-SET":
+                setattr(obj, "def_calprm_set", SerializationHelper.deserialize_by_tag(child, "McFunctionDataRefSet"))
+            elif tag == "IN-MEASUREMENT-SET":
+                setattr(obj, "in_measurement_set", SerializationHelper.deserialize_by_tag(child, "McFunctionDataRefSet"))
+            elif tag == "LOC-MEASUREMENT-SET":
+                setattr(obj, "loc_measurement_set", SerializationHelper.deserialize_by_tag(child, "McFunctionDataRefSet"))
+            elif tag == "OUT-MEASUREMENT-SET":
+                setattr(obj, "out_measurement_set", SerializationHelper.deserialize_by_tag(child, "McFunctionDataRefSet"))
+            elif tag == "REF-CALPRM-SET":
+                setattr(obj, "ref_calprm_set", SerializationHelper.deserialize_by_tag(child, "McFunctionDataRefSet"))
             elif tag == "SUB-FUNCTION-REFS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -234,8 +234,8 @@ class McFunctionBuilder(ARElementBuilder):
         self._obj.def_calprm_set = value
         return self
 
-    def with_in_measurement(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
-        """Set in_measurement attribute.
+    def with_in_measurement_set(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
+        """Set in_measurement_set attribute.
 
         Args:
             value: Value to set
@@ -244,12 +244,12 @@ class McFunctionBuilder(ARElementBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'in_measurement' is required and cannot be None")
-        self._obj.in_measurement = value
+            raise ValueError("Attribute 'in_measurement_set' is required and cannot be None")
+        self._obj.in_measurement_set = value
         return self
 
-    def with_loc(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
-        """Set loc attribute.
+    def with_loc_measurement_set(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
+        """Set loc_measurement_set attribute.
 
         Args:
             value: Value to set
@@ -258,12 +258,12 @@ class McFunctionBuilder(ARElementBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'loc' is required and cannot be None")
-        self._obj.loc = value
+            raise ValueError("Attribute 'loc_measurement_set' is required and cannot be None")
+        self._obj.loc_measurement_set = value
         return self
 
-    def with_out(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
-        """Set out attribute.
+    def with_out_measurement_set(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
+        """Set out_measurement_set attribute.
 
         Args:
             value: Value to set
@@ -272,8 +272,8 @@ class McFunctionBuilder(ARElementBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'out' is required and cannot be None")
-        self._obj.out = value
+            raise ValueError("Attribute 'out_measurement_set' is required and cannot be None")
+        self._obj.out_measurement_set = value
         return self
 
     def with_ref_calprm_set(self, value: Optional[McFunctionDataRefSet]) -> "McFunctionBuilder":
@@ -328,9 +328,9 @@ class McFunctionBuilder(ARElementBuilder):
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
         "defCalprmSet",
-        "inMeasurement",
-        "loc",
-        "out",
+        "inMeasurementSet",
+        "locMeasurementSet",
+        "outMeasurementSet",
         "refCalprmSet",
         "subFunction",
     }

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_support_data.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_support_data.py
@@ -43,16 +43,16 @@ class McSupportData(ARObject):
     _XML_TAG = "MC-SUPPORT-DATA"
 
 
-    emulations: list[McSwEmulationMethodSupport]
-    mc_parameters: list[McDataInstance]
-    mc_variables: list[McDataInstance]
-    measurable_refs: list[ARRef]
+    emulation_supports: list[McSwEmulationMethodSupport]
+    mc_parameter_instances: list[McDataInstance]
+    mc_variable_instances: list[McDataInstance]
+    measurable_system_constant_value_refs: list[ARRef]
     rpt_support_data: Optional[RptSupportData]
     _DESERIALIZE_DISPATCH = {
-        "EMULATIONS": lambda obj, elem: obj.emulations.append(SerializationHelper.deserialize_by_tag(elem, "McSwEmulationMethodSupport")),
-        "MC-PARAMETERS": lambda obj, elem: obj.mc_parameters.append(SerializationHelper.deserialize_by_tag(elem, "McDataInstance")),
-        "MC-VARIABLES": lambda obj, elem: obj.mc_variables.append(SerializationHelper.deserialize_by_tag(elem, "McDataInstance")),
-        "MEASURABLE-REFS": lambda obj, elem: [obj.measurable_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "EMULATION-SUPPORTS": lambda obj, elem: obj.emulation_supports.append(SerializationHelper.deserialize_by_tag(elem, "McSwEmulationMethodSupport")),
+        "MC-PARAMETER-INSTANCES": lambda obj, elem: obj.mc_parameter_instances.append(SerializationHelper.deserialize_by_tag(elem, "McDataInstance")),
+        "MC-VARIABLE-INSTANCES": lambda obj, elem: obj.mc_variable_instances.append(SerializationHelper.deserialize_by_tag(elem, "McDataInstance")),
+        "MEASURABLE-SYSTEM-CONSTANT-VALUES-REFS": lambda obj, elem: [obj.measurable_system_constant_value_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "RPT-SUPPORT-DATA": lambda obj, elem: setattr(obj, "rpt_support_data", SerializationHelper.deserialize_by_tag(elem, "RptSupportData")),
     }
 
@@ -60,10 +60,10 @@ class McSupportData(ARObject):
     def __init__(self) -> None:
         """Initialize McSupportData."""
         super().__init__()
-        self.emulations: list[McSwEmulationMethodSupport] = []
-        self.mc_parameters: list[McDataInstance] = []
-        self.mc_variables: list[McDataInstance] = []
-        self.measurable_refs: list[ARRef] = []
+        self.emulation_supports: list[McSwEmulationMethodSupport] = []
+        self.mc_parameter_instances: list[McDataInstance] = []
+        self.mc_variable_instances: list[McDataInstance] = []
+        self.measurable_system_constant_value_refs: list[ARRef] = []
         self.rpt_support_data: Optional[RptSupportData] = None
 
     def serialize(self) -> ET.Element:
@@ -89,43 +89,43 @@ class McSupportData(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize emulations (list to container "EMULATIONS")
-        if self.emulations:
-            wrapper = ET.Element("EMULATIONS")
-            for item in self.emulations:
+        # Serialize emulation_supports (list to container "EMULATION-SUPPORTS")
+        if self.emulation_supports:
+            wrapper = ET.Element("EMULATION-SUPPORTS")
+            for item in self.emulation_supports:
                 serialized = SerializationHelper.serialize_item(item, "McSwEmulationMethodSupport")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize mc_parameters (list to container "MC-PARAMETERS")
-        if self.mc_parameters:
-            wrapper = ET.Element("MC-PARAMETERS")
-            for item in self.mc_parameters:
+        # Serialize mc_parameter_instances (list to container "MC-PARAMETER-INSTANCES")
+        if self.mc_parameter_instances:
+            wrapper = ET.Element("MC-PARAMETER-INSTANCES")
+            for item in self.mc_parameter_instances:
                 serialized = SerializationHelper.serialize_item(item, "McDataInstance")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize mc_variables (list to container "MC-VARIABLES")
-        if self.mc_variables:
-            wrapper = ET.Element("MC-VARIABLES")
-            for item in self.mc_variables:
+        # Serialize mc_variable_instances (list to container "MC-VARIABLE-INSTANCES")
+        if self.mc_variable_instances:
+            wrapper = ET.Element("MC-VARIABLE-INSTANCES")
+            for item in self.mc_variable_instances:
                 serialized = SerializationHelper.serialize_item(item, "McDataInstance")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
                 elem.append(wrapper)
 
-        # Serialize measurable_refs (list to container "MEASURABLE-REFS")
-        if self.measurable_refs:
-            wrapper = ET.Element("MEASURABLE-REFS")
-            for item in self.measurable_refs:
+        # Serialize measurable_system_constant_value_refs (list to container "MEASURABLE-SYSTEM-CONSTANT-VALUES-REFS")
+        if self.measurable_system_constant_value_refs:
+            wrapper = ET.Element("MEASURABLE-SYSTEM-CONSTANT-VALUES-REFS")
+            for item in self.measurable_system_constant_value_refs:
                 serialized = SerializationHelper.serialize_item(item, "SwSystemconstantValueSet")
                 if serialized is not None:
-                    child_elem = ET.Element("MEASURABLE-REF")
+                    child_elem = ET.Element("MEASURABLE-SYSTEM-CONSTANT-VALUE-REF")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -169,22 +169,22 @@ class McSupportData(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "EMULATIONS":
+            if tag == "EMULATION-SUPPORTS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.emulations.append(SerializationHelper.deserialize_by_tag(item_elem, "McSwEmulationMethodSupport"))
-            elif tag == "MC-PARAMETERS":
+                    obj.emulation_supports.append(SerializationHelper.deserialize_by_tag(item_elem, "McSwEmulationMethodSupport"))
+            elif tag == "MC-PARAMETER-INSTANCES":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.mc_parameters.append(SerializationHelper.deserialize_by_tag(item_elem, "McDataInstance"))
-            elif tag == "MC-VARIABLES":
+                    obj.mc_parameter_instances.append(SerializationHelper.deserialize_by_tag(item_elem, "McDataInstance"))
+            elif tag == "MC-VARIABLE-INSTANCES":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.mc_variables.append(SerializationHelper.deserialize_by_tag(item_elem, "McDataInstance"))
-            elif tag == "MEASURABLE-REFS":
+                    obj.mc_variable_instances.append(SerializationHelper.deserialize_by_tag(item_elem, "McDataInstance"))
+            elif tag == "MEASURABLE-SYSTEM-CONSTANT-VALUES-REFS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.measurable_refs.append(ARRef.deserialize(item_elem))
+                    obj.measurable_system_constant_value_refs.append(ARRef.deserialize(item_elem))
             elif tag == "RPT-SUPPORT-DATA":
                 setattr(obj, "rpt_support_data", SerializationHelper.deserialize_by_tag(child, "RptSupportData"))
 
@@ -201,8 +201,8 @@ class McSupportDataBuilder(BuilderBase):
         self._obj: McSupportData = McSupportData()
 
 
-    def with_emulations(self, items: list[McSwEmulationMethodSupport]) -> "McSupportDataBuilder":
-        """Set emulations list attribute.
+    def with_emulation_supports(self, items: list[McSwEmulationMethodSupport]) -> "McSupportDataBuilder":
+        """Set emulation_supports list attribute.
 
         Args:
             items: List of items to set
@@ -210,11 +210,11 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.emulations = list(items) if items else []
+        self._obj.emulation_supports = list(items) if items else []
         return self
 
-    def with_mc_parameters(self, items: list[McDataInstance]) -> "McSupportDataBuilder":
-        """Set mc_parameters list attribute.
+    def with_mc_parameter_instances(self, items: list[McDataInstance]) -> "McSupportDataBuilder":
+        """Set mc_parameter_instances list attribute.
 
         Args:
             items: List of items to set
@@ -222,11 +222,11 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mc_parameters = list(items) if items else []
+        self._obj.mc_parameter_instances = list(items) if items else []
         return self
 
-    def with_mc_variables(self, items: list[McDataInstance]) -> "McSupportDataBuilder":
-        """Set mc_variables list attribute.
+    def with_mc_variable_instances(self, items: list[McDataInstance]) -> "McSupportDataBuilder":
+        """Set mc_variable_instances list attribute.
 
         Args:
             items: List of items to set
@@ -234,11 +234,11 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mc_variables = list(items) if items else []
+        self._obj.mc_variable_instances = list(items) if items else []
         return self
 
-    def with_measurables(self, items: list[SwSystemconstantValueSet]) -> "McSupportDataBuilder":
-        """Set measurables list attribute.
+    def with_measurable_system_constant_valueses(self, items: list[SwSystemconstantValueSet]) -> "McSupportDataBuilder":
+        """Set measurable_system_constant_valueses list attribute.
 
         Args:
             items: List of items to set
@@ -246,7 +246,7 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.measurables = list(items) if items else []
+        self._obj.measurable_system_constant_valueses = list(items) if items else []
         return self
 
     def with_rpt_support_data(self, value: Optional[RptSupportData]) -> "McSupportDataBuilder":
@@ -264,8 +264,8 @@ class McSupportDataBuilder(BuilderBase):
         return self
 
 
-    def add_emulation(self, item: McSwEmulationMethodSupport) -> "McSupportDataBuilder":
-        """Add a single item to emulations list.
+    def add_emulation_support(self, item: McSwEmulationMethodSupport) -> "McSupportDataBuilder":
+        """Add a single item to emulation_supports list.
 
         Args:
             item: Item to add
@@ -273,20 +273,20 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.emulations.append(item)
+        self._obj.emulation_supports.append(item)
         return self
 
-    def clear_emulations(self) -> "McSupportDataBuilder":
-        """Clear all items from emulations list.
+    def clear_emulation_supports(self) -> "McSupportDataBuilder":
+        """Clear all items from emulation_supports list.
 
         Returns:
             self for method chaining
         """
-        self._obj.emulations = []
+        self._obj.emulation_supports = []
         return self
 
-    def add_mc_parameter(self, item: McDataInstance) -> "McSupportDataBuilder":
-        """Add a single item to mc_parameters list.
+    def add_mc_parameter_instance(self, item: McDataInstance) -> "McSupportDataBuilder":
+        """Add a single item to mc_parameter_instances list.
 
         Args:
             item: Item to add
@@ -294,20 +294,20 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mc_parameters.append(item)
+        self._obj.mc_parameter_instances.append(item)
         return self
 
-    def clear_mc_parameters(self) -> "McSupportDataBuilder":
-        """Clear all items from mc_parameters list.
+    def clear_mc_parameter_instances(self) -> "McSupportDataBuilder":
+        """Clear all items from mc_parameter_instances list.
 
         Returns:
             self for method chaining
         """
-        self._obj.mc_parameters = []
+        self._obj.mc_parameter_instances = []
         return self
 
-    def add_mc_variable(self, item: McDataInstance) -> "McSupportDataBuilder":
-        """Add a single item to mc_variables list.
+    def add_mc_variable_instance(self, item: McDataInstance) -> "McSupportDataBuilder":
+        """Add a single item to mc_variable_instances list.
 
         Args:
             item: Item to add
@@ -315,20 +315,20 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.mc_variables.append(item)
+        self._obj.mc_variable_instances.append(item)
         return self
 
-    def clear_mc_variables(self) -> "McSupportDataBuilder":
-        """Clear all items from mc_variables list.
+    def clear_mc_variable_instances(self) -> "McSupportDataBuilder":
+        """Clear all items from mc_variable_instances list.
 
         Returns:
             self for method chaining
         """
-        self._obj.mc_variables = []
+        self._obj.mc_variable_instances = []
         return self
 
-    def add_measurable(self, item: SwSystemconstantValueSet) -> "McSupportDataBuilder":
-        """Add a single item to measurables list.
+    def add_measurable_system_constant_values(self, item: SwSystemconstantValueSet) -> "McSupportDataBuilder":
+        """Add a single item to measurable_system_constant_valueses list.
 
         Args:
             item: Item to add
@@ -336,25 +336,25 @@ class McSupportDataBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.measurables.append(item)
+        self._obj.measurable_system_constant_valueses.append(item)
         return self
 
-    def clear_measurables(self) -> "McSupportDataBuilder":
-        """Clear all items from measurables list.
+    def clear_measurable_system_constant_valueses(self) -> "McSupportDataBuilder":
+        """Clear all items from measurable_system_constant_valueses list.
 
         Returns:
             self for method chaining
         """
-        self._obj.measurables = []
+        self._obj.measurable_system_constant_valueses = []
         return self
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "emulation",
-        "mcParameter",
-        "mcVariable",
-        "measurable",
+        "emulationSupport",
+        "mcParameterInstance",
+        "mcVariableInstance",
+        "measurableSystemConstantValues",
         "rptSupportData",
     }
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/role_based_mc_data_assignment.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/role_based_mc_data_assignment.py
@@ -42,11 +42,11 @@ class RoleBasedMcDataAssignment(ARObject):
     _XML_TAG = "ROLE-BASED-MC-DATA-ASSIGNMENT"
 
 
-    execution_refs: list[ARRef]
+    execution_context_refs: list[ARRef]
     mc_data_instance_refs: list[ARRef]
     role: Optional[Identifier]
     _DESERIALIZE_DISPATCH = {
-        "EXECUTION-REFS": lambda obj, elem: [obj.execution_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "EXECUTION-CONTEXT-REFS": lambda obj, elem: [obj.execution_context_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "MC-DATA-INSTANCE-REFS": lambda obj, elem: [obj.mc_data_instance_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "ROLE": lambda obj, elem: setattr(obj, "role", SerializationHelper.deserialize_by_tag(elem, "Identifier")),
     }
@@ -55,7 +55,7 @@ class RoleBasedMcDataAssignment(ARObject):
     def __init__(self) -> None:
         """Initialize RoleBasedMcDataAssignment."""
         super().__init__()
-        self.execution_refs: list[ARRef] = []
+        self.execution_context_refs: list[ARRef] = []
         self.mc_data_instance_refs: list[ARRef] = []
         self.role: Optional[Identifier] = None
 
@@ -82,13 +82,13 @@ class RoleBasedMcDataAssignment(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize execution_refs (list to container "EXECUTION-REFS")
-        if self.execution_refs:
-            wrapper = ET.Element("EXECUTION-REFS")
-            for item in self.execution_refs:
+        # Serialize execution_context_refs (list to container "EXECUTION-CONTEXT-REFS")
+        if self.execution_context_refs:
+            wrapper = ET.Element("EXECUTION-CONTEXT-REFS")
+            for item in self.execution_context_refs:
                 serialized = SerializationHelper.serialize_item(item, "RptExecutionContext")
                 if serialized is not None:
-                    child_elem = ET.Element("EXECUTION-REF")
+                    child_elem = ET.Element("EXECUTION-CONTEXT-REF")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -149,10 +149,10 @@ class RoleBasedMcDataAssignment(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "EXECUTION-REFS":
+            if tag == "EXECUTION-CONTEXT-REFS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.execution_refs.append(ARRef.deserialize(item_elem))
+                    obj.execution_context_refs.append(ARRef.deserialize(item_elem))
             elif tag == "MC-DATA-INSTANCE-REFS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -173,8 +173,8 @@ class RoleBasedMcDataAssignmentBuilder(BuilderBase):
         self._obj: RoleBasedMcDataAssignment = RoleBasedMcDataAssignment()
 
 
-    def with_executions(self, items: list[RptExecutionContext]) -> "RoleBasedMcDataAssignmentBuilder":
-        """Set executions list attribute.
+    def with_execution_contexts(self, items: list[RptExecutionContext]) -> "RoleBasedMcDataAssignmentBuilder":
+        """Set execution_contexts list attribute.
 
         Args:
             items: List of items to set
@@ -182,7 +182,7 @@ class RoleBasedMcDataAssignmentBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.executions = list(items) if items else []
+        self._obj.execution_contexts = list(items) if items else []
         return self
 
     def with_mc_data_instances(self, items: list[McDataInstance]) -> "RoleBasedMcDataAssignmentBuilder":
@@ -212,8 +212,8 @@ class RoleBasedMcDataAssignmentBuilder(BuilderBase):
         return self
 
 
-    def add_execution(self, item: RptExecutionContext) -> "RoleBasedMcDataAssignmentBuilder":
-        """Add a single item to executions list.
+    def add_execution_context(self, item: RptExecutionContext) -> "RoleBasedMcDataAssignmentBuilder":
+        """Add a single item to execution_contexts list.
 
         Args:
             item: Item to add
@@ -221,16 +221,16 @@ class RoleBasedMcDataAssignmentBuilder(BuilderBase):
         Returns:
             self for method chaining
         """
-        self._obj.executions.append(item)
+        self._obj.execution_contexts.append(item)
         return self
 
-    def clear_executions(self) -> "RoleBasedMcDataAssignmentBuilder":
-        """Clear all items from executions list.
+    def clear_execution_contexts(self) -> "RoleBasedMcDataAssignmentBuilder":
+        """Clear all items from execution_contexts list.
 
         Returns:
             self for method chaining
         """
-        self._obj.executions = []
+        self._obj.execution_contexts = []
         return self
 
     def add_mc_data_instance(self, item: McDataInstance) -> "RoleBasedMcDataAssignmentBuilder":
@@ -257,7 +257,7 @@ class RoleBasedMcDataAssignmentBuilder(BuilderBase):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "execution",
+        "executionContext",
         "mcDataInstance",
         "role",
     }

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
@@ -34,6 +34,9 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger.internal_triggering_point import (
     InternalTriggeringPoint,
 )
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RunnableEntity.runnable_entity_argument import (
+    RunnableEntityArgument,
+)
 
 if TYPE_CHECKING:
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ModeDeclarationGroup.mode_access_point import (
@@ -74,7 +77,7 @@ class RunnableEntity(ExecutableEntity):
     _XML_TAG = "RUNNABLE-ENTITY"
 
 
-    arguments: list[RunnableEntity]
+    arguments: list[RunnableEntityArgument]
     asynchronous_server_call_result_points: list[AsynchronousServerCallResultPoint]
     can_be_invoked_concurrently: Optional[Boolean]
     data_read_accesses: list[VariableAccess]
@@ -93,7 +96,7 @@ class RunnableEntity(ExecutableEntity):
     wait_points: list[WaitPoint]
     _written_local_variables: list[VariableAccess]
     _DESERIALIZE_DISPATCH = {
-        "ARGUMENTS": lambda obj, elem: obj.arguments.append(SerializationHelper.deserialize_by_tag(elem, "RunnableEntity")),
+        "ARGUMENTS": lambda obj, elem: obj.arguments.append(SerializationHelper.deserialize_by_tag(elem, "RunnableEntityArgument")),
         "ASYNCHRONOUS-SERVER-CALL-RESULT-POINTS": lambda obj, elem: obj.asynchronous_server_call_result_points.append(SerializationHelper.deserialize_by_tag(elem, "AsynchronousServerCallResultPoint")),
         "CAN-BE-INVOKED-CONCURRENTLY": lambda obj, elem: setattr(obj, "can_be_invoked_concurrently", SerializationHelper.deserialize_by_tag(elem, "Boolean")),
         "DATA-READ-ACCESSS": lambda obj, elem: obj.data_read_accesses.append(SerializationHelper.deserialize_by_tag(elem, "VariableAccess")),
@@ -117,7 +120,7 @@ class RunnableEntity(ExecutableEntity):
     def __init__(self) -> None:
         """Initialize RunnableEntity."""
         super().__init__()
-        self.arguments: list[RunnableEntity] = []
+        self.arguments: list[RunnableEntityArgument] = []
         self.asynchronous_server_call_result_points: list[AsynchronousServerCallResultPoint] = []
         self.can_be_invoked_concurrently: Optional[Boolean] = None
         self.data_read_accesses: list[VariableAccess] = []
@@ -207,7 +210,7 @@ class RunnableEntity(ExecutableEntity):
         if self.arguments:
             wrapper = ET.Element("ARGUMENTS")
             for item in self.arguments:
-                serialized = SerializationHelper.serialize_item(item, "RunnableEntity")
+                serialized = SerializationHelper.serialize_item(item, "RunnableEntityArgument")
                 if serialized is not None:
                     wrapper.append(serialized)
             if len(wrapper) > 0:
@@ -427,7 +430,7 @@ class RunnableEntity(ExecutableEntity):
             if tag == "ARGUMENTS":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.arguments.append(SerializationHelper.deserialize_by_tag(item_elem, "RunnableEntity"))
+                    obj.arguments.append(SerializationHelper.deserialize_by_tag(item_elem, "RunnableEntityArgument"))
             elif tag == "ASYNCHRONOUS-SERVER-CALL-RESULT-POINTS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -510,7 +513,7 @@ class RunnableEntityBuilder(ExecutableEntityBuilder):
         self._obj: RunnableEntity = RunnableEntity()
 
 
-    def with_arguments(self, items: list[RunnableEntity]) -> "RunnableEntityBuilder":
+    def with_arguments(self, items: list[RunnableEntityArgument]) -> "RunnableEntityBuilder":
         """Set arguments list attribute.
 
         Args:
@@ -731,7 +734,7 @@ class RunnableEntityBuilder(ExecutableEntityBuilder):
         return self
 
 
-    def add_argument(self, item: RunnableEntity) -> "RunnableEntityBuilder":
+    def add_argument(self, item: RunnableEntityArgument) -> "RunnableEntityBuilder":
         """Add a single item to arguments list.
 
         Args:

--- a/src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_scale.py
+++ b/src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_scale.py
@@ -108,10 +108,10 @@ class CompuScale(ARObject):
     compu_inverse_value: Optional[CompuConst]
     compu_scale_contents: Optional[CompuScaleContents]
     desc: Optional[MultiLanguageOverviewParagraph]
-    lower_limit: Optional[Limit]
-    mask: Optional[PositiveUnlimitedInteger]
     short_label: Optional[Identifier]
     symbol: Optional[CIdentifier]
+    mask: Optional[PositiveUnlimitedInteger]
+    lower_limit: Optional[Limit]
     upper_limit: Optional[Limit]
     def __init__(self) -> None:
         """Initialize CompuScale."""
@@ -120,10 +120,10 @@ class CompuScale(ARObject):
         self.compu_inverse_value: Optional[CompuConst] = None
         self.compu_scale_contents: Optional[CompuScaleContents] = None
         self.desc: Optional[MultiLanguageOverviewParagraph] = None
-        self.lower_limit: Optional[Limit] = None
-        self.mask: Optional[PositiveUnlimitedInteger] = None
         self.short_label: Optional[Identifier] = None
         self.symbol: Optional[CIdentifier] = None
+        self.mask: Optional[PositiveUnlimitedInteger] = None
+        self.lower_limit: Optional[Limit] = None
         self.upper_limit: Optional[Limit] = None
 
     def serialize(self) -> ET.Element:
@@ -273,24 +273,24 @@ class CompuScale(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Reorder elements to match AUTOSAR XML schema order
-        # The correct order is: DESC, LOWER-LIMIT, UPPER-LIMIT, COMPU-CONST/COMPU-RATIONAL-COEFFS, ...
+        # Reorder elements to match AUTOSAR XML schema order (matching JSON file order)
+        # The correct order is: DESC, SHORT-LABEL, SYMBOL, MASK, LOWER-LIMIT, UPPER-LIMIT, ...
         # Extract all children and reorder them
         children = list(elem)
         elem.clear()  # Remove all children
 
-        # Define the desired order of elements
+        # Define the desired order of elements (matching JSON file order)
         element_order = [
             "DESC",
+            "SHORT-LABEL",
+            "SYMBOL",
+            "MASK",
             "LOWER-LIMIT",
             "UPPER-LIMIT",
             "COMPU-CONST",
             "COMPU-RATIONAL-COEFFS",
             "COMPU-INVERSE-VALUE",
             "A2L-DISPLAY-TEXT",
-            "MASK",
-            "SHORT-LABEL",
-            "SYMBOL",
         ]
 
         # Add elements in the desired order

--- a/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py
+++ b/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py
@@ -16,7 +16,6 @@ from armodel2.models.M2.MSR.DataDictionary.CalibrationParameter import (
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Numerical,
-    VerbatimString,
 )
 from armodel2.models.M2.MSR.DataDictionary.RecordLayout import (
     AxisIndexType,
@@ -61,11 +60,11 @@ class SwAxisCont(ARObject):
     category: Optional[CalprmAxisCategoryEnum]
     sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
+    vts: list[Numerical]
     sw_axis_index: Optional[AxisIndexType]
     sw_values_phys: Optional[SwValues]
     vf: Optional[Numerical]
     vg: Optional[ValueGroup]
-    vt: Optional[VerbatimString]
     vtf: Optional[NumericalOrText]
     unit_ref: Optional[ARRef]
     unit_display: Optional[SingleLanguageUnitNames]
@@ -73,11 +72,11 @@ class SwAxisCont(ARObject):
         "CATEGORY": lambda obj, elem: setattr(obj, "category", CalprmAxisCategoryEnum.deserialize(elem)),
         "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-AXIS-INDEX": lambda obj, elem: setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(elem, "AxisIndexType")),
         "SW-VALUES-PHYS": lambda obj, elem: setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(elem, "SwValues")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VG": lambda obj, elem: setattr(obj, "vg", SerializationHelper.deserialize_by_tag(elem, "ValueGroup")),
-        "VT": lambda obj, elem: setattr(obj, "vt", SerializationHelper.deserialize_by_tag(elem, "VerbatimString")),
         "VTF": lambda obj, elem: setattr(obj, "vtf", SerializationHelper.deserialize_by_tag(elem, "NumericalOrText")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
         "UNIT-DISPLAY": lambda obj, elem: setattr(obj, "unit_display", SerializationHelper.deserialize_by_tag(elem, "SingleLanguageUnitNames")),
@@ -90,11 +89,11 @@ class SwAxisCont(ARObject):
         self.category: Optional[CalprmAxisCategoryEnum] = None
         self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
         self.sw_axis_index: Optional[AxisIndexType] = None
         self.sw_values_phys: Optional[SwValues] = None
         self.vf: Optional[Numerical] = None
         self.vg: Optional[ValueGroup] = None
-        self.vt: Optional[VerbatimString] = None
         self.vtf: Optional[NumericalOrText] = None
         self.unit_ref: Optional[ARRef] = None
         self.unit_display: Optional[SingleLanguageUnitNames] = None
@@ -163,6 +162,23 @@ class SwAxisCont(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize vts (list to container "VTS")
+        if self.vts:
+            wrapper = ET.Element("VTS")
+            for item in self.vts:
+                serialized = SerializationHelper.serialize_item(item, "Numerical")
+                if serialized is not None:
+                    child_elem = ET.Element("VT")
+                    if hasattr(serialized, 'attrib'):
+                        child_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        child_elem.text = serialized.text
+                    for child in serialized:
+                        child_elem.append(child)
+                    wrapper.append(child_elem)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize sw_axis_index
         if self.sw_axis_index is not None:
             serialized = SerializationHelper.serialize_item(self.sw_axis_index, "AxisIndexType")
@@ -210,20 +226,6 @@ class SwAxisCont(ARObject):
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("VG")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
-
-        # Serialize vt
-        if self.vt is not None:
-            serialized = SerializationHelper.serialize_item(self.vt, "VerbatimString")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("VT")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -299,6 +301,10 @@ class SwAxisCont(ARObject):
                 setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "VTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.vts.append(SerializationHelper.deserialize_by_tag(item_elem, "Numerical"))
             elif tag == "SW-AXIS-INDEX":
                 setattr(obj, "sw_axis_index", SerializationHelper.deserialize_by_tag(child, "AxisIndexType"))
             elif tag == "SW-VALUES-PHYS":
@@ -307,8 +313,6 @@ class SwAxisCont(ARObject):
                 setattr(obj, "vf", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VG":
                 setattr(obj, "vg", SerializationHelper.deserialize_by_tag(child, "ValueGroup"))
-            elif tag == "VT":
-                setattr(obj, "vt", SerializationHelper.deserialize_by_tag(child, "VerbatimString"))
             elif tag == "VTF":
                 setattr(obj, "vtf", SerializationHelper.deserialize_by_tag(child, "NumericalOrText"))
             elif tag == "UNIT-REF":
@@ -371,6 +375,18 @@ class SwAxisContBuilder(BuilderBase):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "SwAxisContBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
     def with_sw_axis_index(self, value: Optional[AxisIndexType]) -> "SwAxisContBuilder":
         """Set sw_axis_index attribute.
 
@@ -427,20 +443,6 @@ class SwAxisContBuilder(BuilderBase):
         self._obj.vg = value
         return self
 
-    def with_vt(self, value: Optional[VerbatimString]) -> "SwAxisContBuilder":
-        """Set vt attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not True:
-            raise ValueError("Attribute 'vt' is required and cannot be None")
-        self._obj.vt = value
-        return self
-
     def with_vtf(self, value: Optional[NumericalOrText]) -> "SwAxisContBuilder":
         """Set vtf attribute.
 
@@ -483,6 +485,27 @@ class SwAxisContBuilder(BuilderBase):
         self._obj.unit_display = value
         return self
 
+
+    def add_vt(self, item: Numerical) -> "SwAxisContBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "SwAxisContBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)

--- a/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py
+++ b/src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py
@@ -13,7 +13,6 @@ from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     Numerical,
-    VerbatimString,
 )
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Constants.numerical_or_text import (
     NumericalOrText,
@@ -54,20 +53,20 @@ class SwValueCont(ARObject):
 
     sw_arraysize_ref: Optional[ARRef]
     v: Optional[Numerical]
+    vts: list[Numerical]
     sw_values_phys: Optional[SwValues]
     vf: Optional[Numerical]
     vg: Optional[ValueGroup]
-    vt: Optional[VerbatimString]
     vtf: Optional[NumericalOrText]
     unit_ref: Optional[ARRef]
     unit_display: Optional[SingleLanguageUnitNames]
     _DESERIALIZE_DISPATCH = {
         "SW-ARRAYSIZE-REF": lambda obj, elem: setattr(obj, "sw_arraysize_ref", ARRef.deserialize(elem)),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-VALUES-PHYS": lambda obj, elem: setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(elem, "SwValues")),
         "VF": lambda obj, elem: setattr(obj, "vf", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "VG": lambda obj, elem: setattr(obj, "vg", SerializationHelper.deserialize_by_tag(elem, "ValueGroup")),
-        "VT": lambda obj, elem: setattr(obj, "vt", SerializationHelper.deserialize_by_tag(elem, "VerbatimString")),
         "VTF": lambda obj, elem: setattr(obj, "vtf", SerializationHelper.deserialize_by_tag(elem, "NumericalOrText")),
         "UNIT-REF": lambda obj, elem: setattr(obj, "unit_ref", ARRef.deserialize(elem)),
         "UNIT-DISPLAY": lambda obj, elem: setattr(obj, "unit_display", SerializationHelper.deserialize_by_tag(elem, "SingleLanguageUnitNames")),
@@ -79,10 +78,10 @@ class SwValueCont(ARObject):
         super().__init__()
         self.sw_arraysize_ref: Optional[ARRef] = None
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
         self.sw_values_phys: Optional[SwValues] = None
         self.vf: Optional[Numerical] = None
         self.vg: Optional[ValueGroup] = None
-        self.vt: Optional[VerbatimString] = None
         self.vtf: Optional[NumericalOrText] = None
         self.unit_ref: Optional[ARRef] = None
         self.unit_display: Optional[SingleLanguageUnitNames] = None
@@ -137,6 +136,23 @@ class SwValueCont(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize vts (list to container "VTS")
+        if self.vts:
+            wrapper = ET.Element("VTS")
+            for item in self.vts:
+                serialized = SerializationHelper.serialize_item(item, "Numerical")
+                if serialized is not None:
+                    child_elem = ET.Element("VT")
+                    if hasattr(serialized, 'attrib'):
+                        child_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        child_elem.text = serialized.text
+                    for child in serialized:
+                        child_elem.append(child)
+                    wrapper.append(child_elem)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize sw_values_phys (atp_mixed - append children directly)
         if self.sw_values_phys is not None:
             serialized = SerializationHelper.serialize_item(self.sw_values_phys, "SwValues")
@@ -170,20 +186,6 @@ class SwValueCont(ARObject):
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("VG")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
-                for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
-
-        # Serialize vt
-        if self.vt is not None:
-            serialized = SerializationHelper.serialize_item(self.vt, "VerbatimString")
-            if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("VT")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -257,14 +259,16 @@ class SwValueCont(ARObject):
                 setattr(obj, "sw_arraysize_ref", ARRef.deserialize(child))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "VTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.vts.append(SerializationHelper.deserialize_by_tag(item_elem, "Numerical"))
             elif tag == "SW-VALUES-PHYS":
                 setattr(obj, "sw_values_phys", SerializationHelper.deserialize_by_tag(child, "SwValues"))
             elif tag == "VF":
                 setattr(obj, "vf", SerializationHelper.deserialize_by_tag(child, "Numerical"))
             elif tag == "VG":
                 setattr(obj, "vg", SerializationHelper.deserialize_by_tag(child, "ValueGroup"))
-            elif tag == "VT":
-                setattr(obj, "vt", SerializationHelper.deserialize_by_tag(child, "VerbatimString"))
             elif tag == "VTF":
                 setattr(obj, "vtf", SerializationHelper.deserialize_by_tag(child, "NumericalOrText"))
             elif tag == "UNIT-REF":
@@ -313,6 +317,18 @@ class SwValueContBuilder(BuilderBase):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "SwValueContBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
     def with_sw_values_phys(self, value: Optional[SwValues]) -> "SwValueContBuilder":
         """Set sw_values_phys attribute.
 
@@ -353,20 +369,6 @@ class SwValueContBuilder(BuilderBase):
         if value is None and not True:
             raise ValueError("Attribute 'vg' is required and cannot be None")
         self._obj.vg = value
-        return self
-
-    def with_vt(self, value: Optional[VerbatimString]) -> "SwValueContBuilder":
-        """Set vt attribute.
-
-        Args:
-            value: Value to set
-
-        Returns:
-            self for method chaining
-        """
-        if value is None and not True:
-            raise ValueError("Attribute 'vt' is required and cannot be None")
-        self._obj.vt = value
         return self
 
     def with_vtf(self, value: Optional[NumericalOrText]) -> "SwValueContBuilder":
@@ -411,6 +413,27 @@ class SwValueContBuilder(BuilderBase):
         self._obj.unit_display = value
         return self
 
+
+    def add_vt(self, item: Numerical) -> "SwValueContBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "SwValueContBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_def_props.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_def_props.py
@@ -58,9 +58,6 @@ from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_bit_representati
 from armodel2.models.M2.MSR.DataDictionary.CalibrationParameter.sw_calprm_axis_set import (
     SwCalprmAxisSet,
 )
-from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_data_dependency import (
-    SwDataDependency,
-)
 from armodel2.models.M2.MSR.DataDictionary.RecordLayout.sw_record_layout import (
     SwRecordLayout,
 )
@@ -77,6 +74,9 @@ if TYPE_CHECKING:
     )
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.Datatypes.application_primitive_data_type import (
         ApplicationPrimitiveDataType,
+    )
+    from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_data_dependency import (
+        SwDataDependency,
     )
     from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_pointer_target_props import (
         SwPointerTargetProps,

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency.py
@@ -13,10 +13,22 @@ from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.MSR.AsamHdo.ComputationMethod.compu_generic_math import (
     CompuGenericMath,
 )
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_calprm_ref_proxy import (
+        SwCalprmRefProxy,
+    )
+    from armodel2.models.M2.MSR.DataDictionary.DataDefProperties.sw_data_dependency_args import (
+        SwDataDependencyArgs,
+    )
+    from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_variable_ref_proxy import (
+        SwVariableRefProxy,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class SwDataDependency(ARObject):
     """AUTOSAR SwDataDependency."""
 
@@ -32,16 +44,25 @@ class SwDataDependency(ARObject):
     _XML_TAG = "SW-DATA-DEPENDENCY"
 
 
-    sw_data: Optional[CompuGenericMath]
+    sw_data_dependency_args: Optional[SwDataDependencyArgs]
+    sw_calprm_ref: Optional[SwCalprmRefProxy]
+    sw_variable: Optional[SwVariableRefProxy]
+    sw_data_dependency_formula: Optional[CompuGenericMath]
     _DESERIALIZE_DISPATCH = {
-        "SW-DATA": lambda obj, elem: setattr(obj, "sw_data", SerializationHelper.deserialize_by_tag(elem, "CompuGenericMath")),
+        "SW-DATA-DEPENDENCY-ARGS": lambda obj, elem: setattr(obj, "sw_data_dependency_args", SerializationHelper.deserialize_by_tag(elem, "SwDataDependencyArgs")),
+        "SW-CALPRM-REF": lambda obj, elem: setattr(obj, "sw_calprm_ref", SerializationHelper.deserialize_by_tag(elem, "SwCalprmRefProxy")),
+        "SW-VARIABLE": lambda obj, elem: setattr(obj, "sw_variable", SerializationHelper.deserialize_by_tag(elem, "SwVariableRefProxy")),
+        "SW-DATA-DEPENDENCY-FORMULA": lambda obj, elem: setattr(obj, "sw_data_dependency_formula", SerializationHelper.deserialize_by_tag(elem, "CompuGenericMath")),
     }
 
 
     def __init__(self) -> None:
         """Initialize SwDataDependency."""
         super().__init__()
-        self.sw_data: Optional[CompuGenericMath] = None
+        self.sw_data_dependency_args: Optional[SwDataDependencyArgs] = None
+        self.sw_calprm_ref: Optional[SwCalprmRefProxy] = None
+        self.sw_variable: Optional[SwVariableRefProxy] = None
+        self.sw_data_dependency_formula: Optional[CompuGenericMath] = None
 
     def serialize(self) -> ET.Element:
         """Serialize SwDataDependency to XML element.
@@ -66,12 +87,53 @@ class SwDataDependency(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize sw_data
-        if self.sw_data is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_data, "CompuGenericMath")
+        # Serialize sw_data_dependency_args (atp_mixed - append children directly)
+        if self.sw_data_dependency_args is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_data_dependency_args, "SwDataDependencyArgs")
+            if serialized is not None:
+                # atpMixed type: append children directly without wrapper
+                if hasattr(serialized, 'attrib'):
+                    elem.attrib.update(serialized.attrib)
+                # Only copy text if it's a non-empty string (not None or whitespace)
+                if serialized.text and serialized.text.strip():
+                    elem.text = serialized.text
+                for child in serialized:
+                    elem.append(child)
+
+        # Serialize sw_calprm_ref
+        if self.sw_calprm_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_calprm_ref, "SwCalprmRefProxy")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("SW-DATA")
+                wrapped = ET.Element("SW-CALPRM-REF")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_variable
+        if self.sw_variable is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_variable, "SwVariableRefProxy")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-VARIABLE")
+                if hasattr(serialized, 'attrib'):
+                    wrapped.attrib.update(serialized.attrib)
+                if serialized.text:
+                    wrapped.text = serialized.text
+                for child in serialized:
+                    wrapped.append(child)
+                elem.append(wrapped)
+
+        # Serialize sw_data_dependency_formula
+        if self.sw_data_dependency_formula is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_data_dependency_formula, "CompuGenericMath")
+            if serialized is not None:
+                # Wrap with correct tag
+                wrapped = ET.Element("SW-DATA-DEPENDENCY-FORMULA")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -99,8 +161,14 @@ class SwDataDependency(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "SW-DATA":
-                setattr(obj, "sw_data", SerializationHelper.deserialize_by_tag(child, "CompuGenericMath"))
+            if tag == "SW-DATA-DEPENDENCY-ARGS":
+                setattr(obj, "sw_data_dependency_args", SerializationHelper.deserialize_by_tag(child, "SwDataDependencyArgs"))
+            elif tag == "SW-CALPRM-REF":
+                setattr(obj, "sw_calprm_ref", SerializationHelper.deserialize_by_tag(child, "SwCalprmRefProxy"))
+            elif tag == "SW-VARIABLE":
+                setattr(obj, "sw_variable", SerializationHelper.deserialize_by_tag(child, "SwVariableRefProxy"))
+            elif tag == "SW-DATA-DEPENDENCY-FORMULA":
+                setattr(obj, "sw_data_dependency_formula", SerializationHelper.deserialize_by_tag(child, "CompuGenericMath"))
 
         return obj
 
@@ -115,8 +183,8 @@ class SwDataDependencyBuilder(BuilderBase):
         self._obj: SwDataDependency = SwDataDependency()
 
 
-    def with_sw_data(self, value: Optional[CompuGenericMath]) -> "SwDataDependencyBuilder":
-        """Set sw_data attribute.
+    def with_sw_data_dependency_args(self, value: Optional[SwDataDependencyArgs]) -> "SwDataDependencyBuilder":
+        """Set sw_data_dependency_args attribute.
 
         Args:
             value: Value to set
@@ -125,15 +193,58 @@ class SwDataDependencyBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'sw_data' is required and cannot be None")
-        self._obj.sw_data = value
+            raise ValueError("Attribute 'sw_data_dependency_args' is required and cannot be None")
+        self._obj.sw_data_dependency_args = value
+        return self
+
+    def with_sw_calprm_ref(self, value: Optional[SwCalprmRefProxy]) -> "SwDataDependencyBuilder":
+        """Set sw_calprm_ref attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_calprm_ref' is required and cannot be None")
+        self._obj.sw_calprm_ref = value
+        return self
+
+    def with_sw_variable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDependencyBuilder":
+        """Set sw_variable attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_variable' is required and cannot be None")
+        self._obj.sw_variable = value
+        return self
+
+    def with_sw_data_dependency_formula(self, value: Optional[CompuGenericMath]) -> "SwDataDependencyBuilder":
+        """Set sw_data_dependency_formula attribute.
+
+        Args:
+            value: Value to set
+
+        Returns:
+            self for method chaining
+        """
+        if value is None and not True:
+            raise ValueError("Attribute 'sw_data_dependency_formula' is required and cannot be None")
+        self._obj.sw_data_dependency_formula = value
         return self
 
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "swData",
+        "swDataDependencyArgs",
+        "swDataDependencyFormula",
     }
 
 

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency_args.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency_args.py
@@ -11,17 +11,19 @@ import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import atp_mixed
 
 from armodel2.models.M2.builder_base import BuilderBase
-from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_calprm_ref_proxy import (
-    SwCalprmRefProxy,
-)
-from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_variable_ref_proxy import (
-    SwVariableRefProxy,
-)
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_calprm_ref_proxy import (
+        SwCalprmRefProxy,
+    )
+    from armodel2.models.M2.MSR.DataDictionary.DatadictionaryProxies.sw_variable_ref_proxy import (
+        SwVariableRefProxy,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 @atp_mixed()
 
 class SwDataDependencyArgs(ARObject):
@@ -39,19 +41,19 @@ class SwDataDependencyArgs(ARObject):
     _XML_TAG = "SW-DATA-DEPENDENCY-ARGS"
 
 
-    sw_calprm_ref_proxy_ref: Optional[ARRef]
-    sw_variable_ref_proxy_ref: Optional[ARRef]
+    sw_calprm_ref: Optional[SwCalprmRefProxy]
+    sw_variable: Optional[SwVariableRefProxy]
     _DESERIALIZE_DISPATCH = {
-        "SW-CALPRM-REF-PROXY-REF": lambda obj, elem: setattr(obj, "sw_calprm_ref_proxy_ref", ARRef.deserialize(elem)),
-        "SW-VARIABLE-REF-PROXY-REF": lambda obj, elem: setattr(obj, "sw_variable_ref_proxy_ref", ARRef.deserialize(elem)),
+        "SW-CALPRM-REF": lambda obj, elem: setattr(obj, "sw_calprm_ref", SerializationHelper.deserialize_by_tag(elem, "SwCalprmRefProxy")),
+        "SW-VARIABLE": lambda obj, elem: setattr(obj, "sw_variable", SerializationHelper.deserialize_by_tag(elem, "SwVariableRefProxy")),
     }
 
 
     def __init__(self) -> None:
         """Initialize SwDataDependencyArgs."""
         super().__init__()
-        self.sw_calprm_ref_proxy_ref: Optional[ARRef] = None
-        self.sw_variable_ref_proxy_ref: Optional[ARRef] = None
+        self.sw_calprm_ref: Optional[SwCalprmRefProxy] = None
+        self.sw_variable: Optional[SwVariableRefProxy] = None
 
     def serialize(self) -> ET.Element:
         """Serialize SwDataDependencyArgs to XML element (atp_mixed - no wrapping).
@@ -77,11 +79,11 @@ class SwDataDependencyArgs(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize sw_calprm_ref_proxy_ref (reference)
-        if self.sw_calprm_ref_proxy_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_calprm_ref_proxy_ref, "SwCalprmRefProxy")
+        # Serialize sw_calprm_ref (complex type)
+        if self.sw_calprm_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_calprm_ref, "SwCalprmRefProxy")
             if serialized is not None:
-                wrapped = ET.Element("SW-CALPRM-REF-PROXY-REF")
+                wrapped = ET.Element("SW-CALPRM-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -90,11 +92,11 @@ class SwDataDependencyArgs(ARObject):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize sw_variable_ref_proxy_ref (reference)
-        if self.sw_variable_ref_proxy_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.sw_variable_ref_proxy_ref, "SwVariableRefProxy")
+        # Serialize sw_variable (complex type)
+        if self.sw_variable is not None:
+            serialized = SerializationHelper.serialize_item(self.sw_variable, "SwVariableRefProxy")
             if serialized is not None:
-                wrapped = ET.Element("SW-VARIABLE-REF-PROXY-REF")
+                wrapped = ET.Element("SW-VARIABLE")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -118,17 +120,17 @@ class SwDataDependencyArgs(ARObject):
         # First, call parent's deserialize to handle inherited attributes
         obj = super(SwDataDependencyArgs, cls).deserialize(element)
 
-        # Parse sw_calprm_ref_proxy_ref
-        child = SerializationHelper.find_child_element(element, "SW-CALPRM-REF-PROXY-REF")
+        # Parse sw_calprm_ref
+        child = SerializationHelper.find_child_element(element, "SW-CALPRM-REF")
         if child is not None:
-            sw_calprm_ref_proxy_ref_value = SerializationHelper.deserialize_by_tag(child, "SwCalprmRefProxy")
-            obj.sw_calprm_ref_proxy_ref = sw_calprm_ref_proxy_ref_value
+            sw_calprm_ref_value = SerializationHelper.deserialize_by_tag(child, "SwCalprmRefProxy")
+            obj.sw_calprm_ref = sw_calprm_ref_value
 
-        # Parse sw_variable_ref_proxy_ref
-        child = SerializationHelper.find_child_element(element, "SW-VARIABLE-REF-PROXY-REF")
+        # Parse sw_variable
+        child = SerializationHelper.find_child_element(element, "SW-VARIABLE")
         if child is not None:
-            sw_variable_ref_proxy_ref_value = SerializationHelper.deserialize_by_tag(child, "SwVariableRefProxy")
-            obj.sw_variable_ref_proxy_ref = sw_variable_ref_proxy_ref_value
+            sw_variable_value = SerializationHelper.deserialize_by_tag(child, "SwVariableRefProxy")
+            obj.sw_variable = sw_variable_value
 
         return obj
 
@@ -143,8 +145,8 @@ class SwDataDependencyArgsBuilder(BuilderBase):
         self._obj: SwDataDependencyArgs = SwDataDependencyArgs()
 
 
-    def with_sw_calprm_ref_proxy(self, value: Optional[SwCalprmRefProxy]) -> "SwDataDependencyArgsBuilder":
-        """Set sw_calprm_ref_proxy attribute.
+    def with_sw_calprm_ref(self, value: Optional[SwCalprmRefProxy]) -> "SwDataDependencyArgsBuilder":
+        """Set sw_calprm_ref attribute.
 
         Args:
             value: Value to set
@@ -153,12 +155,12 @@ class SwDataDependencyArgsBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'sw_calprm_ref_proxy' is required and cannot be None")
-        self._obj.sw_calprm_ref_proxy = value
+            raise ValueError("Attribute 'sw_calprm_ref' is required and cannot be None")
+        self._obj.sw_calprm_ref = value
         return self
 
-    def with_sw_variable_ref_proxy(self, value: Optional[SwVariableRefProxy]) -> "SwDataDependencyArgsBuilder":
-        """Set sw_variable_ref_proxy attribute.
+    def with_sw_variable(self, value: Optional[SwVariableRefProxy]) -> "SwDataDependencyArgsBuilder":
+        """Set sw_variable attribute.
 
         Args:
             value: Value to set
@@ -167,16 +169,16 @@ class SwDataDependencyArgsBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'sw_variable_ref_proxy' is required and cannot be None")
-        self._obj.sw_variable_ref_proxy = value
+            raise ValueError("Attribute 'sw_variable' is required and cannot be None")
+        self._obj.sw_variable = value
         return self
 
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "swCalprmRefProxy",
-        "swVariableRefProxy",
+        "swCalprmRef",
+        "swVariable",
     }
 
 

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_text_props.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_text_props.py
@@ -42,12 +42,12 @@ class SwTextProps(ARObject):
     _XML_TAG = "SW-TEXT-PROPS"
 
 
-    array_size: Optional[ArraySizeSemanticsEnum]
+    array_size_semantics: Optional[ArraySizeSemanticsEnum]
     base_type_ref: Optional[ARRef]
     sw_fill_character: Optional[Integer]
     sw_max_text_size: Optional[Integer]
     _DESERIALIZE_DISPATCH = {
-        "ARRAY-SIZE": lambda obj, elem: setattr(obj, "array_size", ArraySizeSemanticsEnum.deserialize(elem)),
+        "ARRAY-SIZE-SEMANTICS": lambda obj, elem: setattr(obj, "array_size_semantics", ArraySizeSemanticsEnum.deserialize(elem)),
         "BASE-TYPE-REF": lambda obj, elem: setattr(obj, "base_type_ref", ARRef.deserialize(elem)),
         "SW-FILL-CHARACTER": lambda obj, elem: setattr(obj, "sw_fill_character", SerializationHelper.deserialize_by_tag(elem, "Integer")),
         "SW-MAX-TEXT-SIZE": lambda obj, elem: setattr(obj, "sw_max_text_size", SerializationHelper.deserialize_by_tag(elem, "Integer")),
@@ -57,7 +57,7 @@ class SwTextProps(ARObject):
     def __init__(self) -> None:
         """Initialize SwTextProps."""
         super().__init__()
-        self.array_size: Optional[ArraySizeSemanticsEnum] = None
+        self.array_size_semantics: Optional[ArraySizeSemanticsEnum] = None
         self.base_type_ref: Optional[ARRef] = None
         self.sw_fill_character: Optional[Integer] = None
         self.sw_max_text_size: Optional[Integer] = None
@@ -85,12 +85,12 @@ class SwTextProps(ARObject):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize array_size
-        if self.array_size is not None:
-            serialized = SerializationHelper.serialize_item(self.array_size, "ArraySizeSemanticsEnum")
+        # Serialize array_size_semantics
+        if self.array_size_semantics is not None:
+            serialized = SerializationHelper.serialize_item(self.array_size_semantics, "ArraySizeSemanticsEnum")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ARRAY-SIZE")
+                wrapped = ET.Element("ARRAY-SIZE-SEMANTICS")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -160,8 +160,8 @@ class SwTextProps(ARObject):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "ARRAY-SIZE":
-                setattr(obj, "array_size", ArraySizeSemanticsEnum.deserialize(child))
+            if tag == "ARRAY-SIZE-SEMANTICS":
+                setattr(obj, "array_size_semantics", ArraySizeSemanticsEnum.deserialize(child))
             elif tag == "BASE-TYPE-REF":
                 setattr(obj, "base_type_ref", ARRef.deserialize(child))
             elif tag == "SW-FILL-CHARACTER":
@@ -182,8 +182,8 @@ class SwTextPropsBuilder(BuilderBase):
         self._obj: SwTextProps = SwTextProps()
 
 
-    def with_array_size(self, value: Optional[ArraySizeSemanticsEnum]) -> "SwTextPropsBuilder":
-        """Set array_size attribute.
+    def with_array_size_semantics(self, value: Optional[ArraySizeSemanticsEnum]) -> "SwTextPropsBuilder":
+        """Set array_size_semantics attribute.
 
         Args:
             value: Value to set
@@ -192,8 +192,8 @@ class SwTextPropsBuilder(BuilderBase):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'array_size' is required and cannot be None")
-        self._obj.array_size = value
+            raise ValueError("Attribute 'array_size_semantics' is required and cannot be None")
+        self._obj.array_size_semantics = value
         return self
 
     def with_base_type(self, value: Optional[SwBaseType]) -> "SwTextPropsBuilder":
@@ -242,7 +242,7 @@ class SwTextPropsBuilder(BuilderBase):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "arraySize",
+        "arraySizeSemantics",
         "baseType",
         "swFillCharacter",
         "swMaxTextSize",

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/value_list.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/value_list.py
@@ -39,8 +39,10 @@ class ValueList(ARObject):
 
 
     v: Optional[Numerical]
+    vts: list[Numerical]
     _DESERIALIZE_DISPATCH = {
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
     }
 
 
@@ -48,6 +50,7 @@ class ValueList(ARObject):
         """Initialize ValueList."""
         super().__init__()
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
 
     def serialize(self) -> ET.Element:
         """Serialize ValueList to XML element (atp_mixed - no wrapping).
@@ -79,6 +82,27 @@ class ValueList(ARObject):
             child.text = str(self.v)
             elem.append(child)
 
+        # Serialize vts (list)
+        if self.vts:
+            for item in self.vts:
+                if is_ref:
+                    # For reference lists, serialize as reference
+                    if hasattr(item, "serialize"):
+                        elem.append(item.serialize())
+                elif is_primitive_type("Numerical", package_data):
+                    # Simple primitive type
+                    child = ET.Element("VT")
+                    child.text = str(item)
+                    elem.append(child)
+                elif is_enum_type("Numerical", package_data):
+                    # Enum type - use serialize method
+                    if hasattr(item, "serialize"):
+                        elem.append(item.serialize())
+                else:
+                    # Complex type - use serialize method
+                    if hasattr(item, "serialize"):
+                        elem.append(item.serialize())
+
         return elem
 
     @classmethod
@@ -99,6 +123,15 @@ class ValueList(ARObject):
         if child is not None:
             v_value = SerializationHelper.deserialize_by_tag(child, "Numerical")
             obj.v = v_value
+
+        # Parse vts (list)
+        obj.vts = []
+        for child in element:
+            tag = SerializationHelper.strip_namespace(child.tag)
+            if tag == "VT":
+                vts_value = SerializationHelper.deserialize_by_tag(child, "Numerical")
+                if vts_value is not None:
+                    obj.vts.append(vts_value)
 
         return obj
 
@@ -127,11 +160,45 @@ class ValueListBuilder(BuilderBase):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "ValueListBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
+
+    def add_vt(self, item: Numerical) -> "ValueListBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "ValueListBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
         "v",
+        "vt",
     }
 
 

--- a/src/armodel2/models/M2/MSR/DataDictionary/DatadictionaryProxies/sw_calprm_ref_proxy.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DatadictionaryProxies/sw_calprm_ref_proxy.py
@@ -11,16 +11,19 @@ import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements.autosar_parameter_ref import (
-    AutosarParameterRef,
-)
-from armodel2.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport.mc_data_instance import (
-    McDataInstance,
-)
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.DataElements.autosar_parameter_ref import (
+        AutosarParameterRef,
+    )
+    from armodel2.models.M2.AUTOSARTemplates.CommonStructure.MeasurementCalibrationSupport.mc_data_instance import (
+        McDataInstance,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class SwCalprmRefProxy(ARObject):
     """AUTOSAR SwCalprmRefProxy."""
 

--- a/src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py
@@ -55,11 +55,13 @@ class SwServiceArg(Identifiable):
     direction: Optional[ArgumentDirectionEnum]
     sw_arraysize: Optional[ValueList]
     v: Optional[Numerical]
+    vts: list[Numerical]
     sw_data_def_props: Optional[SwDataDefProps]
     _DESERIALIZE_DISPATCH = {
         "DIRECTION": lambda obj, elem: setattr(obj, "direction", ArgumentDirectionEnum.deserialize(elem)),
         "SW-ARRAYSIZE": lambda obj, elem: setattr(obj, "sw_arraysize", SerializationHelper.deserialize_by_tag(elem, "ValueList")),
         "V": lambda obj, elem: setattr(obj, "v", SerializationHelper.deserialize_by_tag(elem, "Numerical")),
+        "VTS": lambda obj, elem: obj.vts.append(SerializationHelper.deserialize_by_tag(elem, "Numerical")),
         "SW-DATA-DEF-PROPS": lambda obj, elem: setattr(obj, "sw_data_def_props", SerializationHelper.deserialize_by_tag(elem, "SwDataDefProps")),
     }
 
@@ -70,6 +72,7 @@ class SwServiceArg(Identifiable):
         self.direction: Optional[ArgumentDirectionEnum] = None
         self.sw_arraysize: Optional[ValueList] = None
         self.v: Optional[Numerical] = None
+        self.vts: list[Numerical] = []
         self.sw_data_def_props: Optional[SwDataDefProps] = None
 
     def serialize(self) -> ET.Element:
@@ -136,6 +139,23 @@ class SwServiceArg(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
+        # Serialize vts (list to container "VTS")
+        if self.vts:
+            wrapper = ET.Element("VTS")
+            for item in self.vts:
+                serialized = SerializationHelper.serialize_item(item, "Numerical")
+                if serialized is not None:
+                    child_elem = ET.Element("VT")
+                    if hasattr(serialized, 'attrib'):
+                        child_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        child_elem.text = serialized.text
+                    for child in serialized:
+                        child_elem.append(child)
+                    wrapper.append(child_elem)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
         # Serialize sw_data_def_props
         if self.sw_data_def_props is not None:
             serialized = SerializationHelper.serialize_item(self.sw_data_def_props, "SwDataDefProps")
@@ -175,6 +195,10 @@ class SwServiceArg(Identifiable):
                 setattr(obj, "sw_arraysize", SerializationHelper.deserialize_by_tag(child, "ValueList"))
             elif tag == "V":
                 setattr(obj, "v", SerializationHelper.deserialize_by_tag(child, "Numerical"))
+            elif tag == "VTS":
+                # Iterate through wrapper children
+                for item_elem in child:
+                    obj.vts.append(SerializationHelper.deserialize_by_tag(item_elem, "Numerical"))
             elif tag == "SW-DATA-DEF-PROPS":
                 setattr(obj, "sw_data_def_props", SerializationHelper.deserialize_by_tag(child, "SwDataDefProps"))
 
@@ -233,6 +257,18 @@ class SwServiceArgBuilder(IdentifiableBuilder):
         self._obj.v = value
         return self
 
+    def with_vts(self, items: list[Numerical]) -> "SwServiceArgBuilder":
+        """Set vts list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = list(items) if items else []
+        return self
+
     def with_sw_data_def_props(self, value: Optional[SwDataDefProps]) -> "SwServiceArgBuilder":
         """Set sw_data_def_props attribute.
 
@@ -247,6 +283,27 @@ class SwServiceArgBuilder(IdentifiableBuilder):
         self._obj.sw_data_def_props = value
         return self
 
+
+    def add_vt(self, item: Numerical) -> "SwServiceArgBuilder":
+        """Add a single item to vts list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts.append(item)
+        return self
+
+    def clear_vts(self) -> "SwServiceArgBuilder":
+        """Clear all items from vts list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.vts = []
+        return self
 
 
     # Pre-computed validation constants (generated from JSON schema)


### PR DESCRIPTION
## Summary

This pull request updates multiple JSON mapping files and regenerates the corresponding AUTOSAR model classes to ensure consistency between the mapping definitions and the generated Python code.

## Changes

- Updated JSON mapping files for multiple AUTOSAR packages
- Regenerated Python model classes to reflect the updated mappings
- Fixed attribute ordering in CompuScale to match JSON file definition

## Files Modified

### JSON Mapping Files (6 files)
- `docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_CommonStructure_MeasurementCalibrationSupport.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json`
- `docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RunnableEntity.classes.json`
- `docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json`
- `docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.classes.json`

### Generated Model Classes (20 files)
- `src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_axis_cont.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Constants/rule_based_value_cont.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/implementation_element_in_parameter_instance_ref.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_access_details.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_data_instance.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_function.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/mc_support_data.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/MeasurementCalibrationSupport/role_based_mc_data_assignment.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py`
- `src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_scale.py`
- `src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_axis_cont.py`
- `src/armodel2/models/M2/MSR/CalibrationData/CalibrationValue/sw_value_cont.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_def_props.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_data_dependency_args.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_text_props.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/value_list.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DatadictionaryProxies/sw_calprm_ref_proxy.py`
- `src/armodel2/models/M2/MSR/DataDictionary/ServiceProcessTask/sw_service_arg.py`

## Test Coverage

✅ All 324 tests pass

Quality checks:
- **Ruff**: ✅ All checks passed
- **MyPy**: ✅ No issues found in 2255 source files
- **Pytest**: ✅ All 324 tests passed (22.71s)

Test suites covered:
- Unit tests for model classes
- Integration tests for binary comparison
- Serialization/deserialization tests
- Fluent API builder tests

## Requirements

N/A - Internal refactoring to maintain code generation consistency

Closes #225