### PR TITLE
feat: Update AUTOSAR model mappings and fix type definitions

### DIFF
--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfaces.classes.json
@@ -177,6 +177,22 @@
           "is_ref": false,
           "note": "AUTOSAR identifier of the target module of which the defined. is optional, because the target module be identified by targetModuleRef. 381 Document ID 89: AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate Module Description Template R23-11"
         },
+        "expectedCallback": {
+          "type": "BswModuleEntry",
+          "multiplicity": "*",
+          "kind": "ref",
+          "is_ref": true,
+          "decorator": "ref_conditional:EXPECTED-CALLBACKS",
+          "note": "Indicates a callback expected to be called from another module and implemented by this module. (AUTOSAR 4.0.3)"
+        },
+        "requiredEntry": {
+          "type": "BswModuleEntry",
+          "multiplicity": "*",
+          "kind": "ref",
+          "is_ref": true,
+          "decorator": "ref_conditional:REQUIRED-ENTRYS",
+          "note": "Indicates an entry into another modules which is required by this module. (AUTOSAR 4.0.3)"
+        },
         "targetModule": {
           "type": "BswModuleDescription",
           "multiplicity": "0..1",

--- a/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswOverview.classes.json
@@ -83,9 +83,18 @@
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
-          "revision": "4.0.3",
+          "revision": "4.2.1",
           "decorator": "ref_conditional:PROVIDED-ENTRYS",
           "note": "Specifies an entry provided by this module which can be called by other modules. This includes \"main\" functions and interrupt routines, but not callbacks (because the signature of a callback is defined by the caller)."
+        },
+        "outgoingCallback": {
+           "type": "BswModuleEntry",
+          "multiplicity": "*",
+          "kind": "ref",
+          "is_ref": true,
+          "revision": "4.2.1",
+          "decorator": "ref_conditional:OUTGOING-CALLBACKS",
+          "note": "Specifies a callback, which will be called from this module if required by another module."
         },
         "releasedTrigger": {
           "type": "Trigger",

--- a/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Implementation.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_CommonStructure_Implementation.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "ImplementationProps",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::Implementation",
       "is_abstract": true,
       "atp_type": null,
@@ -225,7 +225,7 @@
     },
     {
       "name": "Code",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::Implementation",
       "is_abstract": false,
       "atp_type": null,
@@ -262,7 +262,7 @@
         "artifactDescriptor": {
           "type": "AutosarEngineeringObject",
           "multiplicity": "*",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "Refers to the artifact belonging to this code descriptor."
         },
@@ -277,7 +277,7 @@
     },
     {
       "name": "DependencyOnArtifact",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::Implementation",
       "is_abstract": false,
       "atp_type": null,
@@ -316,22 +316,22 @@
         "artifactDescriptor": {
           "type": "AutosarEngineeringObject",
           "multiplicity": "0..1",
-          "kind": "attribute",
+          "kind": "aggr",
           "is_ref": false,
           "note": "The specified artifact needs to exist."
         },
         "usage": {
           "type": "DependencyUsageEnum",
           "multiplicity": "*",
-          "kind": "ref",
-          "is_ref": true,
+          "kind": "attribute",
+          "is_ref": false,
           "note": "Specification for which process step(s) this dependency is"
         }
       }
     },
     {
       "name": "Compiler",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::Implementation",
       "is_abstract": false,
       "atp_type": null,
@@ -403,7 +403,7 @@
     },
     {
       "name": "Linker",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::CommonStructure::Implementation",
       "is_abstract": false,
       "atp_type": null,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components_InstanceRefs.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components_InstanceRefs.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "VariableInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": true,
       "atp_type": null,
@@ -32,7 +32,7 @@
         }
       ],
       "attributes": {
-        "abstractTarget": {
+        "abstractTargetDataElement": {
           "type": "VariableDataPrototype",
           "multiplicity": "0..1",
           "kind": "ref",
@@ -104,7 +104,7 @@
     },
     {
       "name": "RModeInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -144,14 +144,14 @@
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
-          "note": "Tags: xml.sequenceOffset=20"
+          "note": "Tags: xml.sequenceOffset=30"
         },
         "contextModeDeclarationGroupPrototype": {
-          "type": "ModeDeclarationGroup",
+          "type": "ModeDeclarationGroupPrototype",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
-          "note": "Tags: xml.sequenceOffset=30"
+          "note": "Tags: xml.sequenceOffset=20"
         },
         "targetModeDeclaration": {
           "type": "ModeDeclaration",
@@ -164,7 +164,7 @@
     },
     {
       "name": "InnerPortGroupInCompositionInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -199,7 +199,7 @@
           "note": "Stereotypes: atpDerived"
         },
         "context": {
-          "type": "any (SwComponent)",
+          "type": "SwComponentPrototype",
           "multiplicity": "*",
           "kind": "ref",
           "is_ref": true,
@@ -216,7 +216,7 @@
     },
     {
       "name": "TriggerInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": true,
       "atp_type": null,
@@ -272,7 +272,7 @@
     },
     {
       "name": "RTriggerInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -319,7 +319,7 @@
     },
     {
       "name": "PTriggerInAtomicSwcTypeInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -366,7 +366,7 @@
     },
     {
       "name": "OperationInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": true,
       "atp_type": null,
@@ -468,7 +468,7 @@
     },
     {
       "name": "POperationInAtomicSwcInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -515,7 +515,7 @@
     },
     {
       "name": "RModeGroupInAtomicSWCInstanceRef",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::Components::InstanceRefs",
       "is_abstract": false,
       "atp_type": null,
@@ -550,7 +550,7 @@
           "is_ref": true,
           "note": "Tags: xml.sequenceOffset=20"
         },
-        "targetMode": {
+        "targetModeGroup": {
           "type": "ModeDeclarationGroup",
           "multiplicity": "0..1",
           "kind": "ref",

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RTEEvents.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RTEEvents.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "OperationInvokedEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -161,7 +161,7 @@
     },
     {
       "name": "TimingEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -220,7 +220,7 @@
     },
     {
       "name": "AsynchronousServerCallReturnsEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -256,7 +256,7 @@
       ],
       "attributes": {
         "eventSource": {
-          "type": "any (AsynchronousServer)",
+          "type": "AsynchronousServerCallResultPoint",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,
@@ -266,7 +266,7 @@
     },
     {
       "name": "DataSendCompletedEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -312,7 +312,7 @@
     },
     {
       "name": "DataWriteCompletedEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -404,7 +404,7 @@
     },
     {
       "name": "DataReceiveErrorEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -440,9 +440,9 @@
       ],
       "attributes": {
         "data": {
-          "type": "VariableDataPrototype",
+          "type": "RVariableInAtomicSwcInstanceRef",
           "multiplicity": "0..1",
-          "kind": "ref",
+          "kind": "iref",
           "is_ref": true,
           "note": "there was an error during the by: RVariableInAtomicSwc"
         }
@@ -450,7 +450,7 @@
     },
     {
       "name": "BackgroundEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -542,7 +542,7 @@
     },
     {
       "name": "ModeSwitchedAckEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -588,7 +588,7 @@
     },
     {
       "name": "ExternalTriggerOccurredEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -624,9 +624,9 @@
       ],
       "attributes": {
         "trigger": {
-          "type": "Trigger",
+          "type": "RTriggerInAtomicSwcInstanceRef",
           "multiplicity": "0..1",
-          "kind": "ref",
+          "kind": "iref",
           "is_ref": true,
           "note": "The referenced Trigger raises this ExternalTrigger"
         }
@@ -634,7 +634,7 @@
     },
     {
       "name": "InternalTriggerOccurredEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -680,7 +680,7 @@
     },
     {
       "name": "InitEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -718,7 +718,7 @@
     },
     {
       "name": "TransformerHardErrorEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -754,16 +754,16 @@
       ],
       "attributes": {
         "operation": {
-          "type": "ClientServerOperation",
+          "type": "POperationInAtomicSwcInstanceRef",
           "multiplicity": "0..1",
-          "kind": "attribute",
-          "is_ref": false,
+          "kind": "iref",
+          "is_ref": true,
           "note": "raise this TransformerHardErrorEvent. by: POperationInAtomicSwc"
         },
         "requiredTrigger": {
-          "type": "Trigger",
+          "type": "RTriggerInAtomicSwcInstanceRef",
           "multiplicity": "0..1",
-          "kind": "ref",
+          "kind": "iref",
           "is_ref": true,
           "note": "This represents the Trigger for which the transformer can"
         }
@@ -771,7 +771,7 @@
     },
     {
       "name": "OsTaskExecutionEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -809,7 +809,7 @@
     },
     {
       "name": "WaitPoint",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -855,7 +855,7 @@
     },
     {
       "name": "SwcModeManagerErrorEvent",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::RTEEvents",
       "is_abstract": false,
       "atp_type": null,
@@ -891,7 +891,7 @@
       ],
       "attributes": {
         "modeGroup": {
-          "type": "ModeDeclarationGroup",
+          "type": "PModeGroupInAtomicSwcInstanceRef",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,

--- a/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServerCall.classes.json
+++ b/docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServerCall.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "AsynchronousServerCallResultPoint",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::AUTOSARTemplates::SWComponentTemplate::SwcInternalBehavior::ServerCall",
       "is_abstract": false,
       "atp_type": null,
@@ -43,8 +43,8 @@
         }
       ],
       "attributes": {
-        "asynchronousServer": {
-          "type": "any (AsynchronousServer)",
+        "asynchronousServerCallPoint": {
+          "type": "AsynchronousServerCallPoint",
           "multiplicity": "0..1",
           "kind": "ref",
           "is_ref": true,

--- a/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.enums.json
+++ b/docs/json/packages/M2_MSR_DataDictionary_DataDefProperties.enums.json
@@ -3,7 +3,7 @@
   "enumerations": [
     {
       "name": "SwCalibrationAccessEnum",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "note": "Determines the access rights to a data object w.r.t. measurement and calibration. Aggregated by ModeDeclarationGroupPrototype.swCalibrationAccess, SwCalprmAxis.swCalibrationAccess, SwData DefProps.swCalibrationAccess",
       "sources": [
@@ -40,7 +40,7 @@
     },
     {
       "name": "SwImplPolicyEnum",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "note": "Specifies the implementation strategy with respect to consistency mechanisms of variables. Aggregated by BswInternalTriggeringPoint.swImplPolicy, InternalTriggeringPoint.swImplPolicy, SwDataDefProps.sw ImplPolicy, Trigger.swImplPolicy",
       "sources": [
@@ -70,16 +70,6 @@
           "description": "forced implementation such that the running software within the ECU shall not modify it. For example implemented with the \"const\" modifier in C. This can be applied for parameters (not for those in<br>Tags: atp.EnumerationLiteralIndex=0"
         },
         {
-          "name": "Basic",
-          "index": null,
-          "description": "Software Module Description Template"
-        },
-        {
-          "name": "AUTOSAR",
-          "index": null,
-          "description": "CP R23-11"
-        },
-        {
           "name": "fixed",
           "index": 1,
           "description": "This data element is fixed. In particular this indicates, that it might also be implemented e.g. as in place data, (#DEFINE).<br>Tags: atp.EnumerationLiteralIndex=1"
@@ -103,7 +93,7 @@
     },
     {
       "name": "DisplayPresentationEnum",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::DataDictionary::DataDefProperties",
       "note": "This meta-class represents the ability to provide values for controlling the presentation of data within measurement and calibration tools. Aggregated by SwDataDefProps.displayPresentation",
       "sources": [

--- a/docs/json/packages/M2_MSR_Documentation_BlockElements_Note.classes.json
+++ b/docs/json/packages/M2_MSR_Documentation_BlockElements_Note.classes.json
@@ -3,7 +3,7 @@
   "classes": [
     {
       "name": "Note",
-      "maturity": "draft",
+      "maturity": "reviewed",
       "package": "M2::MSR::Documentation::BlockElements::Note",
       "is_abstract": false,
       "atp_type": null,

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_dependency.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswInterfaces/bsw_module_dependency.py
@@ -8,6 +8,7 @@ JSON Source: docs/json/packages/M2_AUTOSARTemplates_BswModuleTemplate_BswInterfa
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
+from armodel2.serialization.decorators import ref_conditional
 
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.identifiable import (
     Identifiable,
@@ -17,6 +18,9 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.PrimitiveTypes import (
     PositiveInteger,
+)
+from armodel2.models.M2.AUTOSARTemplates.BswModuleTemplate.BswInterfaces.bsw_module_entry import (
+    BswModuleEntry,
 )
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ServiceNeeds.service_needs import (
     ServiceNeeds,
@@ -47,10 +51,14 @@ class BswModuleDependency(Identifiable):
 
 
     target_module_id: Optional[PositiveInteger]
+    _expected_callback_refs: list[ARRef]
+    _required_entry_refs: list[ARRef]
     target_module_ref: Optional[ARRef]
     service_items: list[ServiceNeeds]
     _DESERIALIZE_DISPATCH = {
         "TARGET-MODULE-ID": lambda obj, elem: setattr(obj, "target_module_id", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
+        "EXPECTED-CALLBACK-REFS": lambda obj, elem: [obj._expected_callback_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "REQUIRED-ENTRY-REFS": lambda obj, elem: [obj._required_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "TARGET-MODULE-REF": lambda obj, elem: setattr(obj, "target_module_ref", ARRef.deserialize(elem)),
         "SERVICE-ITEMS": ("_POLYMORPHIC_LIST", "service_items", ["BswMgrNeeds", "ComMgrUserNeeds", "CryptoKeyManagementNeeds", "CryptoServiceJobNeeds", "CryptoServiceNeeds", "DiagnosticCapabilityElement", "DiagnosticCommunicationManagerNeeds", "DiagnosticComponentNeeds", "DiagnosticControlNeeds", "DiagnosticEnableConditionNeeds", "DiagnosticEventInfoNeeds", "DiagnosticEventManagerNeeds", "DiagnosticEventNeeds", "DiagnosticIoControlNeeds", "DiagnosticOperationCycleNeeds", "DiagnosticRequestFileTransferNeeds", "DiagnosticRoutineNeeds", "DiagnosticStorageConditionNeeds", "DiagnosticUploadDownloadNeeds", "DiagnosticValueNeeds", "DiagnosticsCommunicationSecurityNeeds", "DltUserNeeds", "DoIpActivationLineNeeds", "DoIpGidNeeds", "DoIpGidSynchronizationNeeds", "DoIpPowerModeStatusNeeds", "DoIpRoutingActivationAuthenticationNeeds", "DoIpRoutingActivationConfirmationNeeds", "DoIpServiceNeeds", "DtcStatusChangeNotificationNeeds", "EcuStateMgrUserNeeds", "ErrorTracerNeeds", "FunctionInhibitionAvailabilityNeeds", "FunctionInhibitionNeeds", "GlobalSupervisionNeeds", "HardwareTestNeeds", "IdsMgrCustomTimestampNeeds", "IdsMgrNeeds", "IndicatorStatusNeeds", "J1939DcmDm19Support", "J1939RmIncomingRequestServiceNeeds", "J1939RmOutgoingRequestServiceNeeds", "NvBlockNeeds", "ObdControlServiceNeeds", "ObdInfoServiceNeeds", "ObdMonitorServiceNeeds", "ObdPidServiceNeeds", "ObdRatioDenominatorNeeds", "ObdRatioServiceNeeds", "SecureOnBoardCommunicationNeeds", "SupervisedEntityCheckpointNeeds", "SupervisedEntityNeeds", "SyncTimeBaseMgrUserNeeds", "V2xDataManagerNeeds", "V2xFacUserNeeds", "V2xMUserNeeds", "VendorSpecificServiceNeeds"]),
     }
@@ -60,8 +68,32 @@ class BswModuleDependency(Identifiable):
         """Initialize BswModuleDependency."""
         super().__init__()
         self.target_module_id: Optional[PositiveInteger] = None
+        self._expected_callback_refs: list[ARRef] = []
+        self._required_entry_refs: list[ARRef] = []
         self.target_module_ref: Optional[ARRef] = None
         self.service_items: list[ServiceNeeds] = []
+    @property
+    @ref_conditional("EXPECTED-CALLBACKS")
+    def expected_callback_refs(self) -> list[ARRef]:
+        """Get expected_callback_refs with ref_conditional wrapper."""
+        return self._expected_callback_refs
+
+    @expected_callback_refs.setter
+    def expected_callback_refs(self, value: list[ARRef]) -> None:
+        """Set expected_callback_refs with ref_conditional wrapper."""
+        self._expected_callback_refs = value
+
+    @property
+    @ref_conditional("REQUIRED-ENTRYS")
+    def required_entry_refs(self) -> list[ARRef]:
+        """Get required_entry_refs with ref_conditional wrapper."""
+        return self._required_entry_refs
+
+    @required_entry_refs.setter
+    def required_entry_refs(self, value: list[ARRef]) -> None:
+        """Set required_entry_refs with ref_conditional wrapper."""
+        self._required_entry_refs = value
+
 
     def serialize(self) -> ET.Element:
         """Serialize BswModuleDependency to XML element.
@@ -99,6 +131,46 @@ class BswModuleDependency(Identifiable):
                 for child in serialized:
                     wrapped.append(child)
                 elem.append(wrapped)
+
+        # Serialize expected_callback_refs (list to container "EXPECTED-CALLBACKS")
+        if self.expected_callback_refs:
+            wrapper = ET.Element("EXPECTED-CALLBACKS")
+            for item in self.expected_callback_refs:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
+                if serialized is not None:
+                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
+                    if hasattr(serialized, 'attrib'):
+                        ref_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        ref_elem.text = serialized.text
+                    for child in serialized:
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize required_entry_refs (list to container "REQUIRED-ENTRYS")
+        if self.required_entry_refs:
+            wrapper = ET.Element("REQUIRED-ENTRYS")
+            for item in self.required_entry_refs:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
+                if serialized is not None:
+                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
+                    if hasattr(serialized, 'attrib'):
+                        ref_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        ref_elem.text = serialized.text
+                    for child in serialized:
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
 
         # Serialize target_module_ref
         if self.target_module_ref is not None:
@@ -145,6 +217,20 @@ class BswModuleDependency(Identifiable):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "TARGET-MODULE-ID":
                 setattr(obj, "target_module_id", SerializationHelper.deserialize_by_tag(child, "PositiveInteger"))
+            elif tag == "EXPECTED-CALLBACKS":
+                # Unwrap ref_conditional pattern
+                for item_elem in child:
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._expected_callback_refs.append(ARRef.deserialize(ref_elem))
+            elif tag == "REQUIRED-ENTRYS":
+                # Unwrap ref_conditional pattern
+                for item_elem in child:
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._required_entry_refs.append(ARRef.deserialize(ref_elem))
             elif tag == "TARGET-MODULE-REF":
                 setattr(obj, "target_module_ref", ARRef.deserialize(child))
             elif tag == "SERVICE-ITEMS":
@@ -293,6 +379,30 @@ class BswModuleDependencyBuilder(IdentifiableBuilder):
         self._obj.target_module_id = value
         return self
 
+    def with_expected_callbacks(self, items: list[BswModuleEntry]) -> "BswModuleDependencyBuilder":
+        """Set expected_callbacks list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.expected_callbacks = list(items) if items else []
+        return self
+
+    def with_required_entries(self, items: list[BswModuleEntry]) -> "BswModuleDependencyBuilder":
+        """Set required_entries list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.required_entries = list(items) if items else []
+        return self
+
     def with_target_module(self, value: Optional[BswModuleDescription]) -> "BswModuleDependencyBuilder":
         """Set target_module attribute.
 
@@ -320,6 +430,48 @@ class BswModuleDependencyBuilder(IdentifiableBuilder):
         return self
 
 
+    def add_expected_callback(self, item: BswModuleEntry) -> "BswModuleDependencyBuilder":
+        """Add a single item to expected_callbacks list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.expected_callbacks.append(item)
+        return self
+
+    def clear_expected_callbacks(self) -> "BswModuleDependencyBuilder":
+        """Clear all items from expected_callbacks list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.expected_callbacks = []
+        return self
+
+    def add_required_entry(self, item: BswModuleEntry) -> "BswModuleDependencyBuilder":
+        """Add a single item to required_entries list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.required_entries.append(item)
+        return self
+
+    def clear_required_entries(self) -> "BswModuleDependencyBuilder":
+        """Clear all items from required_entries list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.required_entries = []
+        return self
+
     def add_service_item(self, item: ServiceNeeds) -> "BswModuleDependencyBuilder":
         """Add a single item to service_items list.
 
@@ -344,6 +496,8 @@ class BswModuleDependencyBuilder(IdentifiableBuilder):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
+        "expectedCallback",
+        "requiredEntry",
         "serviceItem",
         "targetModule",
         "targetModuleId",

--- a/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/BswModuleTemplate/BswOverview/bsw_module_description.py
@@ -72,6 +72,7 @@ class BswModuleDescription(ARElement):
 
     module_id: Optional[PositiveInteger]
     _provided_entry_refs: list[ARRef]
+    _outgoing_callback_refs: list[ARRef]
     released_triggers: list[Trigger]
     required_triggers: list[Trigger]
     bsw_module_dependencies: list[BswModuleDependency]
@@ -88,6 +89,7 @@ class BswModuleDescription(ARElement):
     _DESERIALIZE_DISPATCH = {
         "MODULE-ID": lambda obj, elem: setattr(obj, "module_id", SerializationHelper.deserialize_by_tag(elem, "PositiveInteger")),
         "PROVIDED-ENTRY-REFS": lambda obj, elem: [obj._provided_entry_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
+        "OUTGOING-CALLBACK-REFS": lambda obj, elem: [obj._outgoing_callback_refs.append(ARRef.deserialize(item_elem)) for item_elem in elem],
         "RELEASED-TRIGGERS": lambda obj, elem: obj.released_triggers.append(SerializationHelper.deserialize_by_tag(elem, "Trigger")),
         "REQUIRED-TRIGGERS": lambda obj, elem: obj.required_triggers.append(SerializationHelper.deserialize_by_tag(elem, "Trigger")),
         "BSW-MODULE-DEPENDENCYS": lambda obj, elem: obj.bsw_module_dependencies.append(SerializationHelper.deserialize_by_tag(elem, "BswModuleDependency")),
@@ -109,6 +111,7 @@ class BswModuleDescription(ARElement):
         super().__init__()
         self.module_id: Optional[PositiveInteger] = None
         self._provided_entry_refs: list[ARRef] = []
+        self._outgoing_callback_refs: list[ARRef] = []
         self.released_triggers: list[Trigger] = []
         self.required_triggers: list[Trigger] = []
         self.bsw_module_dependencies: list[BswModuleDependency] = []
@@ -132,6 +135,17 @@ class BswModuleDescription(ARElement):
     def provided_entry_refs(self, value: list[ARRef]) -> None:
         """Set provided_entry_refs with ref_conditional wrapper."""
         self._provided_entry_refs = value
+
+    @property
+    @ref_conditional("OUTGOING-CALLBACKS")
+    def outgoing_callback_refs(self) -> list[ARRef]:
+        """Get outgoing_callback_refs with ref_conditional wrapper."""
+        return self._outgoing_callback_refs
+
+    @outgoing_callback_refs.setter
+    def outgoing_callback_refs(self, value: list[ARRef]) -> None:
+        """Set outgoing_callback_refs with ref_conditional wrapper."""
+        self._outgoing_callback_refs = value
 
 
     def serialize(self) -> ET.Element:
@@ -175,6 +189,26 @@ class BswModuleDescription(ARElement):
         if self.provided_entry_refs:
             wrapper = ET.Element("PROVIDED-ENTRYS")
             for item in self.provided_entry_refs:
+                serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
+                if serialized is not None:
+                    # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
+                    conditional = ET.Element("BSW-MODULE-ENTRY-REF-CONDITIONAL")
+                    ref_elem = ET.Element("BSW-MODULE-ENTRY-REF")
+                    if hasattr(serialized, 'attrib'):
+                        ref_elem.attrib.update(serialized.attrib)
+                    if serialized.text:
+                        ref_elem.text = serialized.text
+                    for child in serialized:
+                        ref_elem.append(child)
+                    conditional.append(ref_elem)
+                    wrapper.append(conditional)
+            if len(wrapper) > 0:
+                elem.append(wrapper)
+
+        # Serialize outgoing_callback_refs (list to container "OUTGOING-CALLBACKS")
+        if self.outgoing_callback_refs:
+            wrapper = ET.Element("OUTGOING-CALLBACKS")
+            for item in self.outgoing_callback_refs:
                 serialized = SerializationHelper.serialize_item(item, "BswModuleEntry")
                 if serialized is not None:
                     # Wrap in BSW-MODULE-ENTRY-REF-CONDITIONAL
@@ -367,6 +401,13 @@ class BswModuleDescription(ARElement):
                     if len(item_elem) > 0:
                         ref_elem = item_elem[0]
                         obj._provided_entry_refs.append(ARRef.deserialize(ref_elem))
+            elif tag == "OUTGOING-CALLBACKS":
+                # Unwrap ref_conditional pattern
+                for item_elem in child:
+                    # item_elem is XXX-REF-CONDITIONAL, unwrap to get XXX-REF
+                    if len(item_elem) > 0:
+                        ref_elem = item_elem[0]
+                        obj._outgoing_callback_refs.append(ARRef.deserialize(ref_elem))
             elif tag == "RELEASED-TRIGGERS":
                 # Iterate through wrapper children
                 for item_elem in child:
@@ -455,6 +496,18 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.provided_entries = list(items) if items else []
+        return self
+
+    def with_outgoing_callbacks(self, items: list[BswModuleEntry]) -> "BswModuleDescriptionBuilder":
+        """Set outgoing_callbacks list attribute.
+
+        Args:
+            items: List of items to set
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.outgoing_callbacks = list(items) if items else []
         return self
 
     def with_released_triggers(self, items: list[Trigger]) -> "BswModuleDescriptionBuilder":
@@ -635,6 +688,27 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
             self for method chaining
         """
         self._obj.provided_entries = []
+        return self
+
+    def add_outgoing_callback(self, item: BswModuleEntry) -> "BswModuleDescriptionBuilder":
+        """Add a single item to outgoing_callbacks list.
+
+        Args:
+            item: Item to add
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.outgoing_callbacks.append(item)
+        return self
+
+    def clear_outgoing_callbacks(self) -> "BswModuleDescriptionBuilder":
+        """Clear all items from outgoing_callbacks list.
+
+        Returns:
+            self for method chaining
+        """
+        self._obj.outgoing_callbacks = []
         return self
 
     def add_released_trigger(self, item: Trigger) -> "BswModuleDescriptionBuilder":
@@ -898,6 +972,7 @@ class BswModuleDescriptionBuilder(ARElementBuilder):
         "implementedEntry",
         "internalBehavior",
         "moduleId",
+        "outgoingCallback",
         "providedClientServerEntry",
         "providedData",
         "providedEntry",

--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Implementation/dependency_on_artifact.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/Implementation/dependency_on_artifact.py
@@ -15,7 +15,6 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 )
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.Identifiable.identifiable import IdentifiableBuilder
-from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.Implementation import (
     DependencyUsageEnum,
 )
@@ -42,10 +41,10 @@ class DependencyOnArtifact(Identifiable):
 
 
     artifact_descriptor: Optional[AutosarEngineeringObject]
-    usage_refs: list[DependencyUsageEnum]
+    usages: list[DependencyUsageEnum]
     _DESERIALIZE_DISPATCH = {
         "ARTIFACT-DESCRIPTOR": lambda obj, elem: setattr(obj, "artifact_descriptor", SerializationHelper.deserialize_by_tag(elem, "AutosarEngineeringObject")),
-        "USAGE-REFS": lambda obj, elem: obj.usage_refs.append(DependencyUsageEnum.deserialize(elem)),
+        "USAGES": lambda obj, elem: obj.usages.append(DependencyUsageEnum.deserialize(elem)),
     }
 
 
@@ -53,7 +52,7 @@ class DependencyOnArtifact(Identifiable):
         """Initialize DependencyOnArtifact."""
         super().__init__()
         self.artifact_descriptor: Optional[AutosarEngineeringObject] = None
-        self.usage_refs: list[DependencyUsageEnum] = []
+        self.usages: list[DependencyUsageEnum] = []
 
     def serialize(self) -> ET.Element:
         """Serialize DependencyOnArtifact to XML element.
@@ -92,13 +91,13 @@ class DependencyOnArtifact(Identifiable):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize usage_refs (list to container "USAGE-REFS")
-        if self.usage_refs:
-            wrapper = ET.Element("USAGE-REFS")
-            for item in self.usage_refs:
+        # Serialize usages (list to container "USAGES")
+        if self.usages:
+            wrapper = ET.Element("USAGES")
+            for item in self.usages:
                 serialized = SerializationHelper.serialize_item(item, "DependencyUsageEnum")
                 if serialized is not None:
-                    child_elem = ET.Element("USAGE-REF")
+                    child_elem = ET.Element("USAGE")
                     if hasattr(serialized, 'attrib'):
                         child_elem.attrib.update(serialized.attrib)
                     if serialized.text:
@@ -130,10 +129,10 @@ class DependencyOnArtifact(Identifiable):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "ARTIFACT-DESCRIPTOR":
                 setattr(obj, "artifact_descriptor", SerializationHelper.deserialize_by_tag(child, "AutosarEngineeringObject"))
-            elif tag == "USAGE-REFS":
+            elif tag == "USAGES":
                 # Iterate through wrapper children
                 for item_elem in child:
-                    obj.usage_refs.append(ARRef.deserialize(item_elem))
+                    obj.usages.append(SerializationHelper.deserialize_by_tag(item_elem, "DependencyUsageEnum"))
 
         return obj
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/inner_port_group_in_composition_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/inner_port_group_in_composition_instance_ref.py
@@ -6,7 +6,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_Components_InstanceRefs.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.builder_base import BuilderBase
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     )
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.port_group import (
         PortGroup,
+    )
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Composition.sw_component_prototype import (
+        SwComponentPrototype,
     )
 
 
@@ -40,7 +43,7 @@ class InnerPortGroupInCompositionInstanceRef(ARObject):
 
 
     base_ref: Optional[ARRef]
-    context_refs: list[Any]
+    context_refs: list[ARRef]
     target_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "BASE-REF": lambda obj, elem: setattr(obj, "base_ref", ARRef.deserialize(elem)),
@@ -53,7 +56,7 @@ class InnerPortGroupInCompositionInstanceRef(ARObject):
         """Initialize InnerPortGroupInCompositionInstanceRef."""
         super().__init__()
         self.base_ref: Optional[ARRef] = None
-        self.context_refs: list[Any] = []
+        self.context_refs: list[ARRef] = []
         self.target_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
@@ -97,7 +100,7 @@ class InnerPortGroupInCompositionInstanceRef(ARObject):
         if self.context_refs:
             wrapper = ET.Element("CONTEXT-REFS")
             for item in self.context_refs:
-                serialized = SerializationHelper.serialize_item(item, "Any")
+                serialized = SerializationHelper.serialize_item(item, "SwComponentPrototype")
                 if serialized is not None:
                     child_elem = ET.Element("CONTEXT-REF")
                     if hasattr(serialized, 'attrib'):
@@ -179,7 +182,7 @@ class InnerPortGroupInCompositionInstanceRefBuilder(BuilderBase):
         self._obj.base = value
         return self
 
-    def with_contexts(self, items: list[Any]) -> "InnerPortGroupInCompositionInstanceRefBuilder":
+    def with_contexts(self, items: list[SwComponentPrototype]) -> "InnerPortGroupInCompositionInstanceRefBuilder":
         """Set contexts list attribute.
 
         Args:
@@ -206,7 +209,7 @@ class InnerPortGroupInCompositionInstanceRefBuilder(BuilderBase):
         return self
 
 
-    def add_context(self, item: Any) -> "InnerPortGroupInCompositionInstanceRefBuilder":
+    def add_context(self, item: SwComponentPrototype) -> "InnerPortGroupInCompositionInstanceRefBuilder":
         """Add a single item to contexts list.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/r_mode_group_in_atomic_swc_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/r_mode_group_in_atomic_swc_instance_ref.py
@@ -41,10 +41,10 @@ class RModeGroupInAtomicSWCInstanceRef(ModeGroupInAtomicSwcInstanceRef):
 
 
     context_r_port_ref: Optional[ARRef]
-    target_mode_ref: Optional[ARRef]
+    target_mode_group_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "CONTEXT-R-PORT-REF": ("_POLYMORPHIC", "context_r_port_ref", ["PRPortPrototype", "RPortPrototype"]),
-        "TARGET-MODE-REF": lambda obj, elem: setattr(obj, "target_mode_ref", ARRef.deserialize(elem)),
+        "TARGET-MODE-GROUP-REF": lambda obj, elem: setattr(obj, "target_mode_group_ref", ARRef.deserialize(elem)),
     }
 
 
@@ -52,7 +52,7 @@ class RModeGroupInAtomicSWCInstanceRef(ModeGroupInAtomicSwcInstanceRef):
         """Initialize RModeGroupInAtomicSWCInstanceRef."""
         super().__init__()
         self.context_r_port_ref: Optional[ARRef] = None
-        self.target_mode_ref: Optional[ARRef] = None
+        self.target_mode_group_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize RModeGroupInAtomicSWCInstanceRef to XML element.
@@ -91,12 +91,12 @@ class RModeGroupInAtomicSWCInstanceRef(ModeGroupInAtomicSwcInstanceRef):
                     wrapped.append(child)
                 elem.append(wrapped)
 
-        # Serialize target_mode_ref
-        if self.target_mode_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.target_mode_ref, "ModeDeclarationGroup")
+        # Serialize target_mode_group_ref
+        if self.target_mode_group_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.target_mode_group_ref, "ModeDeclarationGroup")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("TARGET-MODE-REF")
+                wrapped = ET.Element("TARGET-MODE-GROUP-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -126,8 +126,8 @@ class RModeGroupInAtomicSWCInstanceRef(ModeGroupInAtomicSwcInstanceRef):
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
             if tag == "CONTEXT-R-PORT-REF":
                 setattr(obj, "context_r_port_ref", ARRef.deserialize(child))
-            elif tag == "TARGET-MODE-REF":
-                setattr(obj, "target_mode_ref", ARRef.deserialize(child))
+            elif tag == "TARGET-MODE-GROUP-REF":
+                setattr(obj, "target_mode_group_ref", ARRef.deserialize(child))
 
         return obj
 
@@ -156,8 +156,8 @@ class RModeGroupInAtomicSWCInstanceRefBuilder(ModeGroupInAtomicSwcInstanceRefBui
         self._obj.context_r_port = value
         return self
 
-    def with_target_mode(self, value: Optional[ModeDeclarationGroup]) -> "RModeGroupInAtomicSWCInstanceRefBuilder":
-        """Set target_mode attribute.
+    def with_target_mode_group(self, value: Optional[ModeDeclarationGroup]) -> "RModeGroupInAtomicSWCInstanceRefBuilder":
+        """Set target_mode_group attribute.
 
         Args:
             value: Value to set
@@ -166,8 +166,8 @@ class RModeGroupInAtomicSWCInstanceRefBuilder(ModeGroupInAtomicSwcInstanceRefBui
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'target_mode' is required and cannot be None")
-        self._obj.target_mode = value
+            raise ValueError("Attribute 'target_mode_group' is required and cannot be None")
+        self._obj.target_mode_group = value
         return self
 
 
@@ -175,7 +175,7 @@ class RModeGroupInAtomicSWCInstanceRefBuilder(ModeGroupInAtomicSwcInstanceRefBui
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
         "contextRPort",
-        "targetMode",
+        "targetModeGroup",
     }
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/r_mode_in_atomic_swc_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/r_mode_in_atomic_swc_instance_ref.py
@@ -14,8 +14,8 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
 from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration.mode_declaration import (
     ModeDeclaration,
 )
-from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration.mode_declaration_group import (
-    ModeDeclarationGroup,
+from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration.mode_declaration_group_prototype import (
+    ModeDeclarationGroupPrototype,
 )
 
 if TYPE_CHECKING:
@@ -118,7 +118,7 @@ class RModeInAtomicSwcInstanceRef(ARObject):
 
         # Serialize context_mode_declaration_group_prototype_ref
         if self.context_mode_declaration_group_prototype_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.context_mode_declaration_group_prototype_ref, "ModeDeclarationGroup")
+            serialized = SerializationHelper.serialize_item(self.context_mode_declaration_group_prototype_ref, "ModeDeclarationGroupPrototype")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("CONTEXT-MODE-DECLARATION-GROUP-PROTOTYPE-REF")
@@ -213,7 +213,7 @@ class RModeInAtomicSwcInstanceRefBuilder(BuilderBase):
         self._obj.context_port = value
         return self
 
-    def with_context_mode_declaration_group_prototype(self, value: Optional[ModeDeclarationGroup]) -> "RModeInAtomicSwcInstanceRefBuilder":
+    def with_context_mode_declaration_group_prototype(self, value: Optional[ModeDeclarationGroupPrototype]) -> "RModeInAtomicSwcInstanceRefBuilder":
         """Set context_mode_declaration_group_prototype attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/variable_in_atomic_swc_instance_ref.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/Components/InstanceRefs/variable_in_atomic_swc_instance_ref.py
@@ -37,11 +37,11 @@ class VariableInAtomicSwcInstanceRef(ARObject, ABC):
         """
         return True
 
-    abstract_target_ref: Optional[ARRef]
+    abstract_target_data_element_ref: Optional[ARRef]
     base_ref: Optional[ARRef]
     context_port_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "ABSTRACT-TARGET-REF": lambda obj, elem: setattr(obj, "abstract_target_ref", ARRef.deserialize(elem)),
+        "ABSTRACT-TARGET-DATA-ELEMENT-REF": lambda obj, elem: setattr(obj, "abstract_target_data_element_ref", ARRef.deserialize(elem)),
         "BASE-REF": ("_POLYMORPHIC", "base_ref", ["ApplicationSwComponentType", "ComplexDeviceDriverSwComponentType", "EcuAbstractionSwComponentType", "NvBlockSwComponentType", "SensorActuatorSwComponentType", "ServiceProxySwComponentType", "ServiceSwComponentType"]),
         "CONTEXT-PORT-REF": ("_POLYMORPHIC", "context_port_ref", ["AbstractProvidedPortPrototype", "AbstractRequiredPortPrototype", "PPortPrototype", "PRPortPrototype", "RPortPrototype"]),
     }
@@ -50,7 +50,7 @@ class VariableInAtomicSwcInstanceRef(ARObject, ABC):
     def __init__(self) -> None:
         """Initialize VariableInAtomicSwcInstanceRef."""
         super().__init__()
-        self.abstract_target_ref: Optional[ARRef] = None
+        self.abstract_target_data_element_ref: Optional[ARRef] = None
         self.base_ref: Optional[ARRef] = None
         self.context_port_ref: Optional[ARRef] = None
 
@@ -77,12 +77,12 @@ class VariableInAtomicSwcInstanceRef(ARObject, ABC):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize abstract_target_ref
-        if self.abstract_target_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.abstract_target_ref, "VariableDataPrototype")
+        # Serialize abstract_target_data_element_ref
+        if self.abstract_target_data_element_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.abstract_target_data_element_ref, "VariableDataPrototype")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ABSTRACT-TARGET-REF")
+                wrapped = ET.Element("ABSTRACT-TARGET-DATA-ELEMENT-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -138,8 +138,8 @@ class VariableInAtomicSwcInstanceRef(ARObject, ABC):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "ABSTRACT-TARGET-REF":
-                setattr(obj, "abstract_target_ref", ARRef.deserialize(child))
+            if tag == "ABSTRACT-TARGET-DATA-ELEMENT-REF":
+                setattr(obj, "abstract_target_data_element_ref", ARRef.deserialize(child))
             elif tag == "BASE-REF":
                 setattr(obj, "base_ref", ARRef.deserialize(child))
             elif tag == "CONTEXT-PORT-REF":
@@ -158,8 +158,8 @@ class VariableInAtomicSwcInstanceRefBuilder(BuilderBase, ABC):
         self._obj: VariableInAtomicSwcInstanceRef = VariableInAtomicSwcInstanceRef()
 
 
-    def with_abstract_target(self, value: Optional[VariableDataPrototype]) -> "VariableInAtomicSwcInstanceRefBuilder":
-        """Set abstract_target attribute.
+    def with_abstract_target_data_element(self, value: Optional[VariableDataPrototype]) -> "VariableInAtomicSwcInstanceRefBuilder":
+        """Set abstract_target_data_element attribute.
 
         Args:
             value: Value to set
@@ -168,8 +168,8 @@ class VariableInAtomicSwcInstanceRefBuilder(BuilderBase, ABC):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'abstract_target' is required and cannot be None")
-        self._obj.abstract_target = value
+            raise ValueError("Attribute 'abstract_target_data_element' is required and cannot be None")
+        self._obj.abstract_target_data_element = value
         return self
 
     def with_base(self, value: Optional[AtomicSwComponentType]) -> "VariableInAtomicSwcInstanceRefBuilder":
@@ -204,7 +204,7 @@ class VariableInAtomicSwcInstanceRefBuilder(BuilderBase, ABC):
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "abstractTarget",
+        "abstractTargetDataElement",
         "base",
         "contextPort",
     }

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/asynchronous_server_call_returns_event.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/asynchronous_server_call_returns_event.py
@@ -6,7 +6,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_RTEEvents.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import (
@@ -15,6 +15,9 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import RTEEventBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServerCall.asynchronous_server_call_result_point import (
+    AsynchronousServerCallResultPoint,
+)
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
 
@@ -34,7 +37,7 @@ class AsynchronousServerCallReturnsEvent(RTEEvent):
     _XML_TAG = "ASYNCHRONOUS-SERVER-CALL-RETURNS-EVENT"
 
 
-    event_source_ref: Optional[Any]
+    event_source_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
         "EVENT-SOURCE-REF": lambda obj, elem: setattr(obj, "event_source_ref", ARRef.deserialize(elem)),
     }
@@ -43,7 +46,7 @@ class AsynchronousServerCallReturnsEvent(RTEEvent):
     def __init__(self) -> None:
         """Initialize AsynchronousServerCallReturnsEvent."""
         super().__init__()
-        self.event_source_ref: Optional[Any] = None
+        self.event_source_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize AsynchronousServerCallReturnsEvent to XML element.
@@ -70,7 +73,7 @@ class AsynchronousServerCallReturnsEvent(RTEEvent):
 
         # Serialize event_source_ref
         if self.event_source_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.event_source_ref, "Any")
+            serialized = SerializationHelper.serialize_item(self.event_source_ref, "AsynchronousServerCallResultPoint")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("EVENT-SOURCE-REF")
@@ -117,7 +120,7 @@ class AsynchronousServerCallReturnsEventBuilder(RTEEventBuilder):
         self._obj: AsynchronousServerCallReturnsEvent = AsynchronousServerCallReturnsEvent()
 
 
-    def with_event_source(self, value: Optional[Any]) -> "AsynchronousServerCallReturnsEventBuilder":
+    def with_event_source(self, value: Optional[AsynchronousServerCallResultPoint]) -> "AsynchronousServerCallReturnsEventBuilder":
         """Set event_source attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/data_receive_error_event.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/data_receive_error_event.py
@@ -15,8 +15,8 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import RTEEventBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Datatype.DataPrototypes.variable_data_prototype import (
-    VariableDataPrototype,
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs.r_variable_in_atomic_swc_instance_ref import (
+    RVariableInAtomicSwcInstanceRef,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -37,16 +37,16 @@ class DataReceiveErrorEvent(RTEEvent):
     _XML_TAG = "DATA-RECEIVE-ERROR-EVENT"
 
 
-    data_ref: Optional[ARRef]
+    data_iref: Optional[RVariableInAtomicSwcInstanceRef]
     _DESERIALIZE_DISPATCH = {
-        "DATA-REF": lambda obj, elem: setattr(obj, "data_ref", ARRef.deserialize(elem)),
+        "DATA-IREF": lambda obj, elem: setattr(obj, "data_iref", SerializationHelper.deserialize_by_tag(elem, "RVariableInAtomicSwcInstanceRef")),
     }
 
 
     def __init__(self) -> None:
         """Initialize DataReceiveErrorEvent."""
         super().__init__()
-        self.data_ref: Optional[ARRef] = None
+        self.data_iref: Optional[RVariableInAtomicSwcInstanceRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize DataReceiveErrorEvent to XML element.
@@ -71,19 +71,16 @@ class DataReceiveErrorEvent(RTEEvent):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize data_ref
-        if self.data_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.data_ref, "VariableDataPrototype")
+        # Serialize data_iref (instance reference with wrapper "DATA-IREF")
+        if self.data_iref is not None:
+            serialized = SerializationHelper.serialize_item(self.data_iref, "RVariableInAtomicSwcInstanceRef")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("DATA-REF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("DATA-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
         return elem
 
@@ -104,8 +101,8 @@ class DataReceiveErrorEvent(RTEEvent):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "DATA-REF":
-                setattr(obj, "data_ref", ARRef.deserialize(child))
+            if tag == "DATA-IREF":
+                setattr(obj, "data_iref", SerializationHelper.deserialize_by_tag(child, "RVariableInAtomicSwcInstanceRef"))
 
         return obj
 
@@ -120,7 +117,7 @@ class DataReceiveErrorEventBuilder(RTEEventBuilder):
         self._obj: DataReceiveErrorEvent = DataReceiveErrorEvent()
 
 
-    def with_data(self, value: Optional[VariableDataPrototype]) -> "DataReceiveErrorEventBuilder":
+    def with_data(self, value: Optional[RVariableInAtomicSwcInstanceRef]) -> "DataReceiveErrorEventBuilder":
         """Set data attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/external_trigger_occurred_event.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/external_trigger_occurred_event.py
@@ -15,8 +15,8 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import RTEEventBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration.trigger import (
-    Trigger,
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs.r_trigger_in_atomic_swc_instance_ref import (
+    RTriggerInAtomicSwcInstanceRef,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -37,16 +37,16 @@ class ExternalTriggerOccurredEvent(RTEEvent):
     _XML_TAG = "EXTERNAL-TRIGGER-OCCURRED-EVENT"
 
 
-    trigger_ref: Optional[ARRef]
+    trigger_iref: Optional[RTriggerInAtomicSwcInstanceRef]
     _DESERIALIZE_DISPATCH = {
-        "TRIGGER-REF": lambda obj, elem: setattr(obj, "trigger_ref", ARRef.deserialize(elem)),
+        "TRIGGER-IREF": lambda obj, elem: setattr(obj, "trigger_iref", SerializationHelper.deserialize_by_tag(elem, "RTriggerInAtomicSwcInstanceRef")),
     }
 
 
     def __init__(self) -> None:
         """Initialize ExternalTriggerOccurredEvent."""
         super().__init__()
-        self.trigger_ref: Optional[ARRef] = None
+        self.trigger_iref: Optional[RTriggerInAtomicSwcInstanceRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize ExternalTriggerOccurredEvent to XML element.
@@ -71,19 +71,16 @@ class ExternalTriggerOccurredEvent(RTEEvent):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize trigger_ref
-        if self.trigger_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.trigger_ref, "Trigger")
+        # Serialize trigger_iref (instance reference with wrapper "TRIGGER-IREF")
+        if self.trigger_iref is not None:
+            serialized = SerializationHelper.serialize_item(self.trigger_iref, "RTriggerInAtomicSwcInstanceRef")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("TRIGGER-REF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("TRIGGER-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
         return elem
 
@@ -104,8 +101,8 @@ class ExternalTriggerOccurredEvent(RTEEvent):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "TRIGGER-REF":
-                setattr(obj, "trigger_ref", ARRef.deserialize(child))
+            if tag == "TRIGGER-IREF":
+                setattr(obj, "trigger_iref", SerializationHelper.deserialize_by_tag(child, "RTriggerInAtomicSwcInstanceRef"))
 
         return obj
 
@@ -120,7 +117,7 @@ class ExternalTriggerOccurredEventBuilder(RTEEventBuilder):
         self._obj: ExternalTriggerOccurredEvent = ExternalTriggerOccurredEvent()
 
 
-    def with_trigger(self, value: Optional[Trigger]) -> "ExternalTriggerOccurredEventBuilder":
+    def with_trigger(self, value: Optional[RTriggerInAtomicSwcInstanceRef]) -> "ExternalTriggerOccurredEventBuilder":
         """Set trigger attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/swc_mode_manager_error_event.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/swc_mode_manager_error_event.py
@@ -15,8 +15,8 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import RTEEventBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.CommonStructure.ModeDeclaration.mode_declaration_group import (
-    ModeDeclarationGroup,
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs.p_mode_group_in_atomic_swc_instance_ref import (
+    PModeGroupInAtomicSwcInstanceRef,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -73,7 +73,7 @@ class SwcModeManagerErrorEvent(RTEEvent):
 
         # Serialize mode_group_ref
         if self.mode_group_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.mode_group_ref, "ModeDeclarationGroup")
+            serialized = SerializationHelper.serialize_item(self.mode_group_ref, "PModeGroupInAtomicSwcInstanceRef")
             if serialized is not None:
                 # Wrap with correct tag
                 wrapped = ET.Element("MODE-GROUP-REF")
@@ -120,7 +120,7 @@ class SwcModeManagerErrorEventBuilder(RTEEventBuilder):
         self._obj: SwcModeManagerErrorEvent = SwcModeManagerErrorEvent()
 
 
-    def with_mode_group(self, value: Optional[ModeDeclarationGroup]) -> "SwcModeManagerErrorEventBuilder":
+    def with_mode_group(self, value: Optional[PModeGroupInAtomicSwcInstanceRef]) -> "SwcModeManagerErrorEventBuilder":
         """Set mode_group attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/transformer_hard_error_event.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/RTEEvents/transformer_hard_error_event.py
@@ -15,11 +15,11 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.RTEEvents.rte_event import RTEEventBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.PortInterface.client_server_operation import (
-    ClientServerOperation,
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs.p_operation_in_atomic_swc_instance_ref import (
+    POperationInAtomicSwcInstanceRef,
 )
-from armodel2.models.M2.AUTOSARTemplates.CommonStructure.TriggerDeclaration.trigger import (
-    Trigger,
+from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.Components.InstanceRefs.r_trigger_in_atomic_swc_instance_ref import (
+    RTriggerInAtomicSwcInstanceRef,
 )
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
@@ -40,19 +40,19 @@ class TransformerHardErrorEvent(RTEEvent):
     _XML_TAG = "TRANSFORMER-HARD-ERROR-EVENT"
 
 
-    operation: Optional[ClientServerOperation]
-    required_trigger_ref: Optional[ARRef]
+    operation_iref: Optional[POperationInAtomicSwcInstanceRef]
+    required_trigger_iref: Optional[RTriggerInAtomicSwcInstanceRef]
     _DESERIALIZE_DISPATCH = {
-        "OPERATION": lambda obj, elem: setattr(obj, "operation", SerializationHelper.deserialize_by_tag(elem, "ClientServerOperation")),
-        "REQUIRED-TRIGGER-REF": lambda obj, elem: setattr(obj, "required_trigger_ref", ARRef.deserialize(elem)),
+        "OPERATION-IREF": lambda obj, elem: setattr(obj, "operation_iref", SerializationHelper.deserialize_by_tag(elem, "POperationInAtomicSwcInstanceRef")),
+        "REQUIRED-TRIGGER-IREF": lambda obj, elem: setattr(obj, "required_trigger_iref", SerializationHelper.deserialize_by_tag(elem, "RTriggerInAtomicSwcInstanceRef")),
     }
 
 
     def __init__(self) -> None:
         """Initialize TransformerHardErrorEvent."""
         super().__init__()
-        self.operation: Optional[ClientServerOperation] = None
-        self.required_trigger_ref: Optional[ARRef] = None
+        self.operation_iref: Optional[POperationInAtomicSwcInstanceRef] = None
+        self.required_trigger_iref: Optional[RTriggerInAtomicSwcInstanceRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize TransformerHardErrorEvent to XML element.
@@ -77,33 +77,27 @@ class TransformerHardErrorEvent(RTEEvent):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize operation
-        if self.operation is not None:
-            serialized = SerializationHelper.serialize_item(self.operation, "ClientServerOperation")
+        # Serialize operation_iref (instance reference with wrapper "OPERATION-IREF")
+        if self.operation_iref is not None:
+            serialized = SerializationHelper.serialize_item(self.operation_iref, "POperationInAtomicSwcInstanceRef")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("OPERATION")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("OPERATION-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
-        # Serialize required_trigger_ref
-        if self.required_trigger_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.required_trigger_ref, "Trigger")
+        # Serialize required_trigger_iref (instance reference with wrapper "REQUIRED-TRIGGER-IREF")
+        if self.required_trigger_iref is not None:
+            serialized = SerializationHelper.serialize_item(self.required_trigger_iref, "RTriggerInAtomicSwcInstanceRef")
             if serialized is not None:
-                # Wrap with correct tag
-                wrapped = ET.Element("REQUIRED-TRIGGER-REF")
-                if hasattr(serialized, 'attrib'):
-                    wrapped.attrib.update(serialized.attrib)
-                if serialized.text:
-                    wrapped.text = serialized.text
+                # Wrap in IREF wrapper element
+                iref_wrapper = ET.Element("REQUIRED-TRIGGER-IREF")
+                # Flatten: append children of serialized element directly to iref wrapper
                 for child in serialized:
-                    wrapped.append(child)
-                elem.append(wrapped)
+                    iref_wrapper.append(child)
+                elem.append(iref_wrapper)
 
         return elem
 
@@ -124,10 +118,10 @@ class TransformerHardErrorEvent(RTEEvent):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "OPERATION":
-                setattr(obj, "operation", SerializationHelper.deserialize_by_tag(child, "ClientServerOperation"))
-            elif tag == "REQUIRED-TRIGGER-REF":
-                setattr(obj, "required_trigger_ref", ARRef.deserialize(child))
+            if tag == "OPERATION-IREF":
+                setattr(obj, "operation_iref", SerializationHelper.deserialize_by_tag(child, "POperationInAtomicSwcInstanceRef"))
+            elif tag == "REQUIRED-TRIGGER-IREF":
+                setattr(obj, "required_trigger_iref", SerializationHelper.deserialize_by_tag(child, "RTriggerInAtomicSwcInstanceRef"))
 
         return obj
 
@@ -142,7 +136,7 @@ class TransformerHardErrorEventBuilder(RTEEventBuilder):
         self._obj: TransformerHardErrorEvent = TransformerHardErrorEvent()
 
 
-    def with_operation(self, value: Optional[ClientServerOperation]) -> "TransformerHardErrorEventBuilder":
+    def with_operation(self, value: Optional[POperationInAtomicSwcInstanceRef]) -> "TransformerHardErrorEventBuilder":
         """Set operation attribute.
 
         Args:
@@ -156,7 +150,7 @@ class TransformerHardErrorEventBuilder(RTEEventBuilder):
         self._obj.operation = value
         return self
 
-    def with_required_trigger(self, value: Optional[Trigger]) -> "TransformerHardErrorEventBuilder":
+    def with_required_trigger(self, value: Optional[RTriggerInAtomicSwcInstanceRef]) -> "TransformerHardErrorEventBuilder":
         """Set required_trigger attribute.
 
         Args:

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall/asynchronous_server_call_result_point.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/ServerCall/asynchronous_server_call_result_point.py
@@ -7,7 +7,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior_ServerCall.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Optional
 import xml.etree.ElementTree as ET
 
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount.abstract_access_point import (
@@ -16,10 +16,16 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 from armodel2.models.M2.builder_base import BuilderBase
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.AccessCount.abstract_access_point import AbstractAccessPointBuilder
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_ref import ARRef
+
+if TYPE_CHECKING:
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServerCall.asynchronous_server_call_point import (
+        AsynchronousServerCallPoint,
+    )
+
+
+
 from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses.ArObject.ar_object import ARObject
 from armodel2.serialization import SerializationHelper
-
-
 class AsynchronousServerCallResultPoint(AbstractAccessPoint):
     """AUTOSAR AsynchronousServerCallResultPoint."""
 
@@ -35,16 +41,16 @@ class AsynchronousServerCallResultPoint(AbstractAccessPoint):
     _XML_TAG = "ASYNCHRONOUS-SERVER-CALL-RESULT-POINT"
 
 
-    asynchronous_server_ref: Optional[Any]
+    asynchronous_server_call_point_ref: Optional[ARRef]
     _DESERIALIZE_DISPATCH = {
-        "ASYNCHRONOUS-SERVER-REF": lambda obj, elem: setattr(obj, "asynchronous_server_ref", ARRef.deserialize(elem)),
+        "ASYNCHRONOUS-SERVER-CALL-POINT-REF": lambda obj, elem: setattr(obj, "asynchronous_server_call_point_ref", ARRef.deserialize(elem)),
     }
 
 
     def __init__(self) -> None:
         """Initialize AsynchronousServerCallResultPoint."""
         super().__init__()
-        self.asynchronous_server_ref: Optional[Any] = None
+        self.asynchronous_server_call_point_ref: Optional[ARRef] = None
 
     def serialize(self) -> ET.Element:
         """Serialize AsynchronousServerCallResultPoint to XML element.
@@ -69,12 +75,12 @@ class AsynchronousServerCallResultPoint(AbstractAccessPoint):
         for child in parent_elem:
             elem.append(child)
 
-        # Serialize asynchronous_server_ref
-        if self.asynchronous_server_ref is not None:
-            serialized = SerializationHelper.serialize_item(self.asynchronous_server_ref, "Any")
+        # Serialize asynchronous_server_call_point_ref
+        if self.asynchronous_server_call_point_ref is not None:
+            serialized = SerializationHelper.serialize_item(self.asynchronous_server_call_point_ref, "AsynchronousServerCallPoint")
             if serialized is not None:
                 # Wrap with correct tag
-                wrapped = ET.Element("ASYNCHRONOUS-SERVER-REF")
+                wrapped = ET.Element("ASYNCHRONOUS-SERVER-CALL-POINT-REF")
                 if hasattr(serialized, 'attrib'):
                     wrapped.attrib.update(serialized.attrib)
                 if serialized.text:
@@ -102,8 +108,8 @@ class AsynchronousServerCallResultPoint(AbstractAccessPoint):
         ns_split = '}'
         for child in element:
             tag = child.tag.split(ns_split, 1)[1] if child.tag.startswith('{') else child.tag
-            if tag == "ASYNCHRONOUS-SERVER-REF":
-                setattr(obj, "asynchronous_server_ref", ARRef.deserialize(child))
+            if tag == "ASYNCHRONOUS-SERVER-CALL-POINT-REF":
+                setattr(obj, "asynchronous_server_call_point_ref", ARRef.deserialize(child))
 
         return obj
 
@@ -118,8 +124,8 @@ class AsynchronousServerCallResultPointBuilder(AbstractAccessPointBuilder):
         self._obj: AsynchronousServerCallResultPoint = AsynchronousServerCallResultPoint()
 
 
-    def with_asynchronous_server(self, value: Optional[Any]) -> "AsynchronousServerCallResultPointBuilder":
-        """Set asynchronous_server attribute.
+    def with_asynchronous_server_call_point(self, value: Optional[AsynchronousServerCallPoint]) -> "AsynchronousServerCallResultPointBuilder":
+        """Set asynchronous_server_call_point attribute.
 
         Args:
             value: Value to set
@@ -128,15 +134,15 @@ class AsynchronousServerCallResultPointBuilder(AbstractAccessPointBuilder):
             self for method chaining
         """
         if value is None and not True:
-            raise ValueError("Attribute 'asynchronous_server' is required and cannot be None")
-        self._obj.asynchronous_server = value
+            raise ValueError("Attribute 'asynchronous_server_call_point' is required and cannot be None")
+        self._obj.asynchronous_server_call_point = value
         return self
 
 
 
     # Pre-computed validation constants (generated from JSON schema)
     _OPTIONAL_ATTRIBUTES = {
-        "asynchronousServer",
+        "asynchronousServerCallPoint",
     }
 
 

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
@@ -25,9 +25,6 @@ from armodel2.models.M2.AUTOSARTemplates.GenericStructure.GeneralTemplateClasses
     Boolean,
     CIdentifier,
 )
-from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServerCall.asynchronous_server_call_result_point import (
-    AsynchronousServerCallResultPoint,
-)
 from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.Trigger.external_triggering_point import (
     ExternalTriggeringPoint,
 )
@@ -39,6 +36,9 @@ from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior
 )
 
 if TYPE_CHECKING:
+    from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ServerCall.asynchronous_server_call_result_point import (
+        AsynchronousServerCallResultPoint,
+    )
     from armodel2.models.M2.AUTOSARTemplates.SWComponentTemplate.SwcInternalBehavior.ModeDeclarationGroup.mode_access_point import (
         ModeAccessPoint,
     )


### PR DESCRIPTION
## Summary
This PR updates AUTOSAR model mappings to add service items support to BSW module classes and fixes incorrect type definitions across multiple packages.

## Changes
### JSON Mapping Updates (8 files)
- Added `expectedCallback` and `requiredEntry` service items to `BswModuleDependency`
- Added `outgoingCallback` service item to `BswModuleDescription`  
- Updated maturity levels from "draft" to "reviewed" for Implementation and InstanceRef classes
- Fixed attribute kinds: `artifactDescriptor` changed from "attribute" to "aggr"
- Fixed type definitions: `contextModeDeclarationGroupPrototype` corrected to `ModeDeclarationGroupPrototype`
- Fixed attribute names: `abstractTarget` renamed to `abstractTargetDataElement`
- Swapped sequence offsets in `RModeInAtomicSwcInstanceRef` for correct XML ordering

### Generated Python Model Updates (15 files)
- Updated RTE event classes to use instance references (`-IREF`) instead of simple references:
  - `DataReceiveErrorEvent`: `data_ref` → `data_iref`
  - `ExternalTriggerOccurredEvent`: `trigger_ref` → `trigger_iref`
  - `SwcModeManagerErrorEvent`: Updated type hints
  - `TransformerHardErrorEvent`: `operation` → `operation_iref`, `required_trigger_ref` → `required_trigger_iref`
  - `AsynchronousServerCallResultPoint`: `asynchronous_server_ref` → `asynchronous_server_call_point_ref`
- Updated imports and type annotations for instance reference classes

## Files Modified
- 8 JSON mapping files in `docs/json/packages/`
- 15 generated Python model files in `src/armodel2/models/M2/`

## Test Coverage
✅ All quality checks passed:
- Ruff: No linting errors
- MyPy: No type errors in 2255 source files
- Pytest: 404 tests passed

## Requirements Traceability
N/A - General model enhancement and bug fixes

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)