### PR TITLE
feat: Add pre-computed XML tag mappings for serialization optimization

### DIFF
--- a/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/executable_entity.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/executable_entity.py
@@ -9,7 +9,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_CommonStructure_InternalBehavior.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, ClassVar, Dict
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_element_name
 
@@ -53,6 +53,12 @@ class ExecutableEntity(Identifiable, ABC):
             True for abstract classes
         """
         return True
+
+    # Pre-computed attribute name → XML tag mappings (exceptional cases only)
+    # Normal attributes use NameConverter.to_xml_tag() for calculation
+    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {
+        "can_enter_refs": "CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA-REF",
+    }
 
     activation_reasons: list[ExecutableEntityActivationReason]
     _can_enter_refs: list[ARRef]

--- a/src/armodel2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles/life_cycle_info_set.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles/life_cycle_info_set.py
@@ -7,7 +7,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_GenericStructure_LifeCycles.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, ClassVar, Dict
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_element_name
 
@@ -47,6 +47,12 @@ class LifeCycleInfoSet(ARElement):
 
     _XML_TAG = "LIFE-CYCLE-INFO-SET"
 
+
+    # Pre-computed attribute name → XML tag mappings (exceptional cases only)
+    # Normal attributes use NameConverter.to_xml_tag() for calculation
+    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {
+        "life_cycle_infoes": "LIFE-CYCLE-INFOS",
+    }
 
     default_lc_state_ref: ARRef
     default_period_begin: Optional[LifeCyclePeriod]

--- a/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
+++ b/src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py
@@ -11,7 +11,7 @@ References:
 JSON Source: docs/json/packages/M2_AUTOSARTemplates_SWComponentTemplate_SwcInternalBehavior.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, ClassVar, Dict
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_element_name
 
@@ -76,6 +76,15 @@ class RunnableEntity(ExecutableEntity):
 
     _XML_TAG = "RUNNABLE-ENTITY"
 
+
+    # Pre-computed attribute name → XML tag mappings (exceptional cases only)
+    # Normal attributes use NameConverter.to_xml_tag() for calculation
+    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {
+        "data_receive_point_by_arguments": "DATA-RECEIVE-POINT-BY-ARGUMENTS",
+        "data_write_accesses": "DATA-WRITE-ACCESSS",
+        "read_local_variables": "READ-LOCAL-VARIABLES",
+        "written_local_variables": "WRITTEN-LOCAL-VARIABLES",
+    }
 
     arguments: list[RunnableEntityArgument]
     asynchronous_server_call_result_points: list[AsynchronousServerCallResultPoint]

--- a/src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_nominator_denominator.py
+++ b/src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_nominator_denominator.py
@@ -6,7 +6,7 @@ References:
 JSON Source: docs/json/packages/M2_MSR_AsamHdo_ComputationMethod.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, ClassVar, Dict
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_element_name
 
@@ -32,6 +32,12 @@ class CompuNominatorDenominator(ARObject):
 
     _XML_TAG = "COMPU-NOMINATOR-DENOMINATOR"
 
+
+    # Pre-computed attribute name → XML tag mappings (exceptional cases only)
+    # Normal attributes use NameConverter.to_xml_tag() for calculation
+    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {
+        "vs": "V",
+    }
 
     _vs: list[Numerical]
     _DESERIALIZE_DISPATCH = {

--- a/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_impl_policy_enum.py
+++ b/src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_impl_policy_enum.py
@@ -29,8 +29,6 @@ class SwImplPolicyEnum(AREnum):
         self._value_ = value
 
     CONST = "CONST"
-    BASIC = "BASIC"
-    AUTOSAR = "A-U-T-O-S-A-R"
     FIXED = "FIXED"
     MEASUREMENT_POINT = "MEASUREMENT-POINT"
     QUEUED = "QUEUED"

--- a/src/armodel2/models/M2/MSR/Documentation/BlockElements/ListElements/ar_list.py
+++ b/src/armodel2/models/M2/MSR/Documentation/BlockElements/ListElements/ar_list.py
@@ -6,7 +6,7 @@ References:
 JSON Source: docs/json/packages/M2_MSR_Documentation_BlockElements_ListElements.classes.json"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, ClassVar, Dict
 import xml.etree.ElementTree as ET
 from armodel2.serialization.decorators import xml_attribute
 from armodel2.serialization.decorators import xml_element_name
@@ -42,6 +42,12 @@ class ARList(Paginateable):
 
     _XML_TAG = "AR-LIST"
 
+
+    # Pre-computed attribute name → XML tag mappings (exceptional cases only)
+    # Normal attributes use NameConverter.to_xml_tag() for calculation
+    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {
+        "items": "ITEM",
+    }
 
     _items: list[Item]
     _type: Optional[ListEnum]

--- a/src/armodel2/serialization/serialization_helper.py
+++ b/src/armodel2/serialization/serialization_helper.py
@@ -184,37 +184,60 @@ class SerializationHelper:
         return False
 
     @staticmethod
-    def get_element_tag(attr_name: str) -> str:
+    def get_element_tag(attr_name: str, obj: Any = None) -> str:
         """Get XML tag name for a class attribute/element.
 
-        Auto-generates from Python attribute name using NameConverter.
+        Priority:
+        1. Object's _ATTRIBUTE_XML_TAG_MAPPING (from xml_element_name decorator)
+        2. NameConverter calculation (default)
 
         Args:
             attr_name: Name of the Python attribute
+            obj: Object instance (optional, for checking pre-computed mappings)
 
         Returns:
             XML tag name to use for this element
         """
+        # Check for pre-computed mapping (from xml_element_name decorator)
+        if obj and hasattr(obj, '_ATTRIBUTE_XML_TAG_MAPPING'):
+            mapping = obj._ATTRIBUTE_XML_TAG_MAPPING
+            if attr_name in mapping:
+                return mapping[attr_name]
+
+        # Default: Calculate using NameConverter
         return NameConverter.to_xml_tag(attr_name)
 
     @staticmethod
-    def get_element_tag_path(attr_name: str) -> Union[str, list[str]]:
+    def get_element_tag_path(attr_name: str, obj: Any = None) -> Union[str, list[str]]:
         """Get full XML tag path for a class attribute/element.
 
-        Auto-generates from Python attribute name using NameConverter.
+        Priority:
+        1. Object's _ATTRIBUTE_XML_TAG_MAPPING (from xml_element_name decorator)
+        2. NameConverter calculation (default)
 
         Args:
             attr_name: Name of the Python attribute
+            obj: Object instance (optional, for checking pre-computed mappings)
 
         Returns:
             XML tag as a string (single-level path only)
         """
-        # Auto-generate from Python name
+        # Check for pre-computed mapping (from xml_element_name decorator)
+        if obj and hasattr(obj, '_ATTRIBUTE_XML_TAG_MAPPING'):
+            mapping = obj._ATTRIBUTE_XML_TAG_MAPPING
+            if attr_name in mapping:
+                return mapping[attr_name]
+
+        # Default: Calculate using NameConverter
         return NameConverter.to_xml_tag(attr_name)
 
     @staticmethod
     def get_element_tag_path_static(cls: type, attr_name: str) -> Union[str, list[str]]:
         """Get full XML tag path for a class attribute/element (static version).
+
+        Priority:
+        1. Class's _ATTRIBUTE_XML_TAG_MAPPING (from xml_element_name decorator)
+        2. NameConverter calculation (default)
 
         Args:
             cls: The class to check
@@ -223,7 +246,13 @@ class SerializationHelper:
         Returns:
             XML tag path as a list for multi-level paths, or a string for single-level paths
         """
-        # Auto-generate from Python name
+        # Check for pre-computed mapping (from xml_element_name decorator)
+        if hasattr(cls, '_ATTRIBUTE_XML_TAG_MAPPING'):
+            mapping = cls._ATTRIBUTE_XML_TAG_MAPPING
+            if attr_name in mapping:
+                return mapping[attr_name]
+
+        # Default: Calculate using NameConverter
         return NameConverter.to_xml_tag(attr_name)
 
     @staticmethod

--- a/tools/generate_models/generators.py
+++ b/tools/generate_models/generators.py
@@ -274,6 +274,65 @@ def _generate_xml_tag_constant(class_name: str) -> str:
     return f'    _XML_TAG = "{xml_tag}"\n\n\n'
 
 
+def _extract_xml_tag_from_decorator(attr_name: str, attr_data: Dict[str, Any]) -> Optional[str]:
+    """Extract XML tag from decorator field if present.
+
+    Args:
+        attr_name: Python attribute name
+        attr_data: Attribute data from JSON (with decorator_name and decorator_params)
+
+    Returns:
+        XML tag if xml_element_name decorator present, None otherwise
+    """
+    decorator_name = attr_data.get("decorator_name", "")
+    if decorator_name == "xml_element_name":
+        # Get the XML tag from decorator_params
+        return attr_data.get("decorator_params", "")
+
+    return None
+
+
+def _generate_attribute_mappings(attribute_types: Dict[str, Dict[str, Any]]) -> str:
+    """Generate _ATTRIBUTE_XML_TAG_MAPPING only for attributes with xml_element_name decorator.
+
+    Only generates mappings for exceptional cases where the XML tag doesn't follow
+    the standard naming convention. All other attributes use NameConverter at runtime.
+
+    Args:
+        attribute_types: Dictionary of attribute information
+
+    Returns:
+        Generated code for _ATTRIBUTE_XML_TAG_MAPPING constant
+    """
+    exceptional_mappings = {}
+
+    for attr_name, attr_data in sorted(attribute_types.items()):
+        xml_tag = _extract_xml_tag_from_decorator(attr_name, attr_data)
+        if xml_tag:
+            # Use the Python identifier (snake_case with ref suffix if needed)
+            # as the key, not the original attr_name
+            python_name = get_python_identifier_with_ref(
+                attr_name,
+                attr_data.get("is_ref", False),
+                attr_data.get("multiplicity", "1"),
+                attr_data.get("kind", "attribute")
+            )
+            exceptional_mappings[python_name] = xml_tag
+
+    if not exceptional_mappings:
+        return ""  # No exceptional cases, don't generate mapping
+
+    code = "    # Pre-computed attribute name → XML tag mappings (exceptional cases only)\n"
+    code += "    # Normal attributes use NameConverter.to_xml_tag() for calculation\n"
+    code += "    _ATTRIBUTE_XML_TAG_MAPPING: ClassVar[Dict[str, str]] = {\n"
+
+    for python_name, tag in sorted(exceptional_mappings.items()):
+        code += f'        "{python_name}": "{tag}",\n'
+
+    code += "    }\n\n"
+    return code
+
+
 def _generate_dispatch_table(
     attribute_types: Dict[str, Dict[str, Any]],
     package_data: Dict[str, Dict[str, Any]],
@@ -570,6 +629,11 @@ def generate_class_code(
                     break
         if has_xml_element_name:
             decorator_import += "from armodel2.serialization.decorators import xml_element_name\n"
+            # Add ClassVar, Dict for _ATTRIBUTE_XML_TAG_MAPPING
+            if uses_any_type:
+                basic_import = "from typing import TYPE_CHECKING, Optional, Any, ClassVar, Dict\n"
+            else:
+                basic_import = "from typing import TYPE_CHECKING, Optional, ClassVar, Dict\n"
 
         # Check if this class uses atpVariation pattern via decorator key
         class_decorator = type_def.get("decorator", None)
@@ -982,6 +1046,10 @@ class {class_name}(ABC):
     # Add _XML_TAG constant for non-abstract classes
     if not is_abstract:
         code += _generate_xml_tag_constant(class_name)
+
+    # Add _ATTRIBUTE_XML_TAG_MAPPING for attributes with xml_element_name decorator
+    if attribute_types:
+        code += _generate_attribute_mappings(attribute_types)
 
     if is_splitable:
         code += f'''    is_splitable = True

--- a/tools/identify_xml_tag_exceptions.py
+++ b/tools/identify_xml_tag_exceptions.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Identify attributes with xml_element_name decorator.
+
+This script scans all JSON package files and reports attributes that use
+the xml_element_name decorator, which indicates they need pre-computed
+XML tag mappings.
+"""
+import json
+from pathlib import Path
+
+
+def find_xml_element_name_decorators(json_path: Path) -> list[dict]:
+    """Find all attributes using xml_element_name decorator.
+
+    Args:
+        json_path: Path to JSON file
+
+    Returns:
+        List of dictionaries with class, attribute, xml_tag, and decorator info
+    """
+    with open(json_path) as f:
+        data = json.load(f)
+
+    results = []
+
+    for class_data in data.get("classes", []):
+        class_name = class_data["name"]
+
+        for attr_name, attr_data in class_data.get("attributes", {}).items():
+            decorator = attr_data.get("decorator", "")
+            if "xml_element_name:" in decorator:
+                # Extract the tag from decorator
+                # Handle: "xml_element_name:TAG" or "decorator1:val1:xml_element_name:TAG"
+                parts = decorator.split(":")
+                for i, part in enumerate(parts):
+                    if part == "xml_element_name" and i + 1 < len(parts):
+                        tag = parts[i + 1]
+                        results.append({
+                            "class": class_name,
+                            "attribute": attr_name,
+                            "xml_tag": tag,
+                            "decorator": decorator
+                        })
+                        break
+
+    return results
+
+
+if __name__ == "__main__":
+    packages_dir = Path("docs/json/packages")
+    total = 0
+    unique_tags = set()
+
+    print("Scanning for xml_element_name decorator usage...\n")
+    print("=" * 80)
+
+    for json_file in sorted(packages_dir.glob("*.classes.json")):
+        decorators = find_xml_element_name_decorators(json_file)
+        if decorators:
+            print(f"\n{json_file.name}:")
+            for dec in decorators:
+                print(f"  {dec['class']}.{dec['attribute']} → {dec['xml_tag']}")
+                unique_tags.add(dec['xml_tag'])
+                total += 1
+
+    print("\n" + "=" * 80)
+    print("\nSummary:")
+    print(f"  Total attributes with xml_element_name: {total}")
+    print(f"  Unique XML tags: {len(unique_tags)}")
+
+    if unique_tags:
+        print(f"\n  Unique tags: {sorted(unique_tags)}")


### PR DESCRIPTION
## Summary
This PR implements a performance optimization for XML serialization by adding pre-computed attribute→XML tag mappings to model classes. This eliminates runtime name conversion overhead for exceptional cases where XML tags don't follow standard naming conventions.

## Changes
- **SerializationHelper**: Updated `get_element_tag()` and related methods to check pre-computed `_ATTRIBUTE_XML_TAG_MAPPING` before falling back to `NameConverter`
- **Code Generator**: Added automatic generation of `_ATTRIBUTE_XML_TAG_MAPPING` for attributes using `xml_element_name` decorator
- **Model Classes**: Added `_ATTRIBUTE_XML_TAG_MAPPING` to 5 classes:
  - `ExecutableEntity`: `can_enter_refs` → `CAN-ENTER-EXCLUSIVE-AREA-REFS/CAN-ENTER-EXCLUSIVE-AREA-REF`
  - `LifeCycleInfoSet`: `life_cycle_infoes` → `LIFE-CYCLE-INFOS`
  - `RunnableEntity`: 4 mappings for `data_receive_point_by_arguments`, `data_write_accesses`, `read_local_variables`, `written_local_variables`
  - `CompuNominatorDenominator`: `vs` → `V`
  - `ARList`: `items` → `ITEM`
- **SwImplPolicyEnum**: Removed invalid enum values (`BASIC`, `AUTOSAR`)
- **New Tool**: Added `tools/identify_xml_tag_exceptions.py` to scan for `xml_element_name` decorator usage

## Files Modified
- `src/armodel2/serialization/serialization_helper.py`
- `tools/generate_models/generators.py`
- `src/armodel2/models/M2/AUTOSARTemplates/CommonStructure/InternalBehavior/executable_entity.py`
- `src/armodel2/models/M2/AUTOSARTemplates/GenericStructure/LifeCycles/life_cycle_info_set.py`
- `src/armodel2/models/M2/AUTOSARTemplates/SWComponentTemplate/SwcInternalBehavior/runnable_entity.py`
- `src/armodel2/models/M2/MSR/AsamHdo/ComputationMethod/compu_nominator_denominator.py`
- `src/armodel2/models/M2/MSR/DataDictionary/DataDefProperties/sw_impl_policy_enum.py`
- `src/armodel2/models/M2/MSR/Documentation/BlockElements/ListElements/ar_list.py`

## Files Added
- `tools/identify_xml_tag_exceptions.py`

## Test Coverage
- All 285 tests pass
- Ruff linting passes (1 fixable error auto-fixed)
- MyPy type checking passes (2255 source files)

## Architecture
This change implements a lookup table pattern for XML tag resolution:
1. Check `_ATTRIBUTE_XML_TAG_MAPPING` (pre-computed, O(1))
2. Fall back to `NameConverter.to_xml_tag()` (calculated, default)

The code generator now automatically generates these mappings during model class generation, eliminating the need for manual maintenance.

Closes #237